### PR TITLE
Full branch url

### DIFF
--- a/instance/github.py
+++ b/instance/github.py
@@ -162,3 +162,10 @@ class PR:
         Extra settings contained in the PR body
         """
         return get_settings_from_pr_body(self.body)
+
+    @property
+    def github_pr_url(self):
+        """
+        Construct the URL for the pull request
+        """
+        return 'https://github.com/{fork_name}/pull/{number}'.format(fork_name=self.fork_name, number=self.number)

--- a/instance/migrations/0031_openedxinstance_github_pr_url.py
+++ b/instance/migrations/0031_openedxinstance_github_pr_url.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.conf import settings
+from django.db import models, migrations
+
+
+def migrate_urls(apps, schema_editor):
+    Instance = apps.get_model("instance", "OpenEdXInstance")
+    instances = Instance.objects.exclude(github_pr_number__isnull=True)
+    for instance in instances:
+        instance.github_pr_url = 'https://github.com/{fork}/pull/{number}'.format(
+            fork=getattr(settings, 'WATCH_FORK', 'edx/edx-platform'),
+            number=instance.github_pr_number
+        )
+        instance.save()
+
+
+def reverse_migrate_urls(apps, schema_editor):
+    Instance = apps.get_model("instance", "OpenEdXInstance")
+    instances = Instance.objects.exclude(github_pr_url='')
+    for instance in instances:
+        instance.github_pr_number = int(instance.github_pr_url.split('/')[-1])
+        instance.save()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('instance', '0030_auto_20150927_1045'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='openedxinstance',
+            name='github_pr_url',
+            field=models.URLField(blank=True),
+        ),
+        migrations.RunPython(migrate_urls, reverse_code=reverse_migrate_urls),
+        migrations.RemoveField(
+            model_name='openedxinstance',
+            name='github_pr_number',
+        ),
+    ]

--- a/instance/models/instance.py
+++ b/instance/models/instance.py
@@ -279,7 +279,7 @@ class GitHubInstanceMixin(VersionControlInstanceMixin):
     """
     github_organization_name = models.CharField(max_length=200, db_index=True)
     github_repository_name = models.CharField(max_length=200, db_index=True)
-    github_pr_number = models.IntegerField(blank=True, null=True)
+    github_pr_url = models.URLField(blank=True)
     github_admin_organization_name = models.CharField(max_length=200, blank=True,
                                                       default=settings.DEFAULT_ADMIN_ORGANIZATION)
 
@@ -310,20 +310,20 @@ class GitHubInstanceMixin(VersionControlInstanceMixin):
         return 'https://github.com/{0.fork_name}'.format(self)
 
     @property
-    def github_pr_url(self):
-        """
-        Web URL of the Github PR, or None if the PR number is not set.
-        """
-        if self.github_pr_number is None:
-            return None
-        return '{0.github_base_url}/pull/{0.github_pr_number}'.format(self)
-
-    @property
     def github_branch_url(self):
         """
         GitHub URL of the branch tree
         """
         return '{0.github_base_url}/tree/{0.branch_name}'.format(self)
+
+    @property
+    def github_pr_number(self):
+        """
+        Get the PR number from the URL of the PR.
+        """
+        if not self.github_pr_url:
+            return None
+        return int(self.github_pr_url.split('/')[-1])
 
     @property
     def repository_url(self):

--- a/instance/tasks.py
+++ b/instance/tasks.py
@@ -71,7 +71,7 @@ def watch_pr():
             truncated_title = truncatewords(pr.title, 4)
             instance.name = 'PR#{pr.number}: {truncated_title} ({pr.username}) - {i.reference_name}'\
                             .format(pr=pr, i=instance, truncated_title=truncated_title)
-            instance.github_pr_number = pr.number
+            instance.github_pr_url = pr.github_pr_url
             instance.ansible_extra_settings = pr.extra_settings
             instance.save()
 

--- a/instance/tests/models/test_instance.py
+++ b/instance/tests/models/test_instance.py
@@ -116,13 +116,13 @@ class GitHubInstanceTestCase(TestCase):
         """
         instance = OpenEdXInstanceFactory(
             github_organization_name='open-craft',
-            github_pr_number=234,
+            github_pr_url='https://github.com/edx/edx/pull/234',
             github_repository_name='edx',
             branch_name='test-branch',
         )
         self.assertEqual(instance.fork_name, 'open-craft/edx')
         self.assertEqual(instance.github_base_url, 'https://github.com/open-craft/edx')
-        self.assertEqual(instance.github_pr_url, 'https://github.com/open-craft/edx/pull/234')
+        self.assertEqual(instance.github_pr_number, 234)
         self.assertEqual(instance.github_branch_url, 'https://github.com/open-craft/edx/tree/test-branch')
         self.assertEqual(instance.repository_url, 'https://github.com/open-craft/edx.git')
         self.assertEqual(instance.updates_feed, 'https://github.com/open-craft/edx/commits/test-branch.atom')

--- a/instance/tests/test_tasks.py
+++ b/instance/tests/test_tasks.py
@@ -67,6 +67,7 @@ class TasksTestCase(TestCase):
             username='bradenmacdonald',
             body='Hello watcher!\n- - -\r\n**Settings**\r\n```\r\nWATCH: true\r\n```\r\nMore...',
         )
+        self.assertEqual(pr.github_pr_url, 'https://github.com/watched/fork/pull/234')
         mock_get_pr_list_from_username.return_value = [pr]
         mock_get_commit_id_from_ref.return_value = '7' * 40
 
@@ -76,6 +77,7 @@ class TasksTestCase(TestCase):
         self.assertEqual(instance.sub_domain, 'pr234.sandbox')
         self.assertEqual(instance.fork_name, 'watched/fork')
         self.assertEqual(instance.github_pr_number, 234)
+        self.assertEqual(instance.github_pr_url, 'https://github.com/watched/fork/pull/234')
         self.assertEqual(instance.branch_name, 'watch-branch')
         self.assertEqual(instance.ansible_extra_settings, 'WATCH: true\r\n')
         self.assertEqual(


### PR DESCRIPTION
Stores the full URL of a pull request in the instance model instead of just the number.

Also tweaks the makefile to fix issues I ran into when trying to use it.