### PR TITLE
Persistent sandbox databases

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,6 +1,8 @@
 DEBUG=true
 SECRET_KEY='tests'
 DATABASE_URL='postgres://localhost/opencraft'
+INSTANCE_MYSQL_URL='mysql://root@localhost'
+INSTANCE_MONGO_URL='mongodb://localhost'
 HUEY_ALWAYS_EAGER=true
 OPENSTACK_USER='test'
 OPENSTACK_PASSWORD='pass'

--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,8 @@ all:
 	rundev
 
 apt_get_update:
+	sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 7F0CEB10
+	echo 'deb http://downloads-distro.mongodb.org/repo/ubuntu-upstart dist 10gen' | sudo tee /etc/apt/sources.list.d/mongodb.list
 	sudo apt-get update
 
 clean:
@@ -47,10 +49,10 @@ clean:
 	find static/external -type f -not -name 'Makefile' -not -name '.gitignore' -delete
 
 install_system_db_dependencies: apt_get_update
-	sudo apt-get install -y `tr -d '\r' < debian_db_packages.lst`
+	sudo -E apt-get install -y `tr -d '\r' < debian_db_packages.lst`
 
 install_system_dependencies: apt_get_update
-	sudo apt-get install -y `tr -d '\r' < debian_packages.lst`
+	sudo -E apt-get install -y `tr -d '\r' < debian_packages.lst`
 
 install_virtualenv_system:
 	sudo pip3 install virtualenv

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ First, install [VirtualBox](https://www.virtualbox.org/wiki/Downloads) and
     vagrant up
 
 This will provision a virtual machine running Ubuntu 14.04, set up local
-Postgres and Redis, install the dependencies and run the tests.
+Postgres, MySQL, MongoDB and Redis, install the dependencies and run the tests.
 
 Once the virtual machine is up and running, you can ssh into it with this
 command:
@@ -46,11 +46,13 @@ $ make install_system_dependencies
 $ pip3 install --user virtualenv && pip3 install --user virtualenvwrapper
 ```
 
-You might also need to install PostgreSQL:
+You might also need to install PostgreSQL, MySQL and MongoDB:
 
 ```
 $ make install_system_db_dependencies
 ```
+Note that the tests expect to be able to access MySQL on localhost using the
+default port, connecting as the root user without a password.
 
 Ensure you load virtualenv with Python 3 in `~/.bashrc`:
 
@@ -169,7 +171,9 @@ $ make collectstatic
 Running the tests
 -----------------
 
-First, the current user can access PostgreSQL and create databases, for the test database. Run:
+If you are setting up a development environment manually, you will need to
+create a database user to run the tests. **If you are using vagrant you can skip
+this step**.
 
 ```
 $ sudo -u postgres createuser -d <currentunixuser>`
@@ -228,3 +232,14 @@ You can also access the Django `manage.py` command directly, using Honcho to loa
 $ honcho run ./manage.py config
 ```
 
+
+User workflow
+-------------
+
+To use ephemeral databases that will be destroyed every time the sandbox is
+reprovisioned, include `(ephemeral databases)` on the same line as the sandbox
+domain in the pull request body.
+
+To request persistent databases that will survive reprovisioning, include
+`(persistent databases)` on the same line as the sandbox domain in the pull
+request body.

--- a/bin/bootstrap
+++ b/bin/bootstrap
@@ -11,6 +11,7 @@ if [[ $USER == 'vagrant' ]]; then
 fi
 
 # Install system packages
+export DEBIAN_FRONTEND=noninteractive  # Prevent mysql prompt for root password
 make install_system_dependencies
 make install_system_db_dependencies
 

--- a/circle.yml
+++ b/circle.yml
@@ -8,5 +8,6 @@ dependencies:
     - pip install -r requirements.txt
 test:
   override:
-      - make test:
+      - case $CIRCLE_NODE_INDEX in 0) make test ;; *) make test_integration ;; esac:
           timeout: 1800
+          parallel: true

--- a/debian_db_packages.lst
+++ b/debian_db_packages.lst
@@ -1,1 +1,3 @@
 postgresql
+mysql-server
+mongodb-org

--- a/debian_packages.lst
+++ b/debian_packages.lst
@@ -2,6 +2,7 @@ make
 git
 python3-pip
 libpq-dev
+libmysqlclient-dev
 python-dev
 redis-server
 firefox

--- a/instance/migrations/0036_external_databases.py
+++ b/instance/migrations/0036_external_databases.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('instance', '0034_auto_20151022_1652'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='openedxinstance',
+            name='mongo_pass',
+            field=models.CharField(blank=True, max_length=32),
+        ),
+        migrations.AddField(
+            model_name='openedxinstance',
+            name='mongo_provisioned',
+            field=models.BooleanField(default=False),
+        ),
+        migrations.AddField(
+            model_name='openedxinstance',
+            name='mongo_user',
+            field=models.CharField(blank=True, max_length=16),
+        ),
+        migrations.AddField(
+            model_name='openedxinstance',
+            name='mysql_pass',
+            field=models.CharField(blank=True, max_length=32),
+        ),
+        migrations.AddField(
+            model_name='openedxinstance',
+            name='mysql_provisioned',
+            field=models.BooleanField(default=False),
+        ),
+        migrations.AddField(
+            model_name='openedxinstance',
+            name='mysql_user',
+            field=models.CharField(blank=True, max_length=16),
+        ),
+        migrations.AddField(
+            model_name='openedxinstance',
+            name='use_ephemeral_databases',
+            field=models.BooleanField(default=True),
+            preserve_default=False,
+        ),
+    ]

--- a/instance/migrations/0037_merge.py
+++ b/instance/migrations/0037_merge.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('instance', '0036_external_databases'),
+        ('instance', '0035_reset_ansible_settings'),
+    ]
+
+    operations = [
+    ]

--- a/instance/migrations/0038_merge.py
+++ b/instance/migrations/0038_merge.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('instance', '0036_auto_20151112_1122'),
+        ('instance', '0037_merge'),
+    ]
+
+    operations = [
+    ]

--- a/instance/models/instance.py
+++ b/instance/models/instance.py
@@ -24,15 +24,21 @@ Instance app models - Instance
 
 import logging
 import os
+import string
 
 from functools import partial
 
 from django.conf import settings
 from django.core.validators import MinValueValidator, RegexValidator
 from django.db import models
+from django.db.backends.utils import truncate_name
 from django.template import loader
 from django.utils import timezone
+from django.utils.crypto import get_random_string
 from django_extensions.db.models import TimeStampedModel
+
+import MySQLdb as mysql
+import pymongo
 
 from instance import ansible, github
 from instance.gandi import GandiAPI
@@ -264,6 +270,19 @@ class GitHubInstanceQuerySet(models.QuerySet):
     Additional methods for instance querysets
     Also used as the standard manager for the GitHubInstance model
     """
+    def update_or_create_from_pr(self, pr, sub_domain):
+        """
+        Create or update an instance for the given pull request
+        """
+        instance, created = self.get_or_create(
+            sub_domain=sub_domain,
+            fork_name=pr.fork_name,
+            branch_name=pr.branch_name,
+        )
+        instance.update_from_pr(pr)
+        instance.save()
+        return instance, created
+
     def create(self, *args, **kwargs):
         """
         Augmented `create()` method:
@@ -350,6 +369,13 @@ class GitHubInstanceMixin(VersionControlInstanceMixin):
         return '{0.github_organization_name}/{0.github_repository_name}'.format(self)
 
     @property
+    def reference_name(self):
+        """
+        A descriptive name for the instance, which includes meaningful attributes
+        """
+        return '{0.github_organization_name}/{0.branch_name} ({0.commit_short_id})'.format(self)
+
+    @property
     def github_base_url(self):
         """
         Base GitHub URL of the fork (eg. 'https://github.com/open-craft/edx-platform')
@@ -420,8 +446,7 @@ class GitHubInstanceMixin(VersionControlInstanceMixin):
 
             # Update the hash in the instance title if it is present there
             # TODO: Find a better way to handle this - include the hash dynamically?
-            # TODO: Figure out why the warnings aren't suppressed despite the fact that it's a mixin
-            if self.name and old_commit_short_id: #pylint: disable=access-member-before-definition
+            if self.name and old_commit_short_id:
                 #pylint: disable=attribute-defined-outside-init
                 self.name = self.name.replace(old_commit_short_id, self.commit_short_id)
 
@@ -444,6 +469,14 @@ class GitHubInstanceMixin(VersionControlInstanceMixin):
         self.github_repository_name = fork_repo
         if commit:
             self.save()
+
+    def update_from_pr(self, pr):
+        """
+        Update this instance with settings from the given pull request
+        """
+        self.name = ('PR#{pr.number}: {pr.truncated_title}' +  #pylint: disable=attribute-defined-outside-init
+                     ' ({pr.username}) - {i.reference_name}').format(pr=pr, i=self)
+        self.github_pr_url = pr.github_pr_url
 
 
 # Ansible #####################################################################
@@ -586,9 +619,86 @@ class AnsibleInstanceMixin(models.Model):
         return (log, returncode)
 
 
+# Databases ###################################################################
+
+class MySQLInstanceMixin(models.Model):
+    """
+    An instance that uses mysql databases
+    """
+    mysql_user = models.CharField(max_length=16, blank=True)  # 16 chars is mysql maximum
+    mysql_pass = models.CharField(max_length=32, blank=True)
+    mysql_provisioned = models.BooleanField(default=False)
+
+    class Meta:
+        abstract = True
+
+    @property
+    def mysql_database_names(self): #pylint: disable=no-self-use
+        """
+        An iterable of database names
+        """
+        return NotImplementedError
+
+    def provision_mysql(self):
+        """
+        Create mysql user and databases
+        """
+        if settings.INSTANCE_MYSQL_URL_OBJ and not self.mysql_provisioned:
+            connection = mysql.connect(
+                host=settings.INSTANCE_MYSQL_URL_OBJ.hostname,
+                user=settings.INSTANCE_MYSQL_URL_OBJ.username,
+                passwd=settings.INSTANCE_MYSQL_URL_OBJ.password or '',
+                port=settings.INSTANCE_MYSQL_URL_OBJ.port or 3306,
+            )
+            cursor = connection.cursor()
+
+            for database in self.mysql_database_names:
+                # We can't use the database name in a parameterized query, the
+                # driver doesn't escape it properly. Se we escape it here instead
+                database_name = connection.escape_string(database).decode()
+                cursor.execute('CREATE DATABASE {0} DEFAULT CHARACTER SET utf8'.format(database_name))
+                cursor.execute('GRANT ALL ON {0}.* TO %s IDENTIFIED BY %s'.format(database_name),
+                               (self.mysql_user, self.mysql_pass))
+
+            self.mysql_provisioned = True
+            self.save()
+
+
+class MongoDBInstanceMixin(models.Model):
+    """
+    An instance that uses mongo databases
+    """
+    mongo_user = models.CharField(max_length=16, blank=True)
+    mongo_pass = models.CharField(max_length=32, blank=True)
+    mongo_provisioned = models.BooleanField(default=False)
+
+    class Meta:
+        abstract = True
+
+    @property
+    def mongo_database_names(self): #pylint: disable=no-self-use
+        """
+        An iterable of database names
+        """
+        return NotImplementedError
+
+    def provision_mongo(self):
+        """
+        Create mongo user and databases
+        """
+        if settings.INSTANCE_MONGO_URL and not self.mongo_provisioned:
+            mongo = pymongo.MongoClient(settings.INSTANCE_MONGO_URL)
+            for database in self.mongo_database_names:
+                mongo[database].add_user(self.mongo_user, self.mongo_pass)
+
+            self.mongo_provisioned = True
+            self.save()
+
+
 # Open edX ####################################################################
 
-class OpenEdXInstance(AnsibleInstanceMixin, GitHubInstanceMixin, Instance):
+# pylint: disable=too-many-instance-attributes
+class OpenEdXInstance(MySQLInstanceMixin, MongoDBInstanceMixin, AnsibleInstanceMixin, GitHubInstanceMixin, Instance):
     """
     A single instance running a set of Open edX services
     """
@@ -601,7 +711,13 @@ class OpenEdXInstance(AnsibleInstanceMixin, GitHubInstanceMixin, Instance):
     s3_secret_access_key = models.CharField(max_length=50, blank=True)
     s3_bucket_name = models.CharField(max_length=50, blank=True)
 
-    ANSIBLE_SETTINGS = AnsibleInstanceMixin.ANSIBLE_SETTINGS + ['ansible_s3_settings']
+    use_ephemeral_databases = models.BooleanField()
+
+    ANSIBLE_SETTINGS = AnsibleInstanceMixin.ANSIBLE_SETTINGS + [
+        'ansible_s3_settings',
+        'ansible_mysql_settings',
+        'ansible_mongo_settings',
+    ]
 
     class Meta:
         verbose_name = 'Open edX Instance'
@@ -615,13 +731,6 @@ class OpenEdXInstance(AnsibleInstanceMixin, GitHubInstanceMixin, Instance):
         return settings.DEFAULT_FORK
 
     @property
-    def reference_name(self):
-        """
-        A descriptive name for the instance, which includes meaningful attributes
-        """
-        return '{s.github_organization_name}/{s.branch_name} ({s.commit_short_id})'.format(s=self)
-
-    @property
     def ansible_s3_settings(self):
         """
         Ansible settings for the S3 bucket
@@ -631,6 +740,37 @@ class OpenEdXInstance(AnsibleInstanceMixin, GitHubInstanceMixin, Instance):
 
         template = loader.get_template('instance/ansible/s3.yml')
         return template.render({'instance': self})
+
+    @property
+    def ansible_mysql_settings(self):
+        """
+        Ansible settings for the external mysql database
+        """
+        if self.use_ephemeral_databases or not settings.INSTANCE_MYSQL_URL_OBJ:
+            return ''
+
+        template = loader.get_template('instance/ansible/mysql.yml')
+        return template.render({'user': self.mysql_user,
+                                'pass': self.mysql_pass,
+                                'host': settings.INSTANCE_MYSQL_URL_OBJ.hostname,
+                                'port': settings.INSTANCE_MYSQL_URL_OBJ.port or 3306,
+                                'database': self.mysql_database_name})
+
+    @property
+    def ansible_mongo_settings(self):
+        """
+        Ansible settings for the external mongo database
+        """
+        if self.use_ephemeral_databases or not settings.INSTANCE_MONGO_URL_OBJ:
+            return ''
+
+        template = loader.get_template('instance/ansible/mongo.yml')
+        return template.render({'user': self.mongo_user,
+                                'pass': self.mongo_pass,
+                                'host': settings.INSTANCE_MONGO_URL_OBJ.hostname,
+                                'port': settings.INSTANCE_MONGO_URL_OBJ.port or 27017,
+                                'database': self.mongo_database_name,
+                                'forum_database': self.forum_database_name})
 
     @property
     def studio_sub_domain(self):
@@ -653,6 +793,70 @@ class OpenEdXInstance(AnsibleInstanceMixin, GitHubInstanceMixin, Instance):
         """
         return u'{0.protocol}://{0.studio_domain}/'.format(self)
 
+    @property
+    def database_name(self):
+        """
+        The database name used for external databases. Escape all non-ascii characters and truncate to 64 chars, the
+        maximum for mysql
+        """
+        name = self.domain.replace('.', '_')
+        allowed = string.ascii_letters + string.digits + '_'
+        escaped = ''.join(char for char in name if char in allowed)
+        return truncate_name(escaped, length=64)
+
+    @property
+    def mysql_database_name(self):
+        """
+        The mysql database name for this instance
+        """
+        return self.database_name
+
+    @property
+    def mysql_database_names(self):
+        """
+        List of mysql database names
+        """
+        return [self.mysql_database_name]
+
+    @property
+    def mongo_database_name(self):
+        """
+        The name of the main external mongo database
+        """
+        return self.database_name
+
+    @property
+    def forum_database_name(self):
+        """
+        The name of the external database used for forums
+        """
+        return '{0}_forum'.format(self.database_name)
+
+    @property
+    def mongo_database_names(self):
+        """
+        List of mongo database names
+        """
+        return [self.mongo_database_name, self.forum_database_name]
+
+    def save(self, **kwargs):
+        """
+        Set this instance's default field values
+        """
+        if self.use_ephemeral_databases is None:
+            self.use_ephemeral_databases = settings.INSTANCE_EPHEMERAL_DATABASES
+        super().save(**kwargs)
+
+    def update_from_pr(self, pr):
+        """
+        Update this instance with settings from the given pull request
+        """
+        super().update_from_pr(pr)
+        self.ansible_extra_settings = pr.extra_settings
+        self.use_ephemeral_databases = pr.use_ephemeral_databases(self.domain)
+        self.ansible_source_repo_url = pr.get_extra_setting('edx_ansible_source_repo')
+        self.configuration_version = pr.get_extra_setting('configuration_version')
+
     @log_exception
     def provision(self):
         """
@@ -661,7 +865,6 @@ class OpenEdXInstance(AnsibleInstanceMixin, GitHubInstanceMixin, Instance):
         Returns: (server, log)
         """
         self.last_provisioning_started = timezone.now()
-        self.reset_ansible_settings(commit=True)
 
         # Server
         self.logger.info('Terminate servers')
@@ -678,7 +881,14 @@ class OpenEdXInstance(AnsibleInstanceMixin, GitHubInstanceMixin, Instance):
         self.logger.info('Updating DNS: Studio at %s...', self.studio_domain)
         gandi.set_dns_record(type='CNAME', name=self.studio_sub_domain, value=self.sub_domain)
 
+        # Provisioning (external databases)
+        if not self.use_ephemeral_databases:
+            self.logger.info('Provisioning external databases...')
+            self.provision_mysql()
+            self.provision_mongo()
+
         # Provisioning (ansible)
+        self.reset_ansible_settings(commit=True)
         log, exit_code = self.deploy()
         if exit_code != 0:
             server.update_status(provisioning=True, failed=True)
@@ -693,3 +903,21 @@ class OpenEdXInstance(AnsibleInstanceMixin, GitHubInstanceMixin, Instance):
         self.logger.info('Provisioning completed')
 
         return (server, log)
+
+    def provision_mysql(self):
+        """
+        Set mysql credentials and provision the database.
+        """
+        if not self.mysql_provisioned:
+            self.mysql_user = get_random_string(length=16, allowed_chars=string.ascii_lowercase)
+            self.mysql_pass = get_random_string(length=32)
+        return super().provision_mysql()
+
+    def provision_mongo(self):
+        """
+        Set mongo credentials and provision the database.
+        """
+        if not self.mongo_provisioned:
+            self.mongo_user = get_random_string(length=16, allowed_chars=string.ascii_lowercase)
+            self.mongo_pass = get_random_string(length=32)
+        return super().provision_mongo()

--- a/instance/tasks.py
+++ b/instance/tasks.py
@@ -25,7 +25,6 @@ Worker tasks for instance hosting & management
 from huey.djhuey import crontab, db_periodic_task, db_task
 
 from django.conf import settings
-from django.template.defaultfilters import truncatewords
 
 from instance.github import get_username_list_from_team, get_pr_list_from_username
 from instance.models.instance import OpenEdXInstance
@@ -61,22 +60,8 @@ def watch_pr():
 
     for username in team_username_list:
         for pr in get_pr_list_from_username(username, settings.WATCH_FORK):
-            pr_sub_domain = 'pr{number}.sandbox'.format(number=pr.number)
-
-            instance, created = OpenEdXInstance.objects.get_or_create(
-                sub_domain=pr_sub_domain,
-                fork_name=pr.fork_name,
-                branch_name=pr.branch_name,
-            )
-            truncated_title = truncatewords(pr.title, 4)
-            instance.name = 'PR#{pr.number}: {truncated_title} ({pr.username}) - {i.reference_name}'\
-                            .format(pr=pr, i=instance, truncated_title=truncated_title)
-            instance.github_pr_url = pr.github_pr_url
-            instance.ansible_extra_settings = pr.extra_settings
-            instance.ansible_source_repo_url = pr.get_extra_setting('edx_ansible_source_repo')
-            instance.configuration_version = pr.get_extra_setting('configuration_version')
-            instance.save()
-
+            sub_domain = 'pr{number}.sandbox'.format(number=pr.number)
+            instance, created = OpenEdXInstance.objects.update_or_create_from_pr(pr, sub_domain)
             if created:
                 logger.info('New PR found, creating sandbox: %s', pr)
                 provision_instance(instance.pk)

--- a/instance/templates/instance/ansible/mongo.yml
+++ b/instance/templates/instance/ansible/mongo.yml
@@ -1,0 +1,11 @@
+EDXAPP_MONGO_USER: '{{ user }}'
+EDXAPP_MONGO_PASSWORD: '{{ pass }}'
+EDXAPP_MONGO_HOSTS: ['{{ host }}']
+EDXAPP_MONGO_PORT: {{ port }}
+EDXAPP_MONGO_DB_NAME: '{{ database }}'
+
+FORUM_MONGO_USER: '{{ user }}'
+FORUM_MONGO_PASSWORD: '{{ pass }}'
+FORUM_MONGO_HOSTS: ['{{ host }}']
+FORUM_MONGO_PORT: {{ port }}
+FORUM_MONGO_DATABASE: '{{ forum_database }}'

--- a/instance/templates/instance/ansible/mysql.yml
+++ b/instance/templates/instance/ansible/mysql.yml
@@ -1,0 +1,8 @@
+EDXAPP_MYSQL_USER: '{{ user }}'
+EDXAPP_MYSQL_PASSWORD: '{{ pass }}'
+EDXAPP_MYSQL_HOST: '{{ host }}'
+EDXAPP_MYSQL_PORT: {{ port }}
+EDXAPP_MYSQL_DB_NAME: '{{ database }}'
+
+COMMON_MYSQL_MIGRATE_USER: '{{ user }}'
+COMMON_MYSQL_MIGRATE_PASS: '{{ pass }}'

--- a/instance/tests/factories/pr.py
+++ b/instance/tests/factories/pr.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+#
+# OpenCraft -- tools to aid developing and hosting free software projects
+# Copyright (C) 2015 OpenCraft <xavier@opencraft.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+"""
+Test factory: PR (Github pull request)
+"""
+
+# Imports #####################################################################
+
+import factory
+
+from instance import github
+
+
+# Classes #####################################################################
+
+class PRFactory(factory.Factory):
+    """
+    Factory for PR instances
+    """
+    class Meta: #pylint: disable=missing-docstring
+        model = github.PR
+
+    number = factory.Sequence(int)
+    source_fork_name = 'fork/repo'
+    target_fork_name = 'source/repo'
+    branch_name = 'master'
+    title = factory.Sequence('PR #{}'.format)
+    username = 'edx'
+    body = ''

--- a/instance/tests/integration/factories/instance.py
+++ b/instance/tests/integration/factories/instance.py
@@ -50,3 +50,4 @@ class OpenEdXInstanceFactory(DjangoModelFactory):
     notifier_version = 'named-release/cypress'
     xqueue_version = 'named-release/cypress'
     certs_version = 'named-release/cypress'
+    use_ephemeral_databases = True

--- a/instance/tests/integration/integration_instance.py
+++ b/instance/tests/integration/integration_instance.py
@@ -33,6 +33,7 @@ from instance.tests.decorators import patch_git_checkout
 from instance.tests.integration.base import IntegrationTestCase
 from instance.tests.integration.factories.instance import OpenEdXInstanceFactory
 from instance.tasks import provision_instance
+from opencraft.tests.utils import shard
 
 
 # Tests #######################################################################
@@ -59,6 +60,7 @@ class InstanceIntegrationTestCase(IntegrationTestCase):
                     raise
             time.sleep(15)
 
+    @shard(1)
     def test_provision_instance(self):
         """
         Provision an instance
@@ -68,6 +70,7 @@ class InstanceIntegrationTestCase(IntegrationTestCase):
         provision_instance(instance.pk)
         self.assert_instance_up(instance)
 
+    @shard(2)
     def test_external_databases(self):
         """
         Ensure that the instance can connect to external databases

--- a/instance/tests/test_github.py
+++ b/instance/tests/test_github.py
@@ -73,6 +73,32 @@ class GitHubTestCase(TestCase):
         pr_body = "Description\r\nover\r\nlines\r\n- - -\r\n**Settings**\r\nMALFORMED"
         self.assertEqual(github.get_settings_from_pr_body(pr_body), '')
 
+    def test_pr_ephemeral_databases(self):
+        """
+        Should the sandbox use ephemeral databases?
+        """
+        pr_body = ('**JIRA Ticket:** https://openedx.atlassian.net/browse/YONK-83\r\n'
+                   '**Sandbox:** [LMS](http://pr9848.sandbox.opencraft.com/), '
+                   '[Studio](http://studio.pr9848.sandbox.opencraft.com/) (ephemeral database)\r\n')
+        domain = 'studio.pr9848.sandbox.opencraft.com'
+        self.assertTrue(github.is_pr_body_requesting_ephemeral_databases(pr_body, domain))
+
+    def test_pr_persistent_databases(self):
+        """
+        Should the sandbox use persistent databases?
+        """
+        pr_body = '* [LMS](http://sandbox.example.com) (persistent databases, please)'
+        domain = 'sandbox.example.com'
+        self.assertFalse(github.is_pr_body_requesting_ephemeral_databases(pr_body, domain))
+
+    def test_pr_databases_not_specified(self):
+        """
+        Does the PR specify whether databases should be ephemeral or persistent?
+        """
+        pr_body = '* [LMS](http://sandbox.example.com)'
+        domain = 'sandbox.example.com'
+        self.assertIsNone(github.is_pr_body_requesting_ephemeral_databases(pr_body, domain))
+
     @responses.activate
     def test_get_pr_by_number(self):
         """

--- a/instance/tests/test_tasks.py
+++ b/instance/tests/test_tasks.py
@@ -26,9 +26,10 @@ import textwrap
 
 from mock import patch
 
-from instance import github, tasks
+from instance import tasks
 from instance.models.instance import OpenEdXInstance
 from instance.tests.base import TestCase
+from instance.tests.factories.pr import PRFactory
 from instance.tests.models.factories.instance import OpenEdXInstanceFactory
 
 
@@ -67,7 +68,7 @@ class TasksTestCase(TestCase):
             configuration_version: named-release/elder
         """)
         mock_get_username_list.return_value = ['itsjeyd']
-        pr = github.PR(
+        pr = PRFactory(
             number=234,
             source_fork_name='fork/repo',
             target_fork_name='source/repo',

--- a/opencraft/settings.py
+++ b/opencraft/settings.py
@@ -275,7 +275,7 @@ DEFAULT_CONFIGURATION_VERSION = env('DEFAULT_CONFIGURATION_VERSION', default='ma
 ANSIBLE_PYTHON_PATH = env('ANSIBLE_PYTHON_PATH', default='/usr/bin/python')
 
 # Time in seconds to wait for the next log line when running an Ansible playbook.
-ANSIBLE_LINE_TIMEOUT = env.int('ANSIBLE_LINE_TIMEOUT', default=900)  # 15 minutes
+ANSIBLE_LINE_TIMEOUT = env.int('ANSIBLE_LINE_TIMEOUT', default=1500)  # 25 minutes
 
 # Timeout in seconds for an entire Ansible playbook.
 ANSIBLE_GLOBAL_TIMEOUT = env.int('ANSIBLE_GLOBAL_TIMEOUT', default=9000)  # 2.5 hours

--- a/opencraft/settings.py
+++ b/opencraft/settings.py
@@ -358,3 +358,16 @@ if 'file' in HANDLERS:
         'filename': 'log/main.log',
         'formatter': 'verbose'
     }
+
+
+# Instances ###################################################################
+
+# By default, instances use local mysql and mongo databases. Set this to False
+# to use external databases instead
+INSTANCE_EPHEMERAL_DATABASES = env.bool('INSTANCE_EPHEMERAL_DATABASES', default=True)
+
+# Configure external databases here
+INSTANCE_MYSQL_URL = env('INSTANCE_MYSQL_URL', default=None)
+INSTANCE_MONGO_URL = env('INSTANCE_MONGO_URL', default=None)
+INSTANCE_MYSQL_URL_OBJ = urlparse(INSTANCE_MYSQL_URL) if INSTANCE_MYSQL_URL else None
+INSTANCE_MONGO_URL_OBJ = urlparse(INSTANCE_MONGO_URL) if INSTANCE_MONGO_URL else None

--- a/opencraft/settings.py
+++ b/opencraft/settings.py
@@ -149,6 +149,11 @@ COMPRESS_PRECOMPILERS = (
 )
 
 
+# Test runner #################################################################
+
+TEST_RUNNER = env('TEST_RUNNER', default='django.test.runner.DiscoverRunner')
+
+
 # Django-extensions ###########################################################
 
 SHELL_PLUS = "ipython"

--- a/opencraft/tests/utils.py
+++ b/opencraft/tests/utils.py
@@ -1,0 +1,63 @@
+"""Utilities to run the OpenCraft IM tests."""
+
+import os
+import unittest
+
+from django.test.runner import DiscoverRunner
+
+
+def shard(index):
+    """Mark a test method as running only on a particular shard when running tests in parallel.
+
+    This decorator sets an attribute on the function that is read by our customised test loader.
+    Undecorated tests always run in shard 0.
+    """
+    def decorator(function):
+        """The actual decorator."""
+        function.shard = index
+        return function
+    return decorator
+
+
+class ShardedTestLoader(unittest.TestLoader):
+    """Load only the tests belonging to a particular shard.
+
+    The constructor takes the arguments `node_index` and `node_total`, indicating the zero-based
+    index of the current node and the total number of nodes.  Only tests that fulfil the condition
+
+        test_shard % node_total == node_index
+
+    are run, where test_shard is the shard a particular test is marked to run in.  Unannotated
+    tests run in shard 0.
+    """
+
+    def __init__(self, node_index, node_total):
+        super().__init__()
+        self.node_index = node_index
+        self.node_total = node_total
+
+    def getTestCaseNames(self, test_case_class):  # nopep8
+        """Only return the test cases that are supposed to run on the current shard."""
+        method_names = super().getTestCaseNames(test_case_class)
+        filtered_method_names = []
+        for method_name in method_names:
+            method = getattr(test_case_class, method_name)
+            test_shard = getattr(method, 'shard', 0)
+            if test_shard % self.node_total == self.node_index:
+                filtered_method_names.append(method_name)
+        return filtered_method_names
+
+
+class CircleCIParallelTestRunner(DiscoverRunner):
+    """Customization of Django's test runner for running tests in parallel on CircleCI.
+
+    This test runner retrieves CircleCI node information from the environment and uses
+    `ShardedTestLoader` to only run the tests meant for the current shard.
+    """
+
+    def __init__(self, *args, **kwargs):
+        node_index = os.getenv('CIRCLE_NODE_INDEX')
+        node_total = os.getenv('CIRCLE_NODE_TOTAL')
+        if node_index is not None and node_total is not None:
+            self.test_loader = ShardedTestLoader(int(node_index), int(node_total))
+        super().__init__(*args, **kwargs)

--- a/requirements.txt
+++ b/requirements.txt
@@ -48,6 +48,7 @@ mccabe==0.3.1
 mock==1.3.0
 monotonic==0.3
 msgpack-python==0.4.6
+mysqlclient==1.3.6
 netaddr==0.7.18
 netifaces==0.10.4
 oauthlib==1.0.3
@@ -73,6 +74,7 @@ pylint-celery==0.3
 pylint-common==0.2.1
 pylint-django==0.6.1
 pylint-plugin-utils==0.2.3
+pymongo==2.7.2
 pyparsing==2.0.3
 python-dateutil==2.4.2
 python-keystoneclient==1.7.1


### PR DESCRIPTION
This pull request adds support for instances to use external mysql and mongo databases. The goal is to [preserve databases during sandbox reprovisioning](http://opencraft.uservoice.com/forums/280754-opencraft/suggestions/9541143-preserve-databases-during-sandbox-reprovisioning).

Default databases for new instances can be set through the `INSTANCE_MYSQL_URL` and `INSTANCE_MONGO_URL` settings.

If the default is to use external databases but the PR submitter would like to use local databases, she can include `(ephemeral databases)` in the pull request body on the same line as the sandbox url to override the default.

See also: https://github.com/edx/configuration/pull/2310