### PR TITLE
Vagrant for windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,11 +76,6 @@ shell:
 upgrade_dependencies:
 	pip freeze --local | grep -v '^\-e' | cut -d = -f 1  | xargs -n1 pip install -U
 
-virtualenv_setup:
-	sudo pip3 install virtualenv
-	mkdir -p ~/.virtualenvs
-	virtualenv -p python3 ~/.virtualenvs/opencraft
-
 # Tests #######################################################################
 
 test_prospector: clean

--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,9 @@ endif
 all:
 	rundev
 
+apt_get_update:
+	sudo apt-get update
+
 clean:
 	find -name '*.pyc' -delete
 	find -name '*~' -delete
@@ -46,10 +49,10 @@ clean:
 collectstatic: clean js_external
 	$(HONCHO_MANAGE) collectstatic --noinput
 
-install_system_db_dependencies:
+install_system_db_dependencies: apt_get_update
 	sudo apt-get install -y `tr -d '\r' < debian_db_packages.lst`
 
-install_system_dependencies:
+install_system_dependencies: apt_get_update
 	sudo apt-get install -y `tr -d '\r' < debian_packages.lst`
 
 install_virtualenv_system:

--- a/Procfile
+++ b/Procfile
@@ -1,4 +1,4 @@
 web: gunicorn opencraft.wsgi --log-file -
-websocket: ./websocket.py
-worker: ./manage.py run_huey --no-periodic
-periodic: ./manage.py run_huey
+websocket: python3 websocket.py
+worker: python3 manage.py run_huey --no-periodic
+periodic: python3 manage.py run_huey

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,3 +1,3 @@
-web: ./manage.py runserver_plus
-websocket: ./websocket.py
-worker: ./manage.py run_huey --no-periodic
+web: python3 manage.py runserver_plus
+websocket: python3 websocket.py
+worker: python3 manage.py run_huey --no-periodic

--- a/README.md
+++ b/README.md
@@ -6,24 +6,24 @@ Install
 
 ### Vagrant install
 
-You can use [vagrant][] to set up a virtual machine for local development and
+You can use Vagrant to set up a virtual machine for local development and
 testing. This is useful to keep your development environment isolated from the
 rest of your system.
 
-First, install [virtualbox](https://www.virtualbox.org/wiki/Downloads) and 
-[vagrant](https://www.vagrantup.com/downloads.html). Then run:
+First, install [VirtualBox](https://www.virtualbox.org/wiki/Downloads) and 
+[Vagrant](https://www.vagrantup.com/downloads.html). Then run:
 
     vagrant up
 
 This will provision a virtual machine running Ubuntu 14.04, set up local
-postgres and redis, install the dependencies and run the tests.
+Postgres and Redis, install the dependencies and run the tests.
 
 Once the virtual machine is up and running, you can ssh into it with this
 command:
 
     vagrant ssh
 
-Vagrant will set up a virtualbox share mapping your local development directory
+Vagrant will set up a VirtualBox share mapping your local development directory
 to `/vagrant` inside the virtual machine. Any changes you make locally will be
 reflected inside the virtual machine automatically.
 
@@ -33,7 +33,7 @@ so you can access the development server using your web browser.
 
 ### Local install
 
-If you prefer not to install vagrant, you can install OpenCraft manually.
+If you prefer not to install Vagrant, you can install OpenCraft manually.
 Instructions based on Ubuntu 14.04.
 
 Install the system package dependencies & virtualenv:
@@ -129,7 +129,7 @@ $ make run WORKERS=2
 Process description
 -------------------
 
-This runs three processus via honcho, which reads `Procfile` or `Procfile.dev` and loads the
+This runs three processus via Honcho, which reads `Procfile` or `Procfile.dev` and loads the
 environment from the `.env` file:
 
 * *web*: the main HTTP server (Django - Werkzeug debugger in dev, gunicorn in prod)
@@ -143,8 +143,8 @@ of Python commands. It should *not* be run in production.
 Static assets collection
 ------------------------
 
-The Web server started in the development environment also doesn't require to run collectstatic
-after each change.
+The Web server started in the development environment also doesn't require 
+collectstatic to run after each change.
 
 The production environment automatically runs collectstatic on startup, but you can also run it
 manually:
@@ -157,7 +157,7 @@ $ make collectstatic
 Running the tests
 -----------------
 
-First, the current user can access postgresql and create databases, for the test database. Run:
+First, the current user can access PostgreSQL and create databases, for the test database. Run:
 
 ```
 $ sudo -u postgres createuser -d <currentunixuser>`
@@ -176,7 +176,7 @@ To run a single test, use `make test_one`:
 $ make test_one instance.tests.models.test_server
 ```
 
-You can also run prospector, the unit tests, JS tests and integration independently:
+You can also run Prospector, the unit tests, JS tests and integration independently:
 
 ```
 $ make test_prospector
@@ -210,12 +210,9 @@ $ make shell
 Manage.py
 ---------
 
-You can also access the Django `manage.py` command directly, using honcho to load the environment:
+You can also access the Django `manage.py` command directly, using Honcho to load the environment:
 
 ```
 $ honcho run ./manage.py config
 ```
 
-
-[virtualbox]: https://www.virtualbox.org/
-[vagrant]:    https://www.vagrantup.com/

--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ You can use [vagrant][] to set up a virtual machine for local development and
 testing. This is useful to keep your development environment isolated from the
 rest of your system.
 
-First, install [virtualbox][] and [vagrant][]. Then run:
+First, install [virtualbox](https://www.virtualbox.org/wiki/Downloads) and 
+[vagrant](https://www.vagrantup.com/downloads.html). Then run:
 
     vagrant up
 
@@ -38,8 +39,15 @@ Instructions based on Ubuntu 14.04.
 Install the system package dependencies & virtualenv:
 
 ```
-$ sudo apt-get install `cat debian_packages.lst`
+$ sudo apt-get update
+$ make install_system_dependencies
 $ pip3 install --user virtualenv && pip3 install --user virtualenvwrapper
+```
+
+You might also need to install PostgreSQL:
+
+```
+$ make install_system_db_dependencies
 ```
 
 Ensure you load virtualenv with Python 3 in `~/.bashrc`:

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -12,10 +12,11 @@ grep -Fq 'cd /vagrant' ~/.bashrc || echo 'cd /vagrant' >> ~/.bashrc
 
 # Install system packages
 sudo apt-get update --quiet
-sudo apt-get install -y $(cat debian_packages.lst) postgresql
+make install_system_dependencies
+make install_system_db_dependencies
 
 # Set up a virtualenv
-sudo pip3 install virtualenv
+make install_virtualenv_system
 mkdir -p ~/.virtualenvs
 virtualenv -p python3 ~/.virtualenvs/opencraft
 source ~/.virtualenvs/opencraft/bin/activate
@@ -25,7 +26,7 @@ grep -Fq 'source ~/.virtualenvs/opencraft/bin/activate' ~/.bashrc ||
   echo 'source ~/.virtualenvs/opencraft/bin/activate' >> ~/.bashrc
 
 # Install python dependencies
-pip install -r requirements.txt
+pip3 install -r requirements.txt
 
 # Create postgres user
 sudo -u postgres createuser -d vagrant

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -11,7 +11,6 @@ cd /vagrant
 grep -Fq 'cd /vagrant' ~/.bashrc || echo 'cd /vagrant' >> ~/.bashrc
 
 # Install system packages
-sudo apt-get update --quiet
 make install_system_dependencies
 make install_system_db_dependencies
 

--- a/debian_db_packages.lst
+++ b/debian_db_packages.lst
@@ -1,0 +1,1 @@
+postgresql


### PR DESCRIPTION
Changes mainly to the Makefile to help OpenCraft run on Windows under Vagrant. The README has also been updated to reflect the new Makefile commands.