### PR TITLE
Add information on how to create a dev user

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,16 @@ exit before starting the server if any are found. You can also check for pending
 $ make migration_check
 ```
 
+Creating a user
+---------------
+
+In order to login to the development server locally you will need to create a superuser through 
+
+```
+honcho run ./manage.py createsuperuser
+```
+
+Once created, you will be able to logon to your locally-host instance with the username and password you set up.
 
 Run
 ---


### PR DESCRIPTION
At the moment the README doesn't have info on how to get set up with a user for an instance.

This PR adds brief instructions to the README on how to create a user and then log in with that account.