### PR TITLE
Vagrant - Increase VM memory to 1GB to avoid OOM process kills

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -62,6 +62,7 @@ Vagrant.configure(2) do |config|
                       keep_color: true
 
   config.vm.provider :virtualbox do |vb|
+    vb.memory = 1024
     # Allow DNS to work for Ubuntu host
     # http://askubuntu.com/questions/238040/how-do-i-fix-name-service-for-vagrant-client
     vb.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]


### PR DESCRIPTION
@Kelketek To fix an out of memory error I had while reviewing https://github.com/open-craft/opencraft/pull/8 locally - it's a one-liner. Good for you?