### PR TITLE
Close DB connection upon task completion

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ rundev: clean migration_check js_external
 	honcho start -f Procfile.dev
 
 shell:
-	$(HONCHO_RUN) shell_plus
+	$(HONCHO_MANAGE) shell_plus
 
 upgrade_dependencies:
 	pip freeze --local | grep -v '^\-e' | cut -d = -f 1  | xargs -n1 pip install -U

--- a/Procfile
+++ b/Procfile
@@ -1,4 +1,4 @@
 web: gunicorn opencraft.wsgi --log-file -
 websocket: python3 websocket.py
 worker: python3 manage.py run_huey --no-periodic
-periodic: python3 manage.py run_huey
+periodic: python3 manage.py run_huey --periodic --workers=0

--- a/instance/tasks.py
+++ b/instance/tasks.py
@@ -22,7 +22,7 @@ Worker tasks for instance hosting & management
 
 # Imports #####################################################################
 
-from huey.djhuey import crontab, periodic_task, task
+from huey.djhuey import crontab, db_periodic_task, db_task
 
 from django.conf import settings
 from django.template.defaultfilters import truncatewords
@@ -39,7 +39,7 @@ logger = logging.getLogger(__name__)
 
 # Tasks #######################################################################
 
-@task()
+@db_task()
 def provision_instance(instance_pk):
     """
     Run provisioning on an existing instance
@@ -51,7 +51,7 @@ def provision_instance(instance_pk):
     instance.provision()
 
 
-@periodic_task(crontab(minute='*/1'))
+@db_periodic_task(crontab(minute='*/1'))
 def watch_pr():
     """
     Automatically create/update sandboxes for PRs opened by members of the watched

--- a/instance/tests/integration/base.py
+++ b/instance/tests/integration/base.py
@@ -35,9 +35,10 @@ class IntegrationTestCase(TestCase):
     Base class for API tests
     """
     def setUp(self):
+        super().setUp()
         # Override the environment setting - always run task in the same process
         djhuey.HUEY.always_eager = True
 
     def tearDown(self):
-        # Ensure we don't leave any VM running
         OpenStackServer.objects.terminate()
+        super().tearDown()

--- a/instance/tests/test_ansible.py
+++ b/instance/tests/test_ansible.py
@@ -38,6 +38,8 @@ class YAMLTestCase(TestCase):
     Test cases for YAML helper functions
     """
     def setUp(self):
+        super().setUp()
+
         self.yaml_dict1 = {
             'testa': 'firsta with unicode «ταБЬℓσ»',
             'testb': 'firstb',

--- a/instance/tests/test_gandi.py
+++ b/instance/tests/test_gandi.py
@@ -35,6 +35,8 @@ class GandiTestCase(TestCase):
     Test cases for Gandi API calls
     """
     def setUp(self):
+        super().setUp()
+
         with patch('xmlrpc.client.ServerProxy'):
             self.api = gandi.GandiAPI()
             self.api.client.domain.zone.version.new.return_value = 'new_zone_version'

--- a/instance/tests/test_openstack.py
+++ b/instance/tests/test_openstack.py
@@ -38,6 +38,8 @@ class OpenStackTestCase(TestCase):
     Test cases for OpenStack helper functions
     """
     def setUp(self):
+        super().setUp()
+
         self.nova = Mock()
 
     def test_create_server(self):

--- a/instance/tests/test_tasks.py
+++ b/instance/tests/test_tasks.py
@@ -48,6 +48,7 @@ class TasksTestCase(TestCase):
         tasks.provision_instance(instance.pk)
         self.assertEqual(mock_instance_provision.call_count, 1)
         self.assertEqual(mock_instance_provision.mock_calls[0][1][0].pk, instance.pk)
+        self.mock_db_connection_close.assert_called_once_with()
 
     @patch('instance.models.instance.github.get_commit_id_from_ref')
     @patch('instance.tasks.provision_instance')
@@ -83,3 +84,4 @@ class TasksTestCase(TestCase):
         self.assertEqual(
             instance.name,
             'PR#234: Watched PR title which ... (bradenmacdonald) - watched/watch-branch (7777777)')
+        self.mock_db_connection_close.assert_called_once_with()


### PR DESCRIPTION
This ensure connections are closed when no task is executing, and ensure no stale connection remains active across task runs.

See http://huey.readthedocs.org/en/latest/django.html#tasks-that-execute-queries

Also prevents sharing the periodic scheduler process with a worker, to avoid using multiple threads, and keep the logs clean. `periodic.1` then only get periodic scheduling log items, instead of mixing worker and scheduler log lines)