### PR TITLE
Mark PR repos on the upstream repo, not the fork.

### DIFF
--- a/instance/github.py
+++ b/instance/github.py
@@ -86,12 +86,12 @@ def get_settings_from_pr_body(pr_body):
         return ''
 
 
-def get_pr_by_number(fork_name, pr_number):
+def get_pr_by_number(pr_target_fork_name, pr_number):
     """
     Returns a PR object based on the reponse
     """
-    r_pr = get_object_from_url('https://api.github.com/repos/{fork_name}/pulls/{pr_number}'.format(
-        fork_name=fork_name,
+    r_pr = get_object_from_url('https://api.github.com/repos/{pr_target_fork_name}/pulls/{pr_number}'.format(
+        pr_target_fork_name=pr_target_fork_name,
         pr_number=pr_number,
     ))
     pr_fork_name = r_pr['head']['repo']['full_name']
@@ -99,6 +99,7 @@ def get_pr_by_number(fork_name, pr_number):
     pr = PR(
         pr_number,
         pr_fork_name,
+        pr_target_fork_name,
         pr_branch_name,
         r_pr['title'],
         r_pr['user']['login'],
@@ -148,9 +149,11 @@ class PR:
     """
     Representation of a GitHub Pull Request
     """
-    def __init__(self, number, fork_name, branch_name, title, username, body=''):
+    # pylint: disable=too-many-arguments
+    def __init__(self, number, source_fork_name, target_fork_name, branch_name, title, username, body=''):
         self.number = number
-        self.fork_name = fork_name
+        self.fork_name = source_fork_name
+        self.repo_name = target_fork_name
         self.branch_name = branch_name
         self.title = title
         self.username = username
@@ -168,4 +171,4 @@ class PR:
         """
         Construct the URL for the pull request
         """
-        return 'https://github.com/{fork_name}/pull/{number}'.format(fork_name=self.fork_name, number=self.number)
+        return 'https://github.com/{repo_name}/pull/{number}'.format(repo_name=self.repo_name, number=self.number)

--- a/instance/tests/test_github.py
+++ b/instance/tests/test_github.py
@@ -94,6 +94,7 @@ class GitHubTestCase(TestCase):
             '- - -\r\n**Settings**\r\n```yaml\r\nEDXAPP_FEATURES:\r\n  ALLOW: true\r\n```')
         self.assertEqual(pr.number, 8474)
         self.assertEqual(pr.fork_name, 'open-craft/edx-platform')
+        self.assertEqual(pr.repo_name, 'edx/edx-platform')
         self.assertEqual(pr.branch_name, 'smarnach/hide-discussion-tab')
         self.assertEqual(pr.extra_settings, 'EDXAPP_FEATURES:\r\n  ALLOW: true\r\n')
         self.assertEqual(pr.username, 'smarnach')

--- a/instance/tests/test_tasks.py
+++ b/instance/tests/test_tasks.py
@@ -62,13 +62,14 @@ class TasksTestCase(TestCase):
         mock_get_username_list.return_value = ['itsjeyd']
         pr = github.PR(
             number=234,
-            fork_name='watched/fork',
+            source_fork_name='fork/repo',
+            target_fork_name='source/repo',
             branch_name='watch-branch',
             title='Watched PR title which is very long',
             username='bradenmacdonald',
             body='Hello watcher!\n- - -\r\n**Settings**\r\n```\r\nWATCH: true\r\n```\r\nMore...',
         )
-        self.assertEqual(pr.github_pr_url, 'https://github.com/watched/fork/pull/234')
+        self.assertEqual(pr.github_pr_url, 'https://github.com/source/repo/pull/234')
         mock_get_pr_list_from_username.return_value = [pr]
         mock_get_commit_id_from_ref.return_value = '7' * 40
 
@@ -76,12 +77,13 @@ class TasksTestCase(TestCase):
         self.assertEqual(mock_provision_instance.call_count, 1)
         instance = OpenEdXInstance.objects.get(pk=mock_provision_instance.mock_calls[0][1][0])
         self.assertEqual(instance.sub_domain, 'pr234.sandbox')
-        self.assertEqual(instance.fork_name, 'watched/fork')
+        self.assertEqual(instance.fork_name, 'fork/repo')
         self.assertEqual(instance.github_pr_number, 234)
-        self.assertEqual(instance.github_pr_url, 'https://github.com/watched/fork/pull/234')
+        self.assertEqual(instance.github_pr_url, 'https://github.com/source/repo/pull/234')
+        self.assertEqual(instance.github_base_url, 'https://github.com/fork/repo')
         self.assertEqual(instance.branch_name, 'watch-branch')
         self.assertEqual(instance.ansible_extra_settings, 'WATCH: true\r\n')
         self.assertEqual(
             instance.name,
-            'PR#234: Watched PR title which ... (bradenmacdonald) - watched/watch-branch (7777777)')
+            'PR#234: Watched PR title which ... (bradenmacdonald) - fork/watch-branch (7777777)')
         self.mock_db_connection_close.assert_called_once_with()


### PR DESCRIPTION
@antoviaque This should fix the outstanding issue with the fork name.