### PR TITLE
Allow to set timeouts for playbook runs.

### DIFF
--- a/instance/models/instance.py
+++ b/instance/models/instance.py
@@ -41,7 +41,7 @@ from instance.github import fork_name2tuple, get_username_list_from_team
 from instance.logging import log_exception
 from instance.logger_adapter import InstanceLoggerAdapter
 from instance.repo import open_repository
-from instance.utils import read_files
+from instance.utils import poll_streams
 
 from instance.models.utils import ValidateModelMixin
 
@@ -528,7 +528,7 @@ class AnsibleInstanceMixin(models.Model):
             username=settings.OPENSTACK_SANDBOX_SSH_USERNAME,
         ) as process:
             try:
-                log_line_generator = read_files(
+                log_line_generator = poll_streams(
                     process.stdout,
                     process.stderr,
                     line_timeout=settings.ANSIBLE_LINE_TIMEOUT,

--- a/instance/models/instance.py
+++ b/instance/models/instance.py
@@ -526,16 +526,26 @@ class AnsibleInstanceMixin(models.Model):
             playbook_path,
             self.ansible_playbook_filename,
             username=settings.OPENSTACK_SANDBOX_SSH_USERNAME,
-        ) as processus:
-            for fd, line in read_files(processus.stdout, processus.stderr):
-                line = line.decode('utf-8').rstrip()
-                if fd == processus.stdout:
-                    self.logger.info(line)
-                elif fd == processus.stderr:
-                    self.logger.error(line)
-                log_lines.append(line)
-            processus.wait()
-            return (log_lines, processus.returncode)
+        ) as process:
+            try:
+                log_line_generator = read_files(
+                    process.stdout,
+                    process.stderr,
+                    line_timeout=settings.ANSIBLE_LINE_TIMEOUT,
+                    global_timeout=settings.ANSIBLE_GLOBAL_TIMEOUT,
+                )
+                for f, line in log_line_generator:
+                    line = line.decode('utf-8').rstrip()
+                    if f == process.stdout:
+                        self.logger.info(line)
+                    elif f == process.stderr:
+                        self.logger.error(line)
+                    log_lines.append(line)
+            except TimeoutError:
+                self.logger.error('Playbook run timed out.  Terminating the Ansible process.')
+                process.terminate()
+            process.wait()
+            return log_lines, process.returncode
 
     def deploy(self):
         """

--- a/instance/tests/models/test_instance.py
+++ b/instance/tests/models/test_instance.py
@@ -327,11 +327,11 @@ class AnsibleInstanceTestCase(TestCase):
         self.assertNotIn('Vars Instance', instance.ansible_settings)
         self.assertIn("EDXAPP_CONTACT_EMAIL: vars@example.com", instance.ansible_settings)
 
-    @patch('instance.models.instance.read_files')
+    @patch('instance.models.instance.poll_streams')
     @patch('instance.models.instance.OpenEdXInstance.inventory_str')
     @patch('instance.models.instance.ansible.run_playbook')
     @patch('instance.models.instance.open_repository')
-    def test_deployment(self, mock_open_repo, mock_run_playbook, mock_inventory, mock_read_files):
+    def test_deployment(self, mock_open_repo, mock_run_playbook, mock_inventory, mock_poll_streams):
         """
         Test instance deployment
         """

--- a/instance/tests/models/test_instance.py
+++ b/instance/tests/models/test_instance.py
@@ -22,8 +22,8 @@ OpenEdXInstance model - Tests
 
 # Imports #####################################################################
 
+import os
 import re
-import tempfile
 from mock import call, patch
 
 from instance.models.server import OpenStackServer, Server
@@ -354,23 +354,20 @@ class AnsibleInstanceTestCase(TestCase):
         """
         Ensure logging routines are working on _run_playbook method
         """
-        with tempfile.NamedTemporaryFile() as stdout:
-            with tempfile.NamedTemporaryFile() as stderr:
-
-                mock_run_playbook.return_value.__enter__.return_value.stdout = open(stdout.name, "rb")
-                mock_run_playbook.return_value.__enter__.return_value.stderr = open(stderr.name, "rb")
-                mock_run_playbook.return_value.__enter__.return_value.returncode = 0
-
-                stdout.write(b"HELLO\n")
-                stdout.flush()
-                stderr.write(b"HI\n")
-                stderr.flush()
-
-                instance = OpenEdXInstanceFactory()
-                log, returncode = instance._run_playbook("requirements", "playbook")
-
-                self.assertCountEqual(log, ['HELLO', 'HI'])
-                self.assertEqual(returncode, 0)
+        stdout_r, stdout_w = os.pipe()
+        stderr_r, stderr_w = os.pipe()
+        with open(stdout_r, 'rb', buffering=0) as stdout, open(stderr_r, 'rb', buffering=0) as stderr:
+            mock_run_playbook.return_value.__enter__.return_value.stdout = stdout
+            mock_run_playbook.return_value.__enter__.return_value.stderr = stderr
+            mock_run_playbook.return_value.__enter__.return_value.returncode = 0
+            os.write(stdout_w, b'Hello\n')
+            os.close(stdout_w)
+            os.write(stderr_w, b'Hi\n')
+            os.close(stderr_w)
+            instance = OpenEdXInstanceFactory()
+            log, returncode = instance._run_playbook("requirements", "playbook")
+            self.assertCountEqual(log, ['Hello', 'Hi'])
+            self.assertEqual(returncode, 0)
 
 
 class OpenEdXInstanceTestCase(TestCase):

--- a/instance/tests/test_utils.py
+++ b/instance/tests/test_utils.py
@@ -36,7 +36,7 @@ class UtilsTestCase(TestCase):
     """
     def test_read_files(self):
         """
-        Ensure that the lines read are in the order they were written
+        Ensure that the lines read are in the order they were written in each stream.
         """
         process = subprocess.Popen([
             "echo line1; echo line1 >&2; echo line2; echo line2 >&2; echo line3"

--- a/instance/tests/test_utils.py
+++ b/instance/tests/test_utils.py
@@ -25,7 +25,7 @@ Utils module - Tests
 import subprocess
 
 from instance.tests.base import TestCase
-from instance.utils import read_files
+from instance.utils import poll_streams
 
 
 # Tests #######################################################################
@@ -34,14 +34,14 @@ class UtilsTestCase(TestCase):
     """
     Test cases for functions in the utils module
     """
-    def test_read_files(self):
+    def test_poll_streams(self):
         """
         Ensure that the lines read are in the order they were written in each stream.
         """
         process = subprocess.Popen([
             "echo line1; echo line1 >&2; echo line2; echo line2 >&2; echo line3"
         ], stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
-        lines = read_files(process.stdout, process.stderr)
+        lines = poll_streams(process.stdout, process.stderr)
 
         expected = [
             (process.stdout, b"line1\n"),

--- a/instance/utils.py
+++ b/instance/utils.py
@@ -77,7 +77,7 @@ def get_requests_retry(total=10, connect=10, read=10, redirect=10, backoff_facto
 
 def _line_timeout_generator(line_timeout, global_timeout):
     """
-    Helper function for read_files() to compute the timeout for a single line.
+    Helper function for poll_streams() to compute the timeout for a single line.
     """
     if global_timeout is not None:
         deadline = time.time() + global_timeout
@@ -91,7 +91,7 @@ def _line_timeout_generator(line_timeout, global_timeout):
         yield from itertools.repeat(line_timeout)
 
 
-def read_files(*files, line_timeout=None, global_timeout=None):
+def poll_streams(*files, line_timeout=None, global_timeout=None):
     """
     Poll a set of file objects for new data and return it line by line.
 

--- a/opencraft/settings.py
+++ b/opencraft/settings.py
@@ -268,6 +268,11 @@ DEFAULT_ADMIN_ORGANIZATION = env('DEFAULT_ADMIN_ORGANIZATION', default='')
 # Ansible requires a Python 2 interpreter
 ANSIBLE_PYTHON_PATH = env('ANSIBLE_PYTHON_PATH', default='/usr/bin/python')
 
+# Time in seconds to wait for the next log line when running an Ansible playbook.
+ANSIBLE_LINE_TIMEOUT = env.int('ANSIBLE_LINE_TIMEOUT', default=900)  # 15 minutes
+
+# Timeout in seconds for an entire Ansible playbook.
+ANSIBLE_GLOBAL_TIMEOUT = env.int('ANSIBLE_GLOBAL_TIMEOUT', default=9000)  # 2.5 hours
 
 # Emails ######################################################################
 

--- a/pylintrc
+++ b/pylintrc
@@ -176,7 +176,7 @@ init-import=no
 
 # A regular expression matching the name of dummy variables (i.e. expectedly
 # not used).
-dummy-variables-rgx=_$|dummy
+dummy-variables-rgx=_$|dummy|unused
 
 # List of additional names supposed to be defined in builtins. Remember that
 # you should avoid to define new builtins when possible.


### PR DESCRIPTION
This PR introduces two new settings:

* `ANSIBLE_LINE_TIMEOUT`: The time in seconds to wait for the next log line when running an Ansible playbook.
* `ANSIBLE_GLOBAL_TIMEOUT`: The timeout in seconds for an entire Ansible playbook.

These settings make sure playbook runs don't hang indefintely.