### PR TITLE
Refactor the PR class.

### DIFF
--- a/instance/github.py
+++ b/instance/github.py
@@ -22,8 +22,11 @@ GitHub Service API - Helper functions
 
 # Imports #####################################################################
 
+import functools
+import operator
 import re
 import requests
+import yaml
 
 from django.conf import settings
 
@@ -165,6 +168,15 @@ class PR:
         Extra settings contained in the PR body
         """
         return get_settings_from_pr_body(self.body)
+
+    def get_extra_setting(self, name):
+        """
+        Return the setting given by "name" from extra_settings.
+
+        The name may be a dot-separated path to retrieve nested settings.
+        """
+        extra_settings_dict = yaml.load(self.extra_settings) or {}
+        return functools.reduce(operator.getitem, name.split('.'), extra_settings_dict)
 
     @property
     def github_pr_url(self):

--- a/instance/migrations/0036_auto_20151112_1122.py
+++ b/instance/migrations/0036_auto_20151112_1122.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('instance', '0035_reset_ansible_settings'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='openedxinstance',
+            name='ansible_source_repo_url',
+            field=models.URLField(blank=True, max_length=256),
+        ),
+        migrations.AlterField(
+            model_name='openedxinstance',
+            name='configuration_version',
+            field=models.CharField(blank=True, max_length=50),
+        ),
+    ]

--- a/instance/tasks.py
+++ b/instance/tasks.py
@@ -73,6 +73,8 @@ def watch_pr():
                             .format(pr=pr, i=instance, truncated_title=truncated_title)
             instance.github_pr_url = pr.github_pr_url
             instance.ansible_extra_settings = pr.extra_settings
+            instance.ansible_source_repo_url = pr.get_extra_setting('edx_ansible_source_repo')
+            instance.configuration_version = pr.get_extra_setting('configuration_version')
             instance.save()
 
             if created:

--- a/opencraft/settings.py
+++ b/opencraft/settings.py
@@ -263,6 +263,12 @@ WATCH_ORGANIZATION = env('WATCH_ORGANIZATION')
 # Default admin organization for instances (gets shell access)
 DEFAULT_ADMIN_ORGANIZATION = env('DEFAULT_ADMIN_ORGANIZATION', default='')
 
+# Fork and branch of the Open edX configuration repo used for sandboxes created for PRs.
+DEFAULT_CONFIGURATION_REPO_URL = env(
+    'DEFAULT_CONFIGURATION_FORK', default='https://github.com/edx/configuration.git'
+)
+DEFAULT_CONFIGURATION_VERSION = env('DEFAULT_CONFIGURATION_VERSION', default='master')
+
 # Ansible #####################################################################
 
 # Ansible requires a Python 2 interpreter

--- a/pylintrc
+++ b/pylintrc
@@ -94,13 +94,13 @@ confidence=
 # no Warning level messages displayed, use"--disable=all --enable=classes
 # --disable=W"
 disable=
-    no-init,
     fixme,
     locally-disabled,
+    no-init,
     too-few-public-methods,
     too-many-ancestors,
-    unused-argument,
-    protected-access
+    protected-access,
+    unused-argument
 
 [SPELLING]
 


### PR DESCRIPTION
An (incomplete) suggestion on how to refactor the PR class.

The new version keeps all data retrieved from Github around, and implements most attributes as properties that simply do a lookup in this data dictionary.  The `extra_settings` which are more expensive to retrieve are cached in read-only attributes.  A method `update_data()` allows to update all fields from Github, and makes sure everything is kept in sync.

The repetitiveness of the code can easily be reduced by storing a mapping of property names to paths in the data dict.  This structure would allow to easily add new properties, like the base branch (the branch targetted by the PR) or the timestamp of the last update.

(I'm also not sure we really need to hide `extra_settings` and `extra_settings_dict` behind read-only attributes.  I usually wouldn't do this, since I dislike code doing nothing.)