### PR TITLE
Fix misnamed env variable.

### DIFF
--- a/opencraft/settings.py
+++ b/opencraft/settings.py
@@ -265,7 +265,7 @@ DEFAULT_ADMIN_ORGANIZATION = env('DEFAULT_ADMIN_ORGANIZATION', default='')
 
 # Fork and branch of the Open edX configuration repo used for sandboxes created for PRs.
 DEFAULT_CONFIGURATION_REPO_URL = env(
-    'DEFAULT_CONFIGURATION_FORK', default='https://github.com/edx/configuration.git'
+    'DEFAULT_CONFIGURATION_REPO_URL', default='https://github.com/edx/configuration.git'
 )
 DEFAULT_CONFIGURATION_VERSION = env('DEFAULT_CONFIGURATION_VERSION', default='master')
 


### PR DESCRIPTION
This typo was introduced when addressing review comments in #29.

cc @antoviaque