### PR TITLE
Add libmysqlclient-dev to the system dependencies.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,6 @@ Instructions based on Ubuntu 14.04.
 Install the system package dependencies & virtualenv:
 
 ```
-$ sudo apt-get update
 $ make install_system_dependencies
 $ pip3 install --user virtualenv && pip3 install --user virtualenvwrapper
 ```

--- a/debian_packages.lst
+++ b/debian_packages.lst
@@ -5,3 +5,4 @@ libpq-dev
 python-dev
 redis-server
 firefox
+libmysqlclient-dev


### PR DESCRIPTION
This package is needed since recently to install the Ansible prerequisites, see
https://github.com/edx/configuration/pull/2537.

Also remove a redundant command from the README file.