### PR TITLE
Don't instantiate novaclient V2 directly

### DIFF
--- a/instance/openstack.py
+++ b/instance/openstack.py
@@ -24,7 +24,7 @@ OpenStack - Helper functions
 
 import requests
 
-from novaclient.v2.client import Client as NovaClient
+from novaclient.client import Client as NovaClient
 
 from django.conf import settings
 
@@ -39,11 +39,12 @@ logger = logging.getLogger(__name__)
 
 # Functions ###################################################################
 
-def get_nova_client():
+def get_nova_client(api_version=2):
     """
     Instanciate a python novaclient.Client() object with proper credentials
     """
     nova = NovaClient(
+        api_version,
         settings.OPENSTACK_USER,
         settings.OPENSTACK_PASSWORD,
         settings.OPENSTACK_TENANT,


### PR DESCRIPTION
It doesn't like it and prints a warning:

    UserWarning: 'novaclient.v2.client.Client' is not designed to be initialized directly. It is inner class of novaclient. Please, use 'novaclient.client.Client' instead. Related lp bug-report: 1493576