### PR TITLE
Limit the number of log lines displayed

### DIFF
--- a/instance/api/instance.py
+++ b/instance/api/instance.py
@@ -28,7 +28,8 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 
 from instance.models.instance import OpenEdXInstance
-from instance.serializers.instance import OpenEdXInstanceSerializer
+from instance.serializers.instance import (OpenEdXInstanceListSerializer,
+                                           OpenEdXInstanceDetailSerializer)
 from instance.tasks import provision_instance
 
 
@@ -39,7 +40,6 @@ class OpenEdXInstanceViewSet(viewsets.ModelViewSet):
     OpenEdXInstance API ViewSet
     """
     queryset = OpenEdXInstance.objects.all()
-    serializer_class = OpenEdXInstanceSerializer
 
     @detail_route(methods=['post'], permission_classes=[IsAuthenticated])
     def provision(self, request, pk=None):
@@ -55,3 +55,11 @@ class OpenEdXInstanceViewSet(viewsets.ModelViewSet):
         provision_instance(pk)
 
         return Response({'status': 'Instance provisioning started'})
+
+    def get_serializer_class(self):
+        """
+        Return the list serializer for the list action, and the detail serializer otherwise.
+        """
+        if self.action == 'list':
+            return OpenEdXInstanceListSerializer
+        return OpenEdXInstanceDetailSerializer

--- a/instance/models/instance.py
+++ b/instance/models/instance.py
@@ -113,8 +113,6 @@ class Instance(ValidateModelMixin, TimeStampedModel):
 
     last_provisioning_started = models.DateTimeField(blank=True, null=True)
 
-    logger = InstanceLoggerAdapter(logger, {})
-
     class Meta:
         abstract = True
         unique_together = ('base_domain', 'sub_domain')

--- a/instance/models/instance.py
+++ b/instance/models/instance.py
@@ -227,30 +227,42 @@ class Instance(ValidateModelMixin, TimeStampedModel):
 
         return log
 
-    def _get_log_entries(self, level_list=None):
+    def _get_log_entries(self, level_list=None, limit=None):
         """
         Return the list of log entry instances for the instance and its current active server,
-        optionally filtering by logging level.
+        optionally filtering by logging level. If a limit is given, only the latest records are
+        returned.
         """
         # TODO: Filter out log entries for which the user doesn't have view rights
         server_log_entry_set = self._current_server.log_entry_set
         if level_list:
             server_log_entry_set = server_log_entry_set.filter(level__in=level_list)
-        server_log_entry_set = server_log_entry_set.order_by('pk').iterator()
+        server_log_entry_set = server_log_entry_set.order_by('pk')
+        if limit:
+            server_log_entry_set = reversed(server_log_entry_set.reverse()[:limit])
+        else:
+            server_log_entry_set = server_log_entry_set.iterator()
 
         instance_log_entry_set = self.log_entry_set
         if level_list:
             instance_log_entry_set = instance_log_entry_set.filter(level__in=level_list)
-        instance_log_entry_set = instance_log_entry_set.order_by('pk').iterator()
+        instance_log_entry_set = instance_log_entry_set.order_by('pk')
+        if limit:
+            instance_log_entry_set = reversed(instance_log_entry_set.reverse()[:limit])
+        else:
+            instance_log_entry_set = instance_log_entry_set.iterator()
 
-        return Instance._sort_log_entries(server_log_entry_set, instance_log_entry_set)
+        entries = self._sort_log_entries(server_log_entry_set, instance_log_entry_set)
+        if limit:
+            return entries[-limit:]
+        return entries
 
     @property
     def log_entries(self):
         """
         Return the list of log entry instances for the instance and its current active server
         """
-        return self._get_log_entries()
+        return self._get_log_entries(limit=settings.LOG_LIMIT)
 
     @property
     def log_error_entries(self):

--- a/instance/serializers/instance.py
+++ b/instance/serializers/instance.py
@@ -31,14 +31,12 @@ from instance.serializers.logentry import LogEntrySerializer
 
 # Serializers #################################################################
 
-class OpenEdXInstanceSerializer(serializers.ModelSerializer):
+class OpenEdXInstanceListSerializer(serializers.ModelSerializer):
     """
-    OpenEdXInstance API Serializer
+    OpenEdXInstance API Serializer (list view).
     """
     api_url = serializers.HyperlinkedIdentityField(view_name='api:openedxinstance-detail')
     active_server_set = OpenStackServerSerializer(many=True, read_only=True)
-    log_entries = LogEntrySerializer(many=True, read_only=True)
-    log_error_entries = LogEntrySerializer(many=True, read_only=True)
 
     class Meta:
         model = OpenEdXInstance
@@ -57,8 +55,6 @@ class OpenEdXInstanceSerializer(serializers.ModelSerializer):
             'github_branch_url',
             'github_pr_number',
             'github_pr_url',
-            'log_entries',
-            'log_error_entries',
             'github_organization_name',
             'modified',
             'name',
@@ -71,3 +67,14 @@ class OpenEdXInstanceSerializer(serializers.ModelSerializer):
             'url',
             'updates_feed',
         )
+
+
+class OpenEdXInstanceDetailSerializer(OpenEdXInstanceListSerializer):
+    """
+    OpenEdXInstance API Serializer (detail view). Includes log entries.
+    """
+    log_entries = LogEntrySerializer(many=True, read_only=True)
+    log_error_entries = LogEntrySerializer(many=True, read_only=True)
+
+    class Meta(OpenEdXInstanceListSerializer.Meta):
+        fields = OpenEdXInstanceListSerializer.Meta.fields + ('log_entries', 'log_error_entries')

--- a/instance/static/html/instance/index.html
+++ b/instance/static/html/instance/index.html
@@ -23,7 +23,7 @@
     <ul class="side-nav" ng-if="instanceList">
       <li ng-repeat="instance in instanceList"
           ng-class="{active: instance == selected.instance}">
-        <a ng-click="select('instance', instance)">{{ instance.name }}</a>
+        <a ng-click="select(instance)">{{ instance.name }}</a>
         <div class="status-icon" ng-switch="instance.progress">
           <i class="fa fa-ellipsis-h" tooltip-placement="top" tooltip="In progress" ng-switch-when="running"></i>
           <i class="fa fa-times" tooltip-placement="top" tooltip="Failed" ng-switch-when="failed"></i>

--- a/instance/static/js/src/instance.js
+++ b/instance/static/js/src/instance.js
@@ -75,9 +75,18 @@ app.controller("Index", ['$scope', 'Restangular', 'OpenCraftAPI', '$q',
             });
         };
 
-        $scope.select = function(selection_type, value) {
-            $scope.selected[selection_type] = value;
-            console.log('Selected ' + selection_type + ':', value);
+        $scope.select = function(instance) {
+            $scope.loading = true; // Display loading message
+            console.log('Selected instance', instance.id);
+
+            return OpenCraftAPI.one('openedxinstance', instance.id).get().then(function(instance) {
+                console.log('Fetched instance', instance.id);
+                $scope.selected.instance = instance;
+            }, function(response) {
+                console.log('Error from server: ', response);
+            }).finally(function () {
+                $scope.loading = false;
+            });
         };
 
         $scope.provision = function(instance) {
@@ -98,14 +107,8 @@ app.controller("Index", ['$scope', 'Restangular', 'OpenCraftAPI', '$q',
                 console.log('Updating instance list', instanceList);
                 $scope.instanceList = instanceList;
 
-                if($scope.selected.instance){
-                    var updated_instance = null;
-                    _.each(instanceList, function(instance) {
-                        if(instance.id === $scope.selected.instance.id) {
-                            updated_instance = instance;
-                        }
-                    });
-                    $scope.selected.instance = updated_instance;
+                if($scope.selected.instance) {
+                    $scope.select($scope.selected.instance);
                 }
             }, function(response) {
                 console.log('Error from server: ', response);

--- a/instance/tests/api/test_instance.py
+++ b/instance/tests/api/test_instance.py
@@ -124,7 +124,7 @@ class InstanceAPITestCase(APITestCase):
         server.logger.info("info")
         server.logger.error("error")
 
-        response = self.api_client.get('/api/v1/openedxinstance/'.format(pk=instance.pk))
+        response = self.api_client.get('/api/v1/openedxinstance/{pk}/'.format(pk=instance.pk))
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         expected_list = [
@@ -133,9 +133,9 @@ class InstanceAPITestCase(APITestCase):
             {'level': 'INFO', 'text': 'instance.models.server    | instance=instance0,server=vm0 | info'},
             {'level': 'ERROR', 'text': 'instance.models.server    | instance=instance0,server=vm0 | error'},
         ]
-        self.assertEqual(len(expected_list), len(response.data[0]['log_entries']))
+        self.assertEqual(len(expected_list), len(response.data['log_entries']))
 
-        for expected_entry, log_entry in zip(expected_list, response.data[0]['log_entries']):
+        for expected_entry, log_entry in zip(expected_list, response.data['log_entries']):
             self.assertEqual(expected_entry['level'], log_entry['level'])
             self.assertEqual(expected_entry['text'], log_entry['text'])
 
@@ -151,15 +151,15 @@ class InstanceAPITestCase(APITestCase):
         server.logger.info("info")
         server.logger.error("error")
 
-        response = self.api_client.get('/api/v1/openedxinstance/'.format(pk=instance.pk))
+        response = self.api_client.get('/api/v1/openedxinstance/{pk}/'.format(pk=instance.pk))
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         expected_list = [
             {'level': 'ERROR', 'text': 'instance.models.instance  | instance=instance0 | error'},
             {'level': 'ERROR', 'text': 'instance.models.server    | instance=instance0,server=vm0 | error'},
         ]
-        self.assertEqual(len(expected_list), len(response.data[0]['log_error_entries']))
+        self.assertEqual(len(expected_list), len(response.data['log_error_entries']))
 
-        for expected_entry, log_entry in zip(expected_list, response.data[0]['log_error_entries']):
+        for expected_entry, log_entry in zip(expected_list, response.data['log_error_entries']):
             self.assertEqual(expected_entry['level'], log_entry['level'])
             self.assertEqual(expected_entry['text'], log_entry['text'])

--- a/instance/tests/fixtures/api/instance_detail.json
+++ b/instance/tests/fixtures/api/instance_detail.json
@@ -1,0 +1,29 @@
+{
+  "id": 2,
+  "api_url": "http://localhost:5000/api/v1/openedxinstance/2/",
+  "active_server_set": [
+    {
+      "id": 23,
+      "api_url": "http://localhost:5000/api/v1/openstackserver/23/",
+      "created": "2015-08-20T06:40:18.835733Z",
+      "instance": "http://localhost:5000/api/v1/openedxinstance/2/",
+      "modified": "2015-08-20T12:12:34.781802Z",
+      "openstack_id": "f889c46a-975a-4ecb-acb8-b6c3c5f97c8e",
+      "status": "ready"
+    }
+  ],
+  "base_domain": "opencraft.com",
+  "branch_name": "master",
+  "commit_id": "24bca27b46a0e65c00628716a77d19a6c5aecd55",
+  "created": "2015-08-08T07:22:56.062796Z",
+  "domain": "tmp.sandbox.opencraft.com",
+  "email": "contact@example.com",
+  "github_base_url": "https://github.com/antoviaque/edx-platform",
+  "github_branch_url": "https://github.com/antoviaque/edx-platform/tree/master",
+  "log_entries": [
+      {"date": "2015-08-08T07:23:16Z", "level": "INFO", "text": "Terminate servers for instance tmp.sandbox - antoviaque/edx-platform/master (24bca27) (http://tmp.sandbox.opencraft.com/)..."},
+      {"date": "2015-08-08T07:23:16Z", "level": "INFO", "text": "Start new server for instance tmp.sandbox - antoviaque/edx-platform/master (24bca27) (http://tmp.sandbox.opencraft.com/)..."},
+      {"date": "2015-08-08T07:23:18Z", "level": "INFO", "text": "Waiting for IP assignment on server 3841c324-c004-4188-9d8c-f1071cd635c5..."}
+  ],
+  "log_error_entries": []
+}

--- a/instance/tests/fixtures/api/instances_list.json
+++ b/instance/tests/fixtures/api/instances_list.json
@@ -20,13 +20,7 @@
     "domain": "tmp.sandbox.opencraft.com",
     "email": "contact@example.com",
     "github_base_url": "https://github.com/antoviaque/edx-platform",
-    "github_branch_url": "https://github.com/antoviaque/edx-platform/tree/master",
-    "log_entries": [
-        {"date": "2015-08-08T07:23:16Z", "level": "INFO", "text": "Terminate servers for instance tmp.sandbox - antoviaque/edx-platform/master (24bca27) (http://tmp.sandbox.opencraft.com/)..."},
-        {"date": "2015-08-08T07:23:16Z", "level": "INFO", "text": "Start new server for instance tmp.sandbox - antoviaque/edx-platform/master (24bca27) (http://tmp.sandbox.opencraft.com/)..."},
-        {"date": "2015-08-08T07:23:18Z", "level": "INFO", "text": "Waiting for IP assignment on server 3841c324-c004-4188-9d8c-f1071cd635c5..."}
-    ],
-    "log_error_entries": []
+    "github_branch_url": "https://github.com/antoviaque/edx-platform/tree/master"
   },
   {
     "id": 1,
@@ -51,10 +45,6 @@
     "email": "contact@example.com",
     "github_base_url": "https://github.com/antoviaque/edx-platform",
     "github_branch_url": "https://github.com/antoviaque/edx-platform/tree/OC-791-course-timeline",
-    "log_entries": [
-        {"date": "2015-08-07T18:10:56Z", "level": "INFO", "text": "Terminate servers for instance PR#2: Display start date, end date, and number of sections (weeks) on \"Course Info\" tab of instructor dashboard. (antoviaque) - antoviaque/edx-platform/OC-791-course-timeline (4095206) (http://pr2.sandbox.opencraft.com/)..."}
-    ],
-    "log_error_entries": [],
     "github_organization_name": "antoviaque",
     "modified": "2015-08-18T05:48:54.356884Z",
     "name": "PR#2: Display start date, end date, and number of sections (weeks) on \"Course Info\" tab of instructor dashboard. (antoviaque) - antoviaque/edx-platform/OC-791-course-timeline (4095206)",

--- a/instance/tests/js/instance_app_spec.js
+++ b/instance/tests/js/instance_app_spec.js
@@ -23,6 +23,7 @@ describe('Instance app', function () {
     var httpBackend,
         indexController,
         instanceList,
+        instanceDetail,
         OpenCraftAPI,
         $scope;
 
@@ -43,7 +44,9 @@ describe('Instance app', function () {
 
             // Models
             instanceList = jasmine.loadFixture('api/instances_list.json');
+            instanceDetail = jasmine.loadFixture('api/instance_detail.json');
             httpBackend.whenGET('/api/v1/openedxinstance/').respond(instanceList);
+            httpBackend.whenGET('/api/v1/openedxinstance/2/').respond(instanceDetail);
 
             indexController = $controller('Index', {$scope: $scope, OpenCraftAPI: OpenCraftAPI});
             httpBackend.flush(); // Clear calls from the controller init
@@ -56,8 +59,9 @@ describe('Instance app', function () {
 
         describe('$scope.select', function() {
             it('select the instance', function() {
-                $scope.select('a', 'b');
-                expect($scope.selected.a).toEqual('b');
+                $scope.select({id: 2});
+                httpBackend.flush();
+                expect($scope.selected.instance.domain).toEqual('tmp.sandbox.opencraft.com');
             });
         });
 
@@ -75,10 +79,12 @@ describe('Instance app', function () {
             });
 
             it('updates the selected instance when updating the list', function() {
-                $scope.instanceList[0].domain = 'old.example.com';
-                $scope.select('instance', $scope.instanceList[0]);
+                instanceDetail.domain = 'old.example.com';
+                $scope.select($scope.instanceList[0]);
+                httpBackend.flush();
                 expect($scope.selected.instance.domain).toEqual('old.example.com');
 
+                instanceDetail.domain = 'tmp.sandbox.opencraft.com';
                 $scope.updateInstanceList();
                 httpBackend.flush();
                 expect($scope.selected.instance.domain).toEqual('tmp.sandbox.opencraft.com');
@@ -104,7 +110,8 @@ describe('Instance app', function () {
             });
 
             it('instance_log', function() {
-                $scope.select('instance', $scope.instanceList[0]);
+                $scope.select($scope.instanceList[0]);
+                httpBackend.flush();
                 var log_entry = {
                     level: 'INFO',
                     created: new Date(2015, 10, 4, 10, 45, 0),
@@ -120,7 +127,8 @@ describe('Instance app', function () {
             });
 
             it('errors', function() {
-                $scope.select('instance', $scope.instanceList[0]);
+                $scope.select($scope.instanceList[0]);
+                httpBackend.flush();
                 var log_entry_error = {
                     level: 'ERROR',
                     created: new Date(2015, 10, 4, 10, 45, 0),

--- a/instance/tests/models/test_log_entry.py
+++ b/instance/tests/models/test_log_entry.py
@@ -22,6 +22,7 @@ Logger models & mixins - Tests
 
 # Imports #####################################################################
 
+from django.test import override_settings
 from freezegun import freeze_time
 from mock import patch
 
@@ -36,10 +37,27 @@ from instance.tests.models.factories.server import OpenStackServerFactory
 # Factory boy doesn't properly support pylint+django
 #pylint: disable=no-member
 
-class LogEntryTestCase(TestCase):
+class LoggingTestCase(TestCase):
     """
-    Test cases for LoggerInstanceMixin
+    Test cases for logging
     """
+    def setUp(self):
+        """
+        Set up an instance and server to use for testing.
+        """
+        super().setUp()
+        self.instance = OpenEdXInstanceFactory(sub_domain='my.instance')
+        self.server = OpenStackServerFactory(instance=self.instance, openstack_id='vm1_id')
+
+    def check_log_entries(self, entries, expected):
+        """
+        Check that the given entries match the expected log output.
+        """
+        for entry, (date, level, text) in zip(entries, expected):
+            self.assertEqual(entry.created.strftime("%Y-%m-%d %H:%M:%S"), date)
+            self.assertEqual(entry.level, level)
+            self.assertEqual(entry.text, text)
+
     def test_default_log_level(self):
         """
         Check that the default log level is INFO
@@ -51,17 +69,15 @@ class LogEntryTestCase(TestCase):
         """
         Check `log_entries` output for combination of instance & server logs
         """
-        instance = OpenEdXInstanceFactory(sub_domain='my.instance')
-        server = OpenStackServerFactory(instance=instance, openstack_id='vm1_id')
-
         lines = [
-            ("2015-08-05 18:07:00", instance.logger.info, 'Line #1, on instance'),
-            ("2015-08-05 18:07:01", server.logger.info, 'Line #2, on server'),
-            ("2015-08-05 18:07:02", instance.logger.debug, 'Line #3, on instance (debug, not published by default)'),
-            ("2015-08-05 18:07:03", instance.logger.info, 'Line #4, on instance'),
-            ("2015-08-05 18:07:04", instance.logger.warn, 'Line #5, on instance (warn)'),
-            ("2015-08-05 18:07:05", server.logger.info, 'Line #6, on server'),
-            ("2015-08-05 18:07:06", server.logger.critical, 'Line #7, exception'),
+            ("2015-08-05 18:07:00", self.instance.logger.info, 'Line #1, on instance'),
+            ("2015-08-05 18:07:01", self.server.logger.info, 'Line #2, on server'),
+            ("2015-08-05 18:07:02", self.instance.logger.debug,
+             'Line #3, on instance (debug, not published by default)'),
+            ("2015-08-05 18:07:03", self.instance.logger.info, 'Line #4, on instance'),
+            ("2015-08-05 18:07:04", self.instance.logger.warn, 'Line #5, on instance (warn)'),
+            ("2015-08-05 18:07:05", self.server.logger.info, 'Line #6, on server'),
+            ("2015-08-05 18:07:06", self.server.logger.critical, 'Line #7, exception'),
         ]
 
         for date, log, text in lines:
@@ -78,24 +94,19 @@ class LogEntryTestCase(TestCase):
             ("2015-08-05 18:07:05", 'INFO', server_prefix + 'Line #6, on server'),
             ("2015-08-05 18:07:06", 'CRITICAL', server_prefix + 'Line #7, exception'),
         ]
+        self.check_log_entries(self.instance.log_entries, expected)
 
-        entries = instance.log_entries
-
-        for entry, (date, level, text) in zip(entries, expected):
-            self.assertEqual(entry.created.strftime("%Y-%m-%d %H:%M:%S"), date)
-            self.assertEqual(entry.level, level)
-            self.assertEqual(entry.text, text)
+        # Check that the `LOG_LIMIT` setting is respected
+        with override_settings(LOG_LIMIT=3):
+            self.check_log_entries(self.instance.log_entries, expected[-3:])
 
     @patch('instance.logging.publish_data')
-    def test_log_publish(self, mock_publish_data): #pylint: disable=no-self-use
+    def test_log_publish(self, mock_publish_data):
         """
         Logger sends an event to the client on each new log entry added
         """
-        instance = OpenEdXInstanceFactory(sub_domain='my.instance')
-        server = OpenStackServerFactory(instance=instance, openstack_id='vm1_id')
-
         with freeze_time("2015-09-21 21:07:00"):
-            instance.logger.info('Text the client should see')
+            self.instance.logger.info('Text the client should see')
 
         mock_publish_data.assert_called_with('log', {
             'log_entry': {
@@ -104,11 +115,11 @@ class LogEntryTestCase(TestCase):
                 'text': 'instance.models.instance  | instance=my.instance | Text the client should see',
             },
             'type': 'instance_log',
-            'instance_id': instance.pk,
+            'instance_id': self.instance.pk,
         })
 
         with freeze_time("2015-09-21 21:07:01"):
-            server.logger.info('Text the client should also see, with unicode «ταБЬℓσ»')
+            self.server.logger.info('Text the client should also see, with unicode «ταБЬℓσ»')
 
         mock_publish_data.assert_called_with('log', {
             'log_entry': {
@@ -118,39 +129,36 @@ class LogEntryTestCase(TestCase):
                          'should also see, with unicode «ταБЬℓσ»'),
             },
             'type': 'instance_log',
-            'instance_id': instance.pk,
-            'server_id': server.pk,
+            'instance_id': self.instance.pk,
+            'server_id': self.server.pk,
         })
 
     def test_log_error_entries(self):
         """
         Check `log_error_entries` output for combination of instance & server logs
         """
-        instance = OpenEdXInstanceFactory(sub_domain='my.instance')
-        server = OpenStackServerFactory(instance=instance, openstack_id='vm1_id')
-
         with freeze_time("2015-08-05 18:07:00"):
-            instance.logger.info('Line #1, on instance')
+            self.instance.logger.info('Line #1, on instance')
 
         with freeze_time("2015-08-05 18:07:01"):
-            instance.logger.error('Line #2, on server')
+            self.instance.logger.error('Line #2, on server')
 
         with freeze_time("2015-08-05 18:07:02"):
-            instance.logger.debug('Line #3, on instance (debug, not published by default)')
+            self.instance.logger.debug('Line #3, on instance (debug, not published by default)')
 
         with freeze_time("2015-08-05 18:07:03"):
-            server.logger.critical('Line #4, on instance')
+            self.server.logger.critical('Line #4, on instance')
 
         with freeze_time("2015-08-05 18:07:04"):
-            instance.logger.warn('Line #5, on instance (warn)')
+            self.instance.logger.warn('Line #5, on instance (warn)')
 
         with freeze_time("2015-08-05 18:07:05"):
-            server.logger.info('Line #6, on server')
+            self.server.logger.info('Line #6, on server')
 
         with freeze_time("2015-08-05 18:07:06"):
-            instance.logger.critical('Line #7, exception')
+            self.instance.logger.critical('Line #7, exception')
 
-        entries = instance.log_error_entries
+        entries = self.instance.log_error_entries
         self.assertEqual(entries[0].level, "ERROR")
         self.assertEqual(entries[0].created.strftime("%Y-%m-%d %H:%M:%S"), "2015-08-05 18:07:01")
         self.assertEqual(entries[0].text,

--- a/opencraft/settings.py
+++ b/opencraft/settings.py
@@ -376,3 +376,6 @@ INSTANCE_MYSQL_URL = env('INSTANCE_MYSQL_URL', default=None)
 INSTANCE_MONGO_URL = env('INSTANCE_MONGO_URL', default=None)
 INSTANCE_MYSQL_URL_OBJ = urlparse(INSTANCE_MYSQL_URL) if INSTANCE_MYSQL_URL else None
 INSTANCE_MONGO_URL_OBJ = urlparse(INSTANCE_MONGO_URL) if INSTANCE_MONGO_URL else None
+
+# Limit the number of log entries fetched for each instance, for performance
+LOG_LIMIT = env.int('LOG_LIMIT', default=10000)


### PR DESCRIPTION
See [OC-1035](https://tasks.opencraft.com/browse/OC-1035).

#### Problem

The interface takes a very long time to load, as it tries to fetch all log entries for all instances and there can be a lot of data sent over the wire.

#### Solution

This pull request adds a configurable limit on the number of log entries returned in the initial request. You can set the limit using the `LOG_LIMIT` environment variable (default: 10000).

In addition, loading log entries from the server is deferred until the user actually selects an instance.

#### Testing

To run the js tests in your development environment, see https://github.com/open-craft/opencraft/pull/39.

To test manually, create a server and instance with some log entries. We can use the test factories for this:

```python
from instance.tests.models.factories.server import OpenStackServerFactory

server = OpenStackServerFactory.create()
server.log_entry_set.create(level='INFO', text='server log message')
server.instance.log_entry_set.create(level='INFO', text='instance log message')
```

Then, start the dev server with

```
make rundev
```

With your web console open, go to http://localhost:5000/ and select the instance we just created. You will see a second request to fetch the log entries.