### PR TITLE
Add xvfb for running selenium tests in vagrant VM

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,7 +101,7 @@ test_integration: clean
 	fi
 
 test_js: clean static_external
-	cd instance/tests/js && jasmine-ci --logs --browser firefox
+	cd instance/tests/js && xvfb-run jasmine-ci --logs --browser firefox
 
 test_js_web: clean static_external
 	cd instance/tests/js && jasmine --host 0.0.0.0

--- a/Makefile
+++ b/Makefile
@@ -101,7 +101,7 @@ test_integration: clean
 	fi
 
 test_js: clean static_external
-	cd instance/tests/js && xvfb-run jasmine-ci --logs --browser firefox
+	cd instance/tests/js && xvfb-run --auto-servernum jasmine-ci --logs --browser firefox
 
 test_js_web: clean static_external
 	cd instance/tests/js && jasmine --host 0.0.0.0

--- a/debian_packages.lst
+++ b/debian_packages.lst
@@ -5,5 +5,5 @@ libpq-dev
 libmysqlclient-dev
 python-dev
 redis-server
+xvfb
 firefox
-libmysqlclient-dev

--- a/requirements.txt
+++ b/requirements.txt
@@ -88,7 +88,7 @@ requests-oauthlib==0.5.0
 requests-toolbelt==0.4.0
 requirements-detector==0.4
 responses==0.4.0
-selenium==2.47.3
+selenium==2.52.0
 setoptconf==0.2.0
 simplegeneric==0.8.1
 simplejson==3.8.0


### PR DESCRIPTION
**Before**:

```
Traceback (most recent call last):
  File "/home/vagrant/.virtualenvs/opencraft/bin/jasmine-ci", line 11, in <module>
    sys.exit(continuous_integration())
  File "/home/vagrant/.virtualenvs/opencraft/lib/python3.4/site-packages/jasmine/entry_points.py", line 44, in continuous_integration
    app=jasmine_app.app
  File "/home/vagrant/.virtualenvs/opencraft/lib/python3.4/site-packages/jasmine/ci.py", line 72, in run
    test_server = self._start_test_server(app, browser)
  File "/home/vagrant/.virtualenvs/opencraft/lib/python3.4/site-packages/jasmine/ci.py", line 115, in _start_test_server
    self.browser = webdriver.WebDriver()
  File "/home/vagrant/.virtualenvs/opencraft/lib/python3.4/site-packages/selenium/webdriver/firefox/webdriver.py", line 78, in __init__
    self.binary, timeout)
  File "/home/vagrant/.virtualenvs/opencraft/lib/python3.4/site-packages/selenium/webdriver/firefox/extension_connection.py", line 51, in __init__
    self.binary.launch_browser(self.profile, timeout=timeout)
  File "/home/vagrant/.virtualenvs/opencraft/lib/python3.4/site-packages/selenium/webdriver/firefox/firefox_binary.py", line 68, in launch_browser
    self._wait_until_connectable(timeout=timeout)
  File "/home/vagrant/.virtualenvs/opencraft/lib/python3.4/site-packages/selenium/webdriver/firefox/firefox_binary.py", line 98, in _wait_until_connectable
    raise WebDriverException("The browser appears to have exited "
selenium.common.exceptions.WebDriverException: Message: The browser appears to have exited before we could connect. If you specified a log_file in the FirefoxBinary constructor, check it for details.
```

**After**:

```
      _                     _
     | |                   (_)
     | | __ _ ___ _ __ ___  _ _ __   ___
 _   | |/ _` / __| '_ ` _ \| | '_ \ / _ \
| |__| | (_| \__ \ | | | | | | | | |  __/
 \____/ \__,_|___/_| |_| |_|_|_| |_|\___|

.........

9 specs, 0 failed
```