### PR TITLE
Set default log level to valid 'INFO' value

### DIFF
--- a/instance/models/log_entry.py
+++ b/instance/models/log_entry.py
@@ -52,7 +52,7 @@ class LogEntry(ValidateModelMixin, TimeStampedModel):
     )
 
     text = models.TextField(blank=True)
-    level = models.CharField(max_length=9, db_index=True, default='info', choices=LOG_LEVEL_CHOICES)
+    level = models.CharField(max_length=9, db_index=True, default='INFO', choices=LOG_LEVEL_CHOICES)
 
     class Meta:
         abstract = True

--- a/instance/tests/models/test_log_entry.py
+++ b/instance/tests/models/test_log_entry.py
@@ -25,6 +25,7 @@ Logger models & mixins - Tests
 from freezegun import freeze_time
 from mock import patch
 
+from instance.models.log_entry import GeneralLogEntry
 from instance.tests.base import TestCase
 from instance.tests.models.factories.instance import OpenEdXInstanceFactory
 from instance.tests.models.factories.server import OpenStackServerFactory
@@ -39,6 +40,13 @@ class LogEntryTestCase(TestCase):
     """
     Test cases for LoggerInstanceMixin
     """
+    def test_default_log_level(self):
+        """
+        Check that the default log level is INFO
+        """
+        log_entry = GeneralLogEntry(text='OHAI')
+        self.assertEqual(log_entry.level, 'INFO')
+
     def test_log_entries(self):
         """
         Check `log_entries` output for combination of instance & server logs


### PR DESCRIPTION
Lowercase 'info' is not a valid choice, and will trigger a ValidationError:

```
ValidationError: {'level': ["Value 'info' is not a valid choice."]}
```