### PR TITLE
Display error when provisioning instance for deleted branch

### DIFF
--- a/instance/github.py
+++ b/instance/github.py
@@ -51,10 +51,14 @@ GH_HEADERS = {
 def get_object_from_url(url):
     """
     Send the request to the provided URL, attaching custom headers, and returns
-    the deserialized object from the returned JSON
+    the deserialized object from the returned JSON.
+
+    Raises ObjectDoesNotExist if github returns a 404 response.
     """
     logger.info('GET URL %s', url)
     r = requests.get(url, headers=GH_HEADERS)
+    if r.status_code == 404:
+        raise ObjectDoesNotExist('404 response from {0}'.format(url))
     r.raise_for_status()
     return r.json()
 
@@ -214,3 +218,10 @@ class PR:
         Does this PR request ephemeral databases?
         """
         return is_pr_body_requesting_ephemeral_databases(self.body, domain)
+
+
+class ObjectDoesNotExist(Exception):
+    """
+    Exception raised when trying to access a github object that does not exist.
+    """
+    pass

--- a/instance/models/instance.py
+++ b/instance/models/instance.py
@@ -445,10 +445,15 @@ class GitHubInstanceMixin(VersionControlInstanceMixin):
         if ref_type is not None:
             self.ref_type = ref_type
         self.logger.info('Setting instance to tip of branch %s', self.branch_name)
-        new_commit_id = github.get_commit_id_from_ref(
-            self.fork_name,
-            self.branch_name,
-            ref_type=self.ref_type)
+        try:
+            new_commit_id = github.get_commit_id_from_ref(
+                self.fork_name,
+                self.branch_name,
+                ref_type=self.ref_type)
+        except github.ObjectDoesNotExist:
+            self.logger.error("Branch '%s' not found. Has it been deleted on GitHub?",
+                              self.branch_name)
+            raise
 
         if new_commit_id != self.commit_id:
             old_commit_short_id = self.commit_short_id

--- a/instance/static/html/instance/index.html
+++ b/instance/static/html/instance/index.html
@@ -17,6 +17,10 @@
     Loading...
 </div>
 
+<div class="notification label {{ notification.type }}" ng-if="notification">
+    {{ notification.message }}
+</div>
+
 <div class="row">
   <!-- Instances List -->
   <div class="large-3 columns">

--- a/instance/static/scss/instance.scss
+++ b/instance/static/scss/instance.scss
@@ -7,6 +7,13 @@
     padding: 5px 15px;
 }
 
+.notification {
+    position: fixed;
+    top: 48px;
+    right: 3px;
+    font-size: 14px;
+}
+
 .content.instance-app {
     .row {
         max-width: none;

--- a/instance/tests/js/instance_app_spec.js
+++ b/instance/tests/js/instance_app_spec.js
@@ -98,7 +98,20 @@ describe('Instance app', function () {
                 httpBackend.expectPOST('/api/v1/openedxinstance/2/provision/').respond('');
                 $scope.provision(instance);
                 httpBackend.flush();
+                expect($scope.notification.message).toEqual('Provisioning');
                 expect(instance.active_server_set[0].status).toEqual('terminating');
+            });
+
+            it('displays errors on 4xx response', function() {
+                var instance = $scope.instanceList[0],
+                    beforeStatus = instance.active_server_set[0].status;
+                httpBackend
+                    .expectPOST('/api/v1/openedxinstance/2/provision/')
+                    .respond(403, {status: 'FAIL'});
+                $scope.provision(instance);
+                httpBackend.flush();
+                expect($scope.notification.message).toEqual('FAIL');
+                expect(instance.active_server_set[0].status).toEqual(beforeStatus);
             });
         });
 


### PR DESCRIPTION
### Problem

If a PR's branch has been deleted from GitHub and the user clicks "Provision", the provisioning fails silently, without any relevant error appearing in the web console error log (also the status says "provisioning" even though it is not).

### Solution

- Return a client error response with a useful error message when the user attempts to provision an instance for a branch that does not exist
- Display that error message as a notification to the user