### PR TITLE
Clean temporary directories left from previous provisioning runs.

### DIFF
--- a/instance/ansible.py
+++ b/instance/ansible.py
@@ -23,11 +23,14 @@ Ansible - Helper functions
 # Imports #####################################################################
 
 import os
+import shutil
 import subprocess
+import sys
+import traceback
 import yaml
 
 from contextlib import contextmanager
-from tempfile import mkdtemp, mkstemp
+from tempfile import mkdtemp, NamedTemporaryFile
 
 from django.conf import settings
 
@@ -67,18 +70,77 @@ def dict_merge(dict1, dict2):
     return dict1
 
 
+def string_to_file_path(string, root_dir=None):
+    """
+    Store a string in a temporary file
+    """
+    f = NamedTemporaryFile('w', delete=False, dir=root_dir)
+    f.write(string)
+    f.close()
+    return f.name
+
+
+def on_remove_error(*args):
+    """
+    A helper function intended to be passed to shutil.rmtree as oneror argiment.
+
+    The only reason it is public is to unittest it.
+    """
+    exctype, value = sys.exc_info()[:2]
+    exception_message = '\n'.join(traceback.format_exception_only(exctype, value)).strip()
+    logger.warning(
+        "Error while deleting temporary directory, this is not related to VM "
+        "creation, but might fill /tmp directory of the IM.\n Exception "
+        "is %s", exception_message
+    )
+
+
 @contextmanager
-def string_to_file_path(string):
+def create_temp_dir():
     """
-    Store a string in a temporary file, to pass on to a third-party shell command as a file parameter
-    Returns the file path string
+    A context manager that creates a temporary directory, returns it. Directory is deleted upon context manager exit.
     """
-    fd, file_path = mkstemp(text=True)
-    fp = os.fdopen(fd, 'w')
-    fp.write(string)
-    fp.close()
-    yield file_path
-    os.remove(file_path)
+    temp_dir = None
+    try:
+        temp_dir = mkdtemp()
+        yield temp_dir
+    finally:
+        # If tempdir is None it means that if wasn't created, so we don't need to delete it
+        if temp_dir is not None:
+            # This is really a "best effort" solution, if something will
+            # block the deletion (like file being locked somehow)
+            # this should just move on rather than raise.
+            shutil.rmtree(temp_dir, onerror=on_remove_error)
+
+
+def render_sandbox_creation_command(
+        requirements_path, inventory_path, vars_path, playbook_name, remote_username, venv_path):
+    """
+    Renders the shell command used to create the sandbox
+    """
+
+    venv_python_path = os.path.join(venv_path, 'bin/python')
+    create_venv_cmd = 'virtualenv -p {python_path} {venv_path}'.format(
+        python_path=settings.ANSIBLE_PYTHON_PATH,
+        venv_path=venv_path,
+    )
+
+    install_requirements_cmd = '{python} -u {pip} install -r {requirements_path}'.format(
+        python=venv_python_path,
+        pip=os.path.join(venv_path, 'bin/pip'),
+        requirements_path=requirements_path,
+    )
+
+    run_playbook_cmd = '{python} -u {ansible} -i {inventory_path} -e @{vars_path} -u {user} {playbook}'.format(
+        python=venv_python_path,
+        ansible=os.path.join(venv_path, 'bin/ansible-playbook'),
+        inventory_path=inventory_path,
+        vars_path=vars_path,
+        user=remote_username,
+        playbook=playbook_name,
+    )
+
+    return ' && '.join([create_venv_cmd, install_requirements_cmd, run_playbook_cmd])
 
 
 @contextmanager
@@ -88,38 +150,35 @@ def run_playbook(requirements_path, inventory_str, vars_str, playbook_path, play
 
     Ansible only supports Python 2 - so we have to run it as a separate command, in its own venv
     """
-    venv_path = mkdtemp()
-    create_venv_cmd = 'virtualenv -p {python_path} {venv_path}'.format(
-        python_path=settings.ANSIBLE_PYTHON_PATH,
-        venv_path=venv_path,
-    )
 
-    venv_python_path = os.path.join(venv_path, 'bin/python')
-    install_requirements_cmd = '{python} -u {pip} install -r {requirements_path}'.format(
-        python=venv_python_path,
-        pip=os.path.join(venv_path, 'bin/pip'),
-        requirements_path=requirements_path,
-    )
+    with create_temp_dir() as ansible_tmp_dir:
 
-    with string_to_file_path(inventory_str) as inventory_path:
-        with string_to_file_path(vars_str) as vars_path:
-            run_playbook_cmd = '{python} -u {ansible} -i {inventory_path} -e @{vars_path} -u {user} {playbook}'\
-                .format(
-                    python=venv_python_path,
-                    ansible=os.path.join(venv_path, 'bin/ansible-playbook'),
-                    inventory_path=inventory_path,
-                    vars_path=vars_path,
-                    user=username,
-                    playbook=playbook_name,
-                )
+        vars_path = string_to_file_path(vars_str, root_dir=ansible_tmp_dir)
+        inventory_path = string_to_file_path(inventory_str, root_dir=ansible_tmp_dir)
+        venv_path = os.path.join(ansible_tmp_dir, 'venv')
 
-            cmd = ' && '.join([create_venv_cmd, install_requirements_cmd, run_playbook_cmd])
-            logger.info('Running: %s', cmd)
-            yield subprocess.Popen(
-                cmd,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-                bufsize=1, # Bufferize one line at a time
-                cwd=playbook_path,
-                shell=True,
-            )
+        cmd = render_sandbox_creation_command(
+            requirements_path=requirements_path,
+            inventory_path=inventory_path,
+            vars_path=vars_path,
+            playbook_name=playbook_name,
+            remote_username=username,
+            venv_path=venv_path
+        )
+
+        logger.info('Running: %s', cmd)
+
+        # Override TMPDIR environmental variable so any temp files created by ansible (and anything else)
+        # are created in a directory that we will safely delete after this command exits
+        env = dict(os.environ)
+        env['TMPDIR'] = ansible_tmp_dir
+
+        yield subprocess.Popen(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            bufsize=1, # Buffer one line at a time
+            cwd=playbook_path,
+            shell=True,
+            env=env,
+        )

--- a/instance/ansible.py
+++ b/instance/ansible.py
@@ -25,8 +25,6 @@ Ansible - Helper functions
 import os
 import shutil
 import subprocess
-import sys
-import traceback
 import yaml
 
 from contextlib import contextmanager
@@ -80,21 +78,6 @@ def string_to_file_path(string, root_dir=None):
     return f.name
 
 
-def on_remove_error(*args):
-    """
-    A helper function intended to be passed to shutil.rmtree as oneror argiment.
-
-    The only reason it is public is to unittest it.
-    """
-    exctype, value = sys.exc_info()[:2]
-    exception_message = '\n'.join(traceback.format_exception_only(exctype, value)).strip()
-    logger.warning(
-        "Error while deleting temporary directory, this is not related to VM "
-        "creation, but might fill /tmp directory of the IM.\n Exception "
-        "is %s", exception_message
-    )
-
-
 @contextmanager
 def create_temp_dir():
     """
@@ -107,10 +90,7 @@ def create_temp_dir():
     finally:
         # If tempdir is None it means that if wasn't created, so we don't need to delete it
         if temp_dir is not None:
-            # This is really a "best effort" solution, if something will
-            # block the deletion (like file being locked somehow)
-            # this should just move on rather than raise.
-            shutil.rmtree(temp_dir, onerror=on_remove_error)
+            shutil.rmtree(temp_dir)
 
 
 def render_sandbox_creation_command(


### PR DESCRIPTION
# Reproduce steps

1. Install IM and setup environment settings
2. Go to `/localhost/admin` and create an instance. 
3. Wait until provisioning is started
4. Log in to shell account to you vagrant instance ``vagrant ssh`` and go to ``/tmp`` dir. Note that quite a lot of folders was created. 
5. Run ``ps -aef | grep python``, and kill the ansible process (killing step is not-neccessary, as venv's are not deleted at all, but it makes it faster)
6. Due to the fact provisioning is restarted you might need to kill it three times. 
7. Note that some of the folders in ``/tmp`` are not deleted. There should be as many folders left as many propositioning runs you started, these folders contain virtualenvs created during provisioning runs. 
8. (For bonus points) If you kill ansible in a "proper" moment it will left a tmp file with a role contents.

# Verification steps

1. Repeat the procedure and note that virtualenves are removes
2. (For bonus points) Note that ansible role files are not being left over. 
3. (For bonus points) Check also that it works for full provisionings (that is if you provision succesfully the sandbox all temporary files/folders are deleted). 
4. Start provisioning, note which tmp directory contains virtualenv, remove ``u-rwx`` permissions from this directory, and kill ansible process. Note that errors about impossibility of cleaning up are logged (to the GeneralLog in /admin)