### PR TITLE
Logrotate - Set logging to use `RotatingFileHandler`

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,8 @@ flavor:
 * `REDIS_URL` (default: `redis://localhost:6379/`)
 * `HUEY_ALWAYS_EAGER` Set to True to run huey tasks synchronously, in the web
   process. Use in development only (default: False)
+* `LOGGING_ROTATE_MAX_KBYTES`: The max size of each log file (in KB, default: 10MB)
+* `LOGGING_ROTATE_MAX_FILES`: The max number of log files to keep (default: 60)
 
 ### OpenStack credentials
 

--- a/opencraft/settings.py
+++ b/opencraft/settings.py
@@ -305,6 +305,8 @@ ADMINS = env.json('ADMINS', default=set())
 
 BASE_HANDLERS = env.json('BASE_HANDLERS', default=["file", "console"])
 HANDLERS = BASE_HANDLERS + ['db']
+LOGGING_ROTATE_MAX_KBYTES = env.json('LOGGING_ROTATE_MAX_KBYTES', default=10 * 1024)
+LOGGING_ROTATE_MAX_FILES = env.json('LOGGING_ROTATE_MAX_FILES', default=60)
 LOGGING = {
     'version': 1,
     'disable_existing_loggers': False,
@@ -359,8 +361,10 @@ LOGGING = {
 if 'file' in HANDLERS:
     LOGGING['handlers']['file'] = {
         'level': 'DEBUG',
-        'class': 'logging.FileHandler',
+        'class': 'logging.handlers.RotatingFileHandler',
         'filename': 'log/main.log',
+        'maxBytes': LOGGING_ROTATE_MAX_KBYTES * 1024,
+        'backupCount': LOGGING_ROTATE_MAX_FILES,
         'formatter': 'verbose'
     }
 


### PR DESCRIPTION
Switch the logging file handler in the Django configuration to `RotatingFileHandler`, to avoid letting log files grow too large. 

Two new configuration variables:

* `LOGGING_ROTATE_MAX_KBYTES`: The max size of each log file (in KB)
* `LOGGING_ROTATE_MAX_FILES`: The max number of log files to keep

How to test:

1. Set `LOGGING_ROTATE_MAX_KBYTES=1` in your local OpenCraft IM `.env` file - this is to trigger log rotation without needing to generate huge logs
2. Generate some logs, for example by provisioning a new instance
3. Check `log/main.*` - you should see lots of small log files, a few KB each (it seem to still log a full message even if it exceeds slightly the max size, which is a desired behavior).

Note: No unit test since this is only a configuration change, but if you see a meaningful way to test this I'm happy to add it.