### PR TITLE
State machine (OC-906)

### DIFF
--- a/.prospector/opencraft.yml
+++ b/.prospector/opencraft.yml
@@ -31,7 +31,7 @@ profile-validator:
   options: {}
   run: null
 pyflakes:
-  disable: [F401, F403]
+  disable: [F401, F403, F841]
   enable: []
   options: {}
   run: null

--- a/.prospector/opencraft.yml
+++ b/.prospector/opencraft.yml
@@ -31,7 +31,10 @@ profile-validator:
   options: {}
   run: null
 pyflakes:
-  disable: [F401, F403, F841]
+  disable:
+    - F401
+    - F403
+    - F841  # "local variable is assigned to but never used" - pylint has an equivalent check, and the pylint version correctly ignores names like 'dummy'
   enable: []
   options: {}
   run: null

--- a/instance/api/instance.py
+++ b/instance/api/instance.py
@@ -29,6 +29,7 @@ from rest_framework.response import Response
 
 from instance import github
 from instance.models.instance import OpenEdXInstance
+from instance.models.server import Server
 from instance.serializers.instance import (OpenEdXInstanceListSerializer,
                                            OpenEdXInstanceDetailSerializer)
 from instance.tasks import provision_instance
@@ -48,7 +49,7 @@ class OpenEdXInstanceViewSet(viewsets.ModelViewSet):
         Start the (re-)provisioning of an instance
         """
         instance = self.get_object()
-        if instance.progress == instance.PROGRESS_RUNNING:
+        if instance.progress == Server.Progress.Running:
             return Response({'status': 'Instance is not ready for reprovisioning'},
                             status=status.HTTP_400_BAD_REQUEST)
 

--- a/instance/models/instance.py
+++ b/instance/models/instance.py
@@ -41,7 +41,7 @@ from instance.models.mixins.ansible import AnsibleInstanceMixin
 from instance.models.mixins.database import MySQLInstanceMixin, MongoDBInstanceMixin
 from instance.models.mixins.utilities import EmailInstanceMixin
 from instance.models.mixins.version_control import GitHubInstanceMixin
-from instance.models.utils import ValidateModelMixin, ResourceState
+from instance.models.utils import ValidateModelMixin
 
 # Constants ###################################################################
 

--- a/instance/models/instance.py
+++ b/instance/models/instance.py
@@ -41,7 +41,7 @@ from instance.models.mixins.ansible import AnsibleInstanceMixin
 from instance.models.mixins.database import MySQLInstanceMixin, MongoDBInstanceMixin
 from instance.models.mixins.utilities import EmailInstanceMixin
 from instance.models.mixins.version_control import GitHubInstanceMixin
-from instance.models.utils import ValidateModelMixin
+from instance.models.utils import ValidateModelMixin, ResourceState
 
 # Constants ###################################################################
 
@@ -73,24 +73,6 @@ class Instance(ValidateModelMixin, TimeStampedModel):
     """
     Instance - Group of servers running an application made of multiple services
     """
-    # See `instance.models.server.Server` for a definition of the states
-    EMPTY = 'empty'
-    NEW = 'new'
-    STARTED = 'started'
-    ACTIVE = 'active'
-    BOOTED = 'booted'
-    PROVISIONING = 'provisioning'
-    REBOOTING = 'rebooting'
-    READY = 'ready'
-    LIVE = 'live'
-    STOPPING = 'stopping'
-    STOPPED = 'stopped'
-    TERMINATING = 'terminating'
-
-    PROGRESS_RUNNING = 'running'
-    PROGRESS_SUCCESS = 'success'
-    PROGRESS_FAILED = 'failed'
-
     sub_domain = models.CharField(max_length=50)
     email = models.EmailField(default='contact@example.com')
     name = models.CharField(max_length=250)
@@ -155,7 +137,7 @@ class Instance(ValidateModelMixin, TimeStampedModel):
         server = self._current_server
         if server:
             return server.status
-        return self.EMPTY
+        return None
 
     @property
     def progress(self):
@@ -165,7 +147,7 @@ class Instance(ValidateModelMixin, TimeStampedModel):
         server = self._current_server
         if server:
             return server.progress
-        return self.EMPTY
+        return None
 
     @property
     def event_context(self):
@@ -447,8 +429,7 @@ class OpenEdXInstance(MySQLInstanceMixin, MongoDBInstanceMixin, AnsibleInstanceM
         try:
             # DNS
             self.logger.info('Waiting for IP assignment on server %s...', server)
-            server.sleep_until_status([server.ACTIVE, server.BOOTED])
-            server.update_status(provisioning=True)
+            server.sleep_until_status(server.Status.Active, server.Status.Booted)
             self.logger.info('Updating DNS: LMS at %s...', self.domain)
             gandi.set_dns_record(type='A', name=self.sub_domain, value=server.public_ip)
             self.logger.info('Updating DNS: Studio at %s...', self.studio_domain)
@@ -461,19 +442,21 @@ class OpenEdXInstance(MySQLInstanceMixin, MongoDBInstanceMixin, AnsibleInstanceM
                 self.provision_mongo()
 
             # Provisioning (ansible)
+            server.sleep_until_status(server.Status.Booted)
+            server.mark_as_provisioning()
             self.reset_ansible_settings(commit=True)
             log, exit_code = self.deploy()
             if exit_code != 0:
-                server.update_status(provisioning=True, failed=True)
+                server.mark_provisioning_finished(success=False)
                 self.provision_failed_email(self.ProvisionMessages.PROVISION_ERROR, log)
                 return (server, log)
 
-            server.update_status(provisioning=True, failed=False)
+            server.mark_provisioning_finished(success=True)
 
             # Reboot
             self.logger.info('Rebooting server %s...', server)
             server.reboot()
-            server.sleep_until_status(server.READY)
+            server.sleep_until_status(server.Status.Ready)
             self.logger.info('Provisioning completed')
 
             return (server, log)

--- a/instance/models/mixins/ansible.py
+++ b/instance/models/mixins/ansible.py
@@ -76,8 +76,8 @@ class AnsibleInstanceMixin(models.Model):
         """
         inventory = ['[app]']
         server_model = self.server_set.model
-        for server in self.server_set.filter(status=server_model.PROVISIONING,
-                                             progress=server_model.PROGRESS_RUNNING)\
+        for server in self.server_set.filter(_status=server_model.Status.Provisioning.state_id,
+                                             _progress=server_model.Progress.Running.state_id)\
                                      .order_by('created'):
             inventory.append(server.public_ip)
         inventory_str = '\n'.join(inventory)

--- a/instance/models/server.py
+++ b/instance/models/server.py
@@ -122,8 +122,8 @@ class Progress(ResourceState.Enum):
         is_final = True
 
 
-
 # Models ######################################################################
+
 
 class ServerQuerySet(models.QuerySet):
     """

--- a/instance/models/server.py
+++ b/instance/models/server.py
@@ -39,7 +39,7 @@ from instance.logger_adapter import ServerLoggerAdapter
 from instance.utils import is_port_open, to_json
 
 from instance.models.instance import OpenEdXInstance
-from instance.models.utils import ValidateModelMixin, ResourceState, ResourceStateDescriptor
+from instance.models.utils import ValidateModelMixin, ResourceState, ModelResourceStateDescriptor
 
 
 # Logging #####################################################################
@@ -151,7 +151,9 @@ class Server(ValidateModelMixin, TimeStampedModel):
     A single server VM
     """
     Status = Status
-    status = ResourceStateDescriptor(state_classes=Status.states, default_state=Status.New, model_field_name='_status')
+    status = ModelResourceStateDescriptor(
+        state_classes=Status.states, default_state=Status.New, model_field_name='_status'
+    )
     _status = models.CharField(
         max_length=20,
         default=status.default_state_class.state_id,
@@ -173,7 +175,7 @@ class Server(ValidateModelMixin, TimeStampedModel):
     _status_to_terminated = status.transition(to_state=Status.Terminated)
 
     Progress = Progress
-    progress = ResourceStateDescriptor(
+    progress = ModelResourceStateDescriptor(
         state_classes=Progress.states,
         default_state=Progress.Running,
         model_field_name='_progress',

--- a/instance/models/server.py
+++ b/instance/models/server.py
@@ -39,7 +39,7 @@ from instance.logger_adapter import ServerLoggerAdapter
 from instance.utils import is_port_open, to_json
 
 from instance.models.instance import OpenEdXInstance
-from instance.models.utils import ValidateModelMixin
+from instance.models.utils import ValidateModelMixin, ResourceState, ResourceStateDescriptor
 
 
 # Logging #####################################################################
@@ -47,13 +47,80 @@ from instance.models.utils import ValidateModelMixin
 logger = logging.getLogger(__name__)
 
 
-# Exceptions ##################################################################
+# States ######################################################################
 
-class ServerNotReady(Exception):
+
+class ServerState(ResourceState):
     """
-    Raised when an action is attempted in a status that doesn't allow it
+    A [finite state machine] state describing a virtual machine.
     """
-    pass
+
+
+class Status(ResourceState.Enum):
+    """
+    The states that a server can be in.
+
+    TODO:
+    * Reduce these to Unknown, Pending, Building, Booting, Ready, BuildFailed, and Terminated.
+    """
+    class New(ServerState):
+        """ Not yet loaded """
+        state_id = 'new'
+
+    class Started(ServerState):
+        """ Running but not active yet """
+        state_id = 'started'
+
+    class Active(ServerState):
+        """ Running but not booted yet """
+        state_id = 'active'
+
+    class Booted(ServerState):
+        """ Booted but not ready to be added to the application """
+        state_id = 'booted'
+
+    class Provisioning(ServerState):
+        """ Provisioning is in progress """
+        state_id = 'provisioning'
+
+    class Rebooting(ServerState):
+        """ Reboot in progress, to apply changes from provisioning """
+        state_id = 'rebooting'
+
+    class Ready(ServerState):
+        """ Booted and ready to add to the application """
+        state_id = 'ready'
+
+    #class Stopped(ServerState):
+    #    """ Stopped temporarily """
+    #    state_id = 'stopped'
+
+    class Terminated(ServerState):
+        """ Stopped forever """
+        state_id = 'terminated'
+
+
+class Progress(ResourceState.Enum):
+    """
+    The progress states that a server can be in.
+
+    TODO: Refactor and perhaps remove this second state.
+    """
+    class Running(ResourceState):
+        """ Running """
+        state_id = 'running'
+        is_final = False
+
+    class Success(ResourceState):
+        """ Success """
+        state_id = 'success'
+        is_final = True
+
+    class Failed(ResourceState):
+        """ Failed """
+        state_id = 'failed'
+        is_final = True
+
 
 
 # Models ######################################################################
@@ -67,7 +134,7 @@ class ServerQuerySet(models.QuerySet):
         """
         Terminate the servers from the queryset
         """
-        qs = self.filter(~Q(status=Server.TERMINATED), *args, **kwargs)
+        qs = self.filter(~Q(_status=Status.Terminated.state_id), *args, **kwargs)
         for server in qs:
             server.terminate()
         return qs
@@ -76,54 +143,52 @@ class ServerQuerySet(models.QuerySet):
         """
         Filter out terminated servers from the queryset
         """
-        return self.filter(~Q(status=Server.TERMINATED))
+        return self.filter(~Q(_status=Status.Terminated.state_id))
 
 
 class Server(ValidateModelMixin, TimeStampedModel):
     """
     A single server VM
     """
-    NEW = 'new'
-    STARTED = 'started'
-    ACTIVE = 'active'
-    BOOTED = 'booted'
-    PROVISIONING = 'provisioning'
-    REBOOTING = 'rebooting'
-    READY = 'ready'
-    LIVE = 'live'
-    STOPPING = 'stopping'
-    STOPPED = 'stopped'
-    TERMINATING = 'terminating'
-    TERMINATED = 'terminated'
-
-    STATUS_CHOICES = (
-        (NEW, 'New - Not yet loaded'),
-        (STARTED, 'Started - Running but not active yet'),
-        (ACTIVE, 'Active - Running but not booted yet'),
-        (BOOTED, 'Booted - Booted but not ready to be added to the application'),
-        (PROVISIONING, 'Provisioning - Provisioning is in progress'),
-        (REBOOTING, 'Rebooting - Reboot in progress, to apply changes from provisioning'),
-        (READY, 'Ready - Rebooted and ready to add to the application'),
-        (LIVE, 'Live - Is actively used in the application and/or accessed by users'),
-        (STOPPING, 'Stopping - Stopping temporarily'),
-        (STOPPED, 'Stopped - Stopped temporarily'),
-        (TERMINATING, 'Terminating - Stopping forever'),
-        (TERMINATED, 'Terminated - Stopped forever'),
+    Status = Status
+    status = ResourceStateDescriptor(state_classes=Status.states, default_state=Status.New, model_field_name='_status')
+    _status = models.CharField(
+        max_length=20,
+        default=status.default_state_class.state_id,
+        choices=status.model_field_choices,
+        db_index=True,
+        db_column='status',
     )
-
-    PROGRESS_RUNNING = 'running'
-    PROGRESS_SUCCESS = 'success'
-    PROGRESS_FAILED = 'failed'
-
-    PROGRESS_CHOICES = (
-        (PROGRESS_RUNNING, 'Running'),
-        (PROGRESS_SUCCESS, 'Success'),
-        (PROGRESS_FAILED, 'Failed'),
+    # State transitions:
+    _status_to_started = status.transition(from_states=Status.New, to_state=Status.Started)
+    _status_to_active = status.transition(from_states=Status.Started, to_state=Status.Active)
+    _status_to_booted = status.transition(from_states=Status.Active, to_state=Status.Booted)
+    _status_to_provisioning = status.transition(from_states=Status.Booted, to_state=Status.Provisioning)
+    _status_to_rebooting = status.transition(
+        from_states=(Status.Active, Status.Booted, Status.Ready, Status.Provisioning), to_state=Status.Rebooting
     )
+    _status_to_ready = status.transition(
+        from_states=(Status.Active, Status.Booted, Status.Provisioning, Status.Rebooting), to_state=Status.Ready
+    )
+    _status_to_terminated = status.transition(to_state=Status.Terminated)
+
+    Progress = Progress
+    progress = ResourceStateDescriptor(
+        state_classes=Progress.states,
+        default_state=Progress.Running,
+        model_field_name='_progress',
+    )
+    _progress = models.CharField(
+        max_length=7,
+        default=progress.default_state_class.state_id,
+        choices=progress.model_field_choices,
+        db_column='progress',
+    )
+    _progress_success = progress.transition(from_states=(Progress.Running, Progress.Success), to_state=Progress.Success)
+    _progress_failed = progress.transition(from_states=Progress.Running, to_state=Progress.Failed)
+    _progress_reset = progress.transition(to_state=Progress.Running)
 
     instance = models.ForeignKey(OpenEdXInstance, related_name='server_set')
-    status = models.CharField(max_length=20, default=NEW, choices=STATUS_CHOICES, db_index=True)
-    progress = models.CharField(max_length=7, default=PROGRESS_RUNNING, choices=PROGRESS_CHOICES)
 
     objects = ServerQuerySet().as_manager()
 
@@ -147,29 +212,43 @@ class Server(ValidateModelMixin, TimeStampedModel):
             'server_id': self.pk,
         }
 
-    def _set_status(self, status, progress):
+    def _transition(self, state_transition, progress=Progress.Running):
         """
-        Update the current status variable, to be called when a status change is detected
-        """
-        if status not in (s[0] for s in self.STATUS_CHOICES):
-            raise ValueError(status)
+        Helper method to update the state and the progress.
 
-        self.status = status
-        self.progress = progress
+        Mostly exists to ensure the 'progress' is in sync with 'state' and the django DB.
+        """
+        state_transition()
+        self._set_progress(progress, expected_status=state_transition.to_state)
+
+    def _set_progress(self, progress, expected_status=None):
+        """
+        Helper method to update the progress.
+
+        Mostly exists to ensure the 'progress' is in sync with the django DB.
+        """
+        if expected_status:
+            assert isinstance(self.status, expected_status)
+        if progress is Progress.Running:
+            self._progress_reset()
+        elif progress is Progress.Success:
+            self._progress_success()
+        else:
+            assert progress is Progress.Failed
+            self._progress_failed()
         self.logger.info('Changed status: %s (%s)', self.status, self.progress)
+        # The '_progress' field needs to be saved:
         self.save()
-        return self.status
 
-    def sleep_until_status(self, target_status):
+    def sleep_until_status(self, *target_status_list):
         """
-        Sleep in a loop until the server reaches one of the specified status
+        Sleep in a loop until the server reaches one of the specified statuses
         """
-        target_status_list = [target_status] if isinstance(target_status, str) else target_status
         self.logger.info('Waiting to reach status %s...', target_status_list)
 
         while True:
             self.update_status()
-            if self.status in target_status and self.progress != self.PROGRESS_RUNNING:
+            if self.progress.is_final and isinstance(self.status, target_status_list):
                 break
             time.sleep(1)
         return self.status
@@ -185,7 +264,7 @@ class Server(ValidateModelMixin, TimeStampedModel):
             'server_pk': self.pk,
         })
 
-    def update_status(self, provisioning=False, rebooting=False, failed=None):
+    def update_status(self):
         """
         Check the current status and update it if it has changed
         """
@@ -214,7 +293,7 @@ class OpenStackServer(Server):
         OpenStack nova server API endpoint
         """
         if not self.openstack_id:
-            assert self.status == self.NEW
+            assert self.status == Status.New
             self.start()
         return self.nova.servers.get(self.openstack_id)
 
@@ -232,7 +311,7 @@ class OpenStackServer(Server):
 
         return public_addr['addr']
 
-    def update_status(self, provisioning=False, rebooting=False, failed=None):
+    def update_status(self):
         """
         Refresh the status by querying the openstack server via nova
         """
@@ -240,36 +319,43 @@ class OpenStackServer(Server):
         os_server = self.os_server
         self.logger.debug('Updating status from nova (currently %s):\n%s', self.status, to_json(os_server))
 
-        if self.status == self.STARTED:
+        if self.status == Status.Started:
             self.logger.debug('OpenStack: loaded="%s" status="%s"', os_server._loaded, os_server.status)
             if os_server._loaded and os_server.status == 'ACTIVE':
-                self._set_status(self.ACTIVE, self.PROGRESS_SUCCESS)
+                self._transition(self._status_to_active, Progress.Success)
             else:
-                self._set_status(self.ACTIVE, self.PROGRESS_RUNNING)
+                self._transition(self._status_to_active, Progress.Running)
 
-        elif self.status == self.ACTIVE and self.public_ip and is_port_open(self.public_ip, 22):
-            self._set_status(self.BOOTED, self.PROGRESS_RUNNING)
+        elif self.status == Status.Active and self.public_ip and is_port_open(self.public_ip, 22):
+            self._transition(self._status_to_booted, Progress.Success)
 
-        elif self.status == self.BOOTED:
-            if provisioning:
-                self._set_status(self.PROVISIONING, self.PROGRESS_RUNNING)
-            else:
-                self._set_status(self.BOOTED, self.PROGRESS_SUCCESS)
-
-        elif self.status == self.PROVISIONING and failed is not None:
-            if failed:
-                self._set_status(self.PROVISIONING, self.PROGRESS_FAILED)
-            else:
-                self._set_status(self.PROVISIONING, self.PROGRESS_SUCCESS)
-
-        elif self.status in (self.PROVISIONING, self.READY) and rebooting:
-            self._set_status(self.REBOOTING, self.PROGRESS_RUNNING)
-
-        elif self.status == self.REBOOTING and not rebooting and is_port_open(self.public_ip, 22):
-            self._set_status(self.READY, self.PROGRESS_SUCCESS)
+        elif self.status == Status.Rebooting and is_port_open(self.public_ip, 22):
+            self._transition(self._status_to_ready, Progress.Success)
 
         return self.status
 
+    @Server.status.only_for(Status.Booted)
+    def mark_as_provisioning(self):
+        """
+        Indicate that this server is being provisioned.
+
+        TODO: Remove this. A 'server' resource shouldn't know or care is ansible is running or not.
+        """
+        self._transition(self._status_to_provisioning, Progress.Running)
+
+    @Server.status.only_for(Status.Provisioning)
+    def mark_provisioning_finished(self, success):
+        """
+        Indicate that this server is done provisioning, either due to success or failure.
+        """
+        if success:
+            # Status does not switch to Ready at this point because the instance reboots the
+            # server before declaring it ready.
+            self._set_progress(Progress.Success, expected_status=Status.Provisioning)
+        else:
+            self._set_progress(Progress.Failed, expected_status=Status.Provisioning)
+
+    @Server.status.only_for(Status.New)
     def start(self):
         """
         Get a server instance started and an openstack_id assigned
@@ -278,31 +364,30 @@ class OpenStackServer(Server):
         TODO: Create the key dynamically
         """
         self.logger.info('Starting server (status=%s)...', self.status)
-        if self.status == self.NEW:
-            self._set_status(self.STARTED, self.PROGRESS_RUNNING)
-            os_server = openstack.create_server(
-                self.nova,
-                self.instance.sub_domain,
-                settings.OPENSTACK_SANDBOX_FLAVOR,
-                settings.OPENSTACK_SANDBOX_BASE_IMAGE,
-                key_name=settings.OPENSTACK_SANDBOX_SSH_KEYNAME,
-            )
-            self.openstack_id = os_server.id
-            self.logger.info('Server got assigned OpenStack id %s', self.openstack_id)
-            self._set_status(self.STARTED, self.PROGRESS_SUCCESS)
-        else:
-            raise NotImplementedError
+        self._transition(self._status_to_started)
+        os_server = openstack.create_server(
+            self.nova,
+            self.instance.sub_domain,
+            settings.OPENSTACK_SANDBOX_FLAVOR,
+            settings.OPENSTACK_SANDBOX_BASE_IMAGE,
+            key_name=settings.OPENSTACK_SANDBOX_SSH_KEYNAME,
+        )
+        self.openstack_id = os_server.id
+        self.logger.info('Server got assigned OpenStack id %s', self.openstack_id)
+        self._set_progress(Progress.Success, expected_status=Status.Started)
 
+    @Server.status.only_for(Status.Provisioning, Status.Ready, Status.Rebooting)
     def reboot(self, reboot_type='SOFT'):
         """
         Reboot the server
 
         This requires to switch the status to 'rebooting', which is first attempted via the
         `update_status` method. If the current state doesn't allow to switch to this status,
-        a ServerNotReady exception is thrown.
+        a WrongStateException exception is thrown.
         """
-        if self.update_status(rebooting=True) != self.REBOOTING:
-            raise ServerNotReady("Can't change status to 'rebooting' (current: '{}')".format(self.status))
+        if self.status == Status.Rebooting:
+            return
+        self._transition(self._status_to_rebooting, Progress.Running)
         self.os_server.reboot(reboot_type=reboot_type)
 
         # TODO: Find a better way to wait for the server shutdown and reboot
@@ -315,18 +400,18 @@ class OpenStackServer(Server):
         Terminate the server
         """
         self.logger.info('Terminating server (status=%s)...', self.status)
-        if self.status == self.TERMINATED:
+        if self.status == Status.Terminated:
             return
-        elif self.status == self.NEW:
-            self._set_status(self.TERMINATED, self.PROGRESS_SUCCESS)
+        elif self.status == Status.New:
+            self._transition(self._status_to_terminated, Progress.Success)
             return
 
-        self._set_status(self.TERMINATED, self.PROGRESS_RUNNING)
+        self._transition(self._status_to_terminated)
         try:
             self.os_server.delete()
         except novaclient.exceptions.NotFound:
             self.logger.error('Error while attempting to terminate server: could not find OS server')
         finally:
-            self._set_status(self.TERMINATED, self.PROGRESS_SUCCESS)
+            self._set_progress(Progress.Success, expected_status=Status.Terminated)
 
 post_save.connect(OpenStackServer.on_post_save, sender=OpenStackServer)

--- a/instance/models/server.py
+++ b/instance/models/server.py
@@ -248,7 +248,7 @@ class Server(ValidateModelMixin, TimeStampedModel):
 
         while True:
             self.update_status()
-            if self.progress.is_final and isinstance(self.status, target_status_list):
+            if self.progress.is_final and self.status.one_of(*target_status_list):
                 break
             time.sleep(1)
         return self.status

--- a/instance/models/utils.py
+++ b/instance/models/utils.py
@@ -19,6 +19,16 @@
 """
 Models Utils
 """
+from weakref import WeakKeyDictionary
+
+# Exceptions ##################################################################
+
+class WrongStateException(RuntimeError):
+    """
+    Raised when a method/action is attempted but the object's current state
+    does not support that method.
+    """
+    pass
 
 
 # Classes #####################################################################
@@ -44,3 +54,259 @@ class ValidateModelMixin(object):
         """Call :meth:`full_clean` before saving."""
         self.full_clean()
         super(ValidateModelMixin, self).save(*args, **kwargs)
+
+
+class ClassProperty(property):
+    """ Same as built-in 'property' global but also works when accessed as a class attribute """
+    def __get__(self, cls, owner):
+        return self.fget.__get__(None, owner)()
+
+
+class ResourceState:
+    """
+    A [finite state machine] state class representing the overall state of a resource,
+    such as a server, a database, a DNS entry, etc.
+    """
+    # state_id: A string uniquely identifying this state
+    state_id = None
+
+    @ClassProperty
+    @classmethod
+    def name(cls):
+        """
+        name: Human-readable name of this state, suitable for display as "Status: _______"
+
+        Doesn't need to be a property; override in the subclass using just 'name = "Name"'
+        """
+        return cls.__name__
+
+    @ClassProperty
+    @classmethod
+    def description(cls):
+        """
+        description: Human-readable explanation of this state (1-2 sentences)
+
+        Defaults to the state class's docstring, but you can override it.
+        Doesn't need to be a property; override in the subclass using just 'description = "..."'
+        """
+        return cls.__doc__.strip()
+
+    # healthy: True if this is a good state (online, ready, loading, provisioning, etc.)
+    #          True is this is a state that may or may not be good (shut down, offline, etc.)
+    #          False if this state is definitely bad (something failed etc.)
+    # This is not a dynamic property of the state; any state is healthy or not by definition..
+    healthy = True
+
+    # Constants:
+    PROGRESS_UNKNOWN = -1
+
+    def __str__(self):
+        return "{} [{}]".format(self.name, self.state_id)
+
+    def __eq__(self, obj):
+        """
+        Syntactic sugar to make comparing states easier.
+
+        obj should be a ResourceState class or instance.
+        """
+        try:
+            return issubclass(self.__class__, obj)
+        except TypeError:  # The provided argument is not a class
+            return type(obj) is type(self)
+
+    @classmethod
+    def one_of(cls, *state_classes):
+        """ Syntactic sugar to make comparing an instance to a set of types easier """
+        return issubclass(cls, state_classes)
+
+    def __init__(self, resource, state_manager):
+        """ Instantiate this state, saving a reference to the parent resource """
+        self._resource = resource
+        self._state_manager = state_manager
+
+    @property
+    def has_progress(self):
+        """ Should the UI show a progress bar for this resource due to its current state? """
+        return self.progress is not None
+
+    @property
+    def progress(self):
+        """
+        If the state represents some action in progress, get the progress value.
+        Returns:
+            - A number between 0 and 1 if an action is in progress
+            - None if no action is in progress
+            - PROGRESS_UNKNOWN if something is in progress but the progress is unknown
+        """
+        return None
+
+    class Enum:
+        """
+        Syntacic sugar for declaring a group of ResourceState classes inside a class.
+
+        Use like:
+
+        class MyStates(ResourceState.Enum):
+            class State1(ResourceState):
+                state_id = '1'
+            class State2(ResourceState):
+                state_id = '2'
+
+        or if states are already declared, use like:
+        class MyStates(ResourceState.Enum):
+            State1, State2 = State1, State2
+
+        Then you can use MyStates.states to get a list of the state classes.
+        """
+        @ClassProperty
+        @classmethod
+        def states(cls):
+            return tuple(state for name, state in cls.__dict__.items() if name[:1] != '_' and name != 'states')
+
+
+class ResourceStateDescriptor:
+    """
+    Descriptor which implements a finite state machine.
+
+    Assign an instance of this to a class attribute such as 'state'. This will create a 'state'
+    property that always returns an instance of one of the allowed state_classes.
+    The 'state' property cannot be assigned to; only the current state instance is allowed to
+    change the state. This makes it easy to reason about the behavior of the state.
+    """
+    def __init__(self, state_classes, default_state, model_field_name=None):
+        """
+        Instantiate a ResourceStateDescriptor to manage a state machine.
+
+        state_classes: A list of class types that are valid states for this state machine.
+        default_state: If no state has been set, assume the state is this state class.
+        model_field_name: The name of a django CharField to keep updated with the name of the
+            current state, or None. (caching the state in a field is optional)
+        """
+        self.state_classes = state_classes
+        assert len(set(state_class.state_id for state_class in state_classes)) == len(state_classes), \
+            "A resource's states must each have a unique state_id"
+        assert default_state in state_classes
+        self.default_state_class = default_state
+        self.model_field_name = model_field_name
+        self.cache = WeakKeyDictionary()  # This holds the current state instance for each resource
+
+    # Public API (implements the python descriptor interface)
+
+    def __get__(self, resource, _type=None):
+        """ Get the current state """
+        if resource is None:
+            return self  # when accessed via the class, return this descriptor itself.
+        try:
+            state = self.cache[resource]
+        except KeyError:
+            # 'resource' refers to a brand new object, whose state property hasn't been accessed
+            # yet. Load the state from the django field, or use the default state.
+            state = self._set_state(resource, self._get_initial_state(resource))
+        assert isinstance(state, self.state_classes)
+        if self.model_field_name:
+            assert getattr(resource, self.model_field_name) == state.state_id, \
+                "The reource's {} field has been tampered with".format(self.model_field_name)
+        return state
+
+    def __set__(self, resource, value):
+        raise AttributeError("You cannot assign to a state machine attribute to change the state.")
+
+    def only_for(self, *accepted_states):
+        """
+        Decorator that can annotate a method and will raise an error if the method is called
+        when the state machine is not in one of the specified states (accepted_states).
+
+        If applied to a method, that method will get a new '.is_available()' attribute that can
+        be used to determine if the method can be called or not (is in an appropriate state or
+        not).
+
+        If applied to a property, it works similarly to a method, but the '.is_available()'
+        feature is not present.
+        """
+        for state in accepted_states:
+            assert state in self.state_classes
+
+        def wrap(method):
+            def require_valid_state(resource):
+                state = self.__get__(resource)
+                if not isinstance(state, accepted_states):
+                    raise WrongStateException("The method '{}' cannot be called in this state ({} / {}).".format(
+                        method.__name__, state.name, state.__class__.__name__
+                    ))
+
+            class MagicWrapper:
+                """ Class which can wrap a method; the result can be used as a property or as a method. """
+                def __call__(_magic_wrapper_instance, resource):
+                    """ We are wrapping a property, not a method. No fancy stuff needed. """
+                    require_valid_state(resource)
+                    return method(resource)
+
+                def __get__(_magic_wrapper_instance, resource, _type):
+                    """ Get the (wrapped) method, and add a .is_available method to it """
+                    def wrapped_method(*args, **kwargs):
+                        require_valid_state(resource)
+                        return method(resource, *args, **kwargs)
+                    wrapped_method.is_available = lambda: isinstance(self.__get__(resource), accepted_states)
+                    return wrapped_method
+            return MagicWrapper()
+        return wrap
+
+    def transition(self, to_state, from_states=None):
+        """
+        Returns a "transition" method, which can be called to change the current state from
+        state(s) 'from' to 'to'.
+
+        from_states can be a state class, a tuple of classes, a parent class or mixin of various
+        state classes, a tuple of mixins, etc.. if None, any valid state will be accepted.
+        """
+        assert to_state in self.state_classes
+
+        def do_transition(resource):
+            current_state = self.__get__(resource)
+            if from_states and not isinstance(current_state, from_states):
+                raise WrongStateException("This transition cannot be used to move from {} to {}".format(
+                    current_state.__class__.__name__, to_state.__name__
+                ))
+            state_instance = self._instantiate_state(resource, to_state)
+            self._set_state(resource, state_instance)
+        do_transition.from_states = from_states  # Convenient way for other code to inspect this transition
+        do_transition.to_state = to_state  # Convenient way for other code to inspect this transition
+        return do_transition
+
+    @property
+    def model_field_choices(self):
+        """
+        Get a tuple of (state_id, name) pairs.
+
+        Suitable for passing to a django CharField choices parameter.
+        """
+        return tuple((state.state_id, state.__class__.__name__) for state in self.state_classes)
+
+    # Internal helper methods:
+
+    def _get_initial_state(self, resource):
+        assert resource not in self.cache, "_get_initial_state is only for determining the initial state."
+        # If the current state was saved into the database in a django field, use that:
+        if self.model_field_name:
+            state_id = getattr(resource, self.model_field_name)
+            if state_id:
+                state_class = self._get_state_class_from_id(state_id)
+                if state_class:
+                    return self._instantiate_state(resource, state_class)
+        # Otherwise, just use the default:
+        return self._instantiate_state(resource, self.default_state_class)
+
+    def _get_state_class_from_id(self, state_id):
+        for state_class in self.state_classes:
+            if state_class.state_id == state_id:
+                return state_class
+
+    def _instantiate_state(self, resource, state_class):
+        assert state_class in self.state_classes
+        return state_class(resource=resource, state_manager=self)
+
+    def _set_state(self, resource, new_state):
+        self.cache[resource] = new_state
+        if self.model_field_name:
+            setattr(resource, self.model_field_name, new_state.state_id)
+        return new_state

--- a/instance/models/utils.py
+++ b/instance/models/utils.py
@@ -123,9 +123,9 @@ class ResourceState:
         return issubclass(cls, state_classes)
 
     def __init__(self, resource, state_manager):
-        """ Instantiate this state, saving a reference to the parent resource """
-        self._resource = resource
-        self._state_manager = state_manager
+        """
+        Instantiate this state
+        """
 
     class Enum:
         """

--- a/instance/serializers/instance.py
+++ b/instance/serializers/instance.py
@@ -68,6 +68,19 @@ class OpenEdXInstanceListSerializer(serializers.ModelSerializer):
             'updates_feed',
         )
 
+    def to_representation(self, obj):
+        output = super().to_representation(obj)
+        # Convert the state values from objects to strings:
+        if output['status'] is None:
+            output['status'] = 'empty'  # 'empty' for backwards compatibility
+        else:
+            output['status'] = obj.status.state_id
+        if output['progress'] is None:
+            output['progress'] = 'empty'
+        else:
+            output['progress'] = obj.progress.state_id
+        return output
+
 
 class OpenEdXInstanceDetailSerializer(OpenEdXInstanceListSerializer):
     """

--- a/instance/serializers/server.py
+++ b/instance/serializers/server.py
@@ -48,3 +48,10 @@ class OpenStackServerSerializer(serializers.ModelSerializer):
             'status',
             'progress',
         )
+
+    def to_representation(self, obj):
+        output = super().to_representation(obj)
+        # Convert the state values from objects to strings:
+        output['status'] = obj.status.state_id
+        output['progress'] = obj.progress.state_id
+        return output

--- a/instance/tests/api/test_instance.py
+++ b/instance/tests/api/test_instance.py
@@ -86,8 +86,8 @@ class InstanceAPITestCase(APITestCase):
         """
         self.api_client.login(username='user1', password='pass')
         instance = OpenEdXInstanceFactory()
-        OpenStackServerFactory(instance=instance, progress=OpenStackServer.PROGRESS_RUNNING)
-        self.assertEqual(instance.progress, instance.PROGRESS_RUNNING)
+        OpenStackServerFactory(instance=instance, progress=OpenStackServer.Progress.Running)
+        self.assertEqual(instance.progress, OpenStackServer.Progress.Running)
         response = self.api_client.post('/api/v1/openedxinstance/{pk}/provision/'.format(pk=instance.pk))
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
@@ -111,8 +111,8 @@ class InstanceAPITestCase(APITestCase):
         self.api_client.login(username='user1', password='pass')
         instance = OpenEdXInstanceFactory(commit_id='0' * 40, branch_name='api-branch', fork_name='api/repo')
         OpenStackServerFactory(instance=instance,
-                               status=OpenStackServer.READY,
-                               progress=OpenStackServer.PROGRESS_SUCCESS)
+                               status=OpenStackServer.Status.Ready,
+                               progress=OpenStackServer.Progress.Success)
         mock_get_commit_id_from_ref.return_value = '1' * 40
 
         response = self.api_client.post('/api/v1/openedxinstance/{pk}/provision/'.format(pk=instance.pk))

--- a/instance/tests/integration/integration_instance.py
+++ b/instance/tests/integration/integration_instance.py
@@ -29,6 +29,7 @@ import requests
 from django.conf import settings
 
 from instance.models.instance import OpenEdXInstance
+from instance.models.server import Status, Progress
 from instance.tests.decorators import patch_git_checkout
 from instance.tests.integration.base import IntegrationTestCase
 from instance.tests.integration.factories.instance import OpenEdXInstanceFactory
@@ -46,8 +47,8 @@ class InstanceIntegrationTestCase(IntegrationTestCase):
         """
         Check that the given instance is up and accepting requests
         """
-        self.assertEqual(instance.status, OpenEdXInstance.READY)
-        self.assertEqual(instance.progress, OpenEdXInstance.PROGRESS_SUCCESS)
+        self.assertEqual(instance.status, Status.Ready)
+        self.assertEqual(instance.progress, Progress.Success)
         server = instance.server_set.first()
         attempts = 3
         while True:
@@ -95,8 +96,8 @@ class InstanceIntegrationTestCase(IntegrationTestCase):
                                ansible_playbook_name='failure')
         instance = OpenEdXInstance.objects.get()
         provision_instance(instance.pk)
-        self.assertEqual(instance.status, OpenEdXInstance.PROVISIONING)
-        self.assertEqual(instance.progress, OpenEdXInstance.PROGRESS_FAILED)
+        self.assertEqual(instance.status, Status.Provisioning)
+        self.assertEqual(instance.progress, Progress.Failed)
 
     @patch_git_checkout
     def test_ansible_failignore(self, git_checkout, git_working_dir):
@@ -109,5 +110,5 @@ class InstanceIntegrationTestCase(IntegrationTestCase):
                                ansible_playbook_name='failignore')
         instance = OpenEdXInstance.objects.get()
         provision_instance(instance.pk)
-        self.assertEqual(instance.status, OpenEdXInstance.READY)
-        self.assertEqual(instance.progress, OpenEdXInstance.PROGRESS_SUCCESS)
+        self.assertEqual(instance.status, Status.Ready)
+        self.assertEqual(instance.progress, Progress.Success)

--- a/instance/tests/models/factories/server.py
+++ b/instance/tests/models/factories/server.py
@@ -75,7 +75,7 @@ class OSServerMockManager:
         Returns the mock `os_server` for this `openstack_id`
         """
         if openstack_id not in self._os_server_dict.keys():
-            self._os_server_dict[openstack_id] = MagicMock(addresses={"Ext-Net": [{"addr": "1.1.1.1",}]})
+            self._os_server_dict[openstack_id] = MagicMock(addresses={"Ext-Net": [{"addr": "1.1.1.1", }]})
         return self._os_server_dict[openstack_id]
 
     def set_os_server_attributes(self, openstack_id, **attributes):
@@ -122,7 +122,7 @@ class OpenStackServerFactory(DjangoModelFactory):
         if 'progress' in kwargs:
             kwargs['_progress'] = kwargs.pop('progress').state_id
         if hasattr(cls, '_status') and '_status' not in kwargs:
-            kwargs['_status'] = cls._status
+            kwargs['_status'] = cls._status  # pylint: disable=no-member
         return kwargs
 
 

--- a/instance/tests/models/factories/server.py
+++ b/instance/tests/models/factories/server.py
@@ -75,7 +75,7 @@ class OSServerMockManager:
         Returns the mock `os_server` for this `openstack_id`
         """
         if openstack_id not in self._os_server_dict.keys():
-            self._os_server_dict[openstack_id] = MagicMock()
+            self._os_server_dict[openstack_id] = MagicMock(addresses={"Ext-Net": [{"addr": "1.1.1.1",}]})
         return self._os_server_dict[openstack_id]
 
     def set_os_server_attributes(self, openstack_id, **attributes):
@@ -105,7 +105,7 @@ class OpenStackServerFactory(DjangoModelFactory):
         os_server_fixture = kwargs.pop('os_server_fixture', None)
         server = super()._create(model_class, *args, **kwargs)
 
-        # This isn't a model fields, so it needs to be set separately, not passed to the model `__init__`
+        # This isn't a model field, so it needs to be set separately, not passed to the model `__init__`
         server.nova = Mock()
 
         # Allow to set OpenStack API data for the current `self.os_server`, using fixtures
@@ -114,26 +114,37 @@ class OpenStackServerFactory(DjangoModelFactory):
 
         return server
 
+    @classmethod
+    def _adjust_kwargs(cls, **kwargs):
+        """ Force FactoryBoy to set the field '_status' even though it starts with an underscore """
+        if 'status' in kwargs:
+            kwargs['_status'] = kwargs.pop('status').state_id
+        if 'progress' in kwargs:
+            kwargs['_progress'] = kwargs.pop('progress').state_id
+        if hasattr(cls, '_status') and '_status' not in kwargs:
+            kwargs['_status'] = cls._status
+        return kwargs
+
 
 class StartedOpenStackServerFactory(OpenStackServerFactory):
     """
-    Factory for a server with a 'started' status
+    Factory for a server with a 'started' state
     """
-    status = OpenStackServer.STARTED
+    _status = OpenStackServer.Status.Started.state_id
     openstack_id = factory.Sequence('started-server-id{}'.format)
 
 
 class BootedOpenStackServerFactory(OpenStackServerFactory):
     """
-    Factory for a server with a 'booted' status
+    Factory for a server with a 'booted' state
     """
-    status = OpenStackServer.BOOTED
+    _status = OpenStackServer.Status.Booted.state_id
     openstack_id = factory.Sequence('booted-server-id{}'.format)
 
 
 class ProvisioningOpenStackServerFactory(OpenStackServerFactory):
     """
-    Factory for a server with a 'provisioning' status
+    Factory for a server with a 'provisioning' state
     """
-    status = OpenStackServer.PROVISIONING
+    _status = OpenStackServer.Status.Provisioning.state_id
     openstack_id = factory.Sequence('provisioning-server-id{}'.format)

--- a/instance/tests/models/test_instance.py
+++ b/instance/tests/models/test_instance.py
@@ -26,7 +26,7 @@ import os
 import re
 import subprocess
 
-from mock import call, patch
+from mock import call, patch, Mock
 from urllib.parse import urlparse
 
 from django.core import mail as django_mail
@@ -43,7 +43,56 @@ from instance.tests.factories.pr import PRFactory
 from instance.tests.models.factories.instance import OpenEdXInstanceFactory
 from instance.tests.models.factories.server import (
     StartedOpenStackServerFactory, BootedOpenStackServerFactory, ProvisioningOpenStackServerFactory,
-    patch_os_server)
+    patch_os_server, OSServerMockManager)
+
+
+# Helper functions ############################################################
+
+def patch_services(func):
+    """
+    Mock most external services so that things 'seem to work' when provisioning a server.
+
+    Returns a mock containing all the mocked services, so each test can customize the process.
+    """
+    new_servers = [Mock(id='server1'), Mock(id='server2'), Mock(id='server3'), Mock(id='server4'), ]
+
+    def wrapper(self, *args, **kwargs):
+        os_server_manager = OSServerMockManager()
+        os_server_manager.set_os_server_attributes('server1', _loaded=True, status='ACTIVE')
+        with \
+        patch('instance.models.server.openstack.get_nova_client') as mock_get_nova_client, \
+        patch('instance.models.server.is_port_open', return_value=True) as mock_is_port_open, \
+        patch('instance.models.server.openstack.create_server', side_effect=new_servers) as mock_create_server, \
+        patch('instance.models.server.time.sleep') as mock_sleep, \
+        patch('instance.models.instance.gandi.set_dns_record') as mock_set_dns_record, \
+        patch('instance.models.instance.OpenEdXInstance.deploy') as mock_deploy, \
+        patch('instance.models.mixins.utilities.EmailInstanceMixin.provision_failed_email') \
+        as mock_provision_failed_email, \
+        patch('instance.models.instance.MySQLInstanceMixin.provision_mysql') as mock_provision_mysql, \
+        patch('instance.models.instance.MongoDBInstanceMixin.provision_mongo') as mock_provision_mongo:
+        #patch('instance.openstack.get_server_public_address', return_value={'addr': '1.1.1.1'}) as mock_get_server_public_address:
+
+            def check_sleep_count(_delay):
+                """ Check that time.sleep() is not used in some sort of infinite loop """
+                self.assertLess(mock_sleep.call_count, 1000, "time.sleep() called too many times.")
+            mock_sleep.side_effect = check_sleep_count
+
+            mocks = Mock(
+                os_server_manager=os_server_manager,
+                mock_get_nova_client=mock_get_nova_client,
+                mock_is_port_open=mock_is_port_open,
+                mock_create_server=mock_create_server,
+                mock_sleep=mock_sleep,
+                mock_set_dns_record=mock_set_dns_record,
+                mock_deploy=mock_deploy,
+                mock_provision_failed_email=mock_provision_failed_email,
+                mock_provision_mysql=mock_provision_mysql,
+                mock_provision_mongo=mock_provision_mongo,
+               # mock_get_server_public_address=mock_get_server_public_address,
+            )
+            mock_get_nova_client.return_value.servers.get = os_server_manager.get_os_server
+            return func(self, mocks, *args, **kwargs)
+    return wrapper
 
 
 # Tests #######################################################################
@@ -89,14 +138,14 @@ class InstanceTestCase(TestCase):
         Instance status with one active server
         """
         instance = OpenEdXInstanceFactory()
-        self.assertEqual(instance.status, instance.EMPTY)
-        self.assertEqual(instance.progress, instance.EMPTY)
+        self.assertIsNone(instance.status)
+        self.assertIsNone(instance.progress)
         server = StartedOpenStackServerFactory(instance=instance)
-        self.assertEqual(instance.status, instance.STARTED)
-        self.assertEqual(instance.progress, instance.PROGRESS_RUNNING)
-        server.status = server.BOOTED
+        self.assertEqual(instance.status, Server.Status.Started)
+        self.assertEqual(instance.progress, Server.Progress.Running)
+        server.status = Server.Status.Booted
         server.save()
-        self.assertEqual(instance.status, instance.BOOTED)
+        self.assertEqual(instance.status, Server.Status.Booted)
 
     def test_status_terminated(self):
         """
@@ -104,10 +153,10 @@ class InstanceTestCase(TestCase):
         """
         instance = OpenEdXInstanceFactory()
         server = StartedOpenStackServerFactory(instance=instance)
-        self.assertEqual(instance.status, instance.STARTED)
+        self.assertEqual(instance.status, server.Status.Started)
         server.status = 'terminated'
         server.save()
-        self.assertEqual(instance.status, instance.EMPTY)
+        self.assertIsNone(instance.status)
 
     def test_status_multiple_servers(self):
         """
@@ -115,8 +164,8 @@ class InstanceTestCase(TestCase):
         """
         instance = OpenEdXInstanceFactory()
         StartedOpenStackServerFactory(instance=instance)
-        self.assertEqual(instance.status, instance.STARTED)
-        self.assertEqual(instance.progress, instance.PROGRESS_RUNNING)
+        self.assertEqual(instance.status, Server.Status.Started)
+        self.assertEqual(instance.progress, Server.Progress.Running)
         StartedOpenStackServerFactory(instance=instance)
         with self.assertRaises(InconsistentInstanceState):
             instance.status #pylint: disable=pointless-statement
@@ -795,142 +844,64 @@ class OpenEdXInstanceTestCase(TestCase):
                     'FORUM_MONGO_DATABASE'):
             self.assertNotIn(var, instance.ansible_settings)
 
-    @patch_os_server
-    @patch('instance.models.server.openstack.create_server')
-    @patch('instance.models.server.OpenStackServer.update_status')
-    @patch('instance.models.server.OpenStackServer.sleep_until_status')
-    @patch('instance.models.server.OpenStackServer.reboot')
-    @patch('instance.models.instance.gandi.set_dns_record')
-    @patch('instance.models.instance.OpenEdXInstance.deploy')
-    @patch('instance.models.instance.OpenEdXInstance.provision_mysql')
-    @patch('instance.models.instance.OpenEdXInstance.provision_mongo')
-    def test_provision(self, os_server_manager, mock_provision_mongo, mock_provision_mysql, mock_deploy,
-                       mock_set_dns_record, mock_server_reboot, mock_sleep_until_status, mock_update_status,
-                       mock_openstack_create_server):
+    @patch_services
+    def test_provision(self, mocks):
         """
         Run provisioning sequence
         """
-        mock_deploy.return_value = (['log'], 0)
-        mock_openstack_create_server.return_value.id = 'test-run-provisioning-server'
-        os_server_manager.add_fixture('test-run-provisioning-server', 'openstack/api_server_2_active.json')
+        mocks.mock_deploy.return_value = (['log'], 0)
+        mocks.mock_create_server.side_effect = [Mock(id='test-run-provisioning-server'), None]
+        mocks.os_server_manager.add_fixture('test-run-provisioning-server', 'openstack/api_server_2_active.json')
+        mock_reboot = mocks.os_server_manager.get_os_server('test-run-provisioning-server').reboot
 
         instance = OpenEdXInstanceFactory(sub_domain='run.provisioning', use_ephemeral_databases=True)
         instance.provision()
-        self.assertEqual(mock_set_dns_record.mock_calls, [
+        self.assertEqual(mocks.mock_set_dns_record.mock_calls, [
             call(name='run.provisioning', type='A', value='192.168.100.200'),
             call(name='studio.run.provisioning', type='CNAME', value='run.provisioning'),
         ])
-        self.assertEqual(mock_deploy.call_count, 1)
-        self.assertEqual(mock_server_reboot.call_count, 1)
-        self.assertEqual(mock_provision_mysql.call_count, 0)
-        self.assertEqual(mock_provision_mongo.call_count, 0)
+        self.assertEqual(mocks.mock_deploy.call_count, 1)
+        self.assertEqual(mock_reboot.call_count, 1)
+        self.assertEqual(mocks.mock_provision_mysql.call_count, 0)
+        self.assertEqual(mocks.mock_provision_mongo.call_count, 0)
 
-    @patch_os_server
-    @patch('instance.models.mixins.utilities.EmailInstanceMixin.provision_failed_email')
-    @patch('instance.models.server.OpenStackServer.sleep_until_status')
-    @patch('instance.models.server.OpenStackServer.os_server', autospec=True)
-    @patch('instance.models.server.OpenStackServer.start', autospec=True)
-    @patch('instance.models.instance.gandi.set_dns_record')
-    @patch('instance.models.instance.OpenEdXInstance.deploy')
-    def test_provision_failed(self, os_server_manager, mock_deploy, mock_set_dns_record,
-                              mock_server_start, mock_os_server, mock_sleep_until_status, mock_provision_failed_email):
+    @patch_services
+    def test_provision_failed(self, mocks):
         """
         Run provisioning sequence failing the deployment on purpose to make sure the
         server status will be set accordingly.
         """
         log_lines = ['log']
-        mock_deploy.return_value = (log_lines, 1)
+        mocks.mock_deploy.return_value = (log_lines, 1)
         instance = OpenEdXInstanceFactory(sub_domain='run.provisioning')
 
-        def server_start(self):
-            """
-            Make sure we get the server in the BOOTED state when it is started
-            """
-            self.status = Server.BOOTED
-            self.progress = Server.PROGRESS_SUCCESS
-        mock_server_start.side_effect = server_start
-
         server = instance.provision()[0]
-        self.assertEqual(server.status, Server.PROVISIONING)
-        self.assertEqual(server.progress, Server.PROGRESS_FAILED)
-        mock_provision_failed_email.assert_called_once_with(instance.ProvisionMessages.PROVISION_ERROR, log_lines)
-        mock_provision_failed_email.assert_called_once_with(instance.ProvisionMessages.PROVISION_ERROR, log_lines)
+        self.assertEqual(server.status, Server.Status.Provisioning)
+        self.assertEqual(server.progress, Server.Progress.Failed)
+        mocks.mock_provision_failed_email.assert_called_once_with(instance.ProvisionMessages.PROVISION_ERROR, log_lines)
+        mocks.mock_provision_failed_email.assert_called_once_with(instance.ProvisionMessages.PROVISION_ERROR, log_lines)
 
-    @patch_os_server
-    @patch('instance.models.mixins.utilities.EmailInstanceMixin.provision_failed_email')
-    @patch('instance.models.server.OpenStackServer.sleep_until_status')
-    @patch('instance.models.server.OpenStackServer.os_server', autospec=True)
-    @patch('instance.models.server.OpenStackServer.start', autospec=True)
-    @patch('instance.models.instance.gandi.set_dns_record')
-    def test_provision_unhandled_exception(self, os_server_manager, mock_set_dns_record,
-                                           mock_server_start, mock_os_server,
-                                           mock_sleep_until_status, mock_provision_failed_email):
+    @patch_services
+    def test_provision_unhandled_exception(self, mocks):
         """
         Make sure that all servers are terminated if there is an unhandled exception during
         provisioning.
         """
-        exception_raised = Exception('Something went catastrophically wrong')
-        mock_set_dns_record.side_effect = exception_raised
+        mocks.mock_set_dns_record.side_effect = Exception('Something went catastrophically wrong')
         instance = OpenEdXInstanceFactory(sub_domain='run.provisioning')
-        with self.assertRaises(Exception):
+        with self.assertRaisesRegex(Exception, 'Something went catastrophically wrong'):
             instance.provision()
         self.assertFalse(instance.server_set.exclude_terminated())
 
-        mock_provision_failed_email.assert_called_once_with(instance.ProvisionMessages.PROVISION_EXCEPTION)
+        mocks.mock_provision_failed_email.assert_called_once_with(instance.ProvisionMessages.PROVISION_EXCEPTION)
 
-    @patch_os_server
-    @patch('instance.models.server.OpenStackServer.update_status', autospec=True)
-    @patch('instance.models.server.time.sleep')
-    @patch('instance.models.server.OpenStackServer.reboot')
-    @patch('instance.models.instance.gandi.set_dns_record')
-    @patch('instance.models.instance.OpenEdXInstance.deploy')
-    @patch('instance.models.instance.OpenEdXInstance.provision_mysql')
-    @patch('instance.models.instance.OpenEdXInstance.provision_mongo')
-    def test_provision_no_active(self, os_server_manager, mock_provision_mongo, mock_provision_mysql, mock_deploy,
-                                 mock_set_dns_record, mock_server_reboot, mock_sleep, mock_update_status):
-        """
-        Run provisioning sequence, with status jumping from 'started' to 'booted' (no 'active')
-        """
-        mock_deploy.return_value = (['log'], 0)
-        instance = OpenEdXInstanceFactory(sub_domain='run.provisioning.noactive')
-        status_queue = [
-            OpenStackServer.STARTED,
-            OpenStackServer.BOOTED,
-            OpenStackServer.BOOTED,
-            OpenStackServer.PROVISIONING,
-            OpenStackServer.REBOOTING,
-            OpenStackServer.READY,
-        ]
-        status_queue.reverse() # To be able to use pop()
-
-        def update_status(self, provisioning=False, rebooting=False, failed=None):
-            """ Simulate status progression successive runs """
-            self.status = status_queue.pop()
-            self.progress = self.PROGRESS_SUCCESS
-        mock_update_status.side_effect = update_status
-
-        with patch('instance.models.server.OpenStackServer.start'):
-            instance.provision()
-        self.assertEqual(mock_deploy.call_count, 1)
-
-    @patch_os_server
-    @patch('instance.models.server.openstack.create_server')
-    @patch('instance.models.server.OpenStackServer.update_status')
-    @patch('instance.models.server.OpenStackServer.sleep_until_status')
-    @patch('instance.models.server.OpenStackServer.reboot')
-    @patch('instance.models.instance.gandi.set_dns_record')
-    @patch('instance.models.instance.OpenEdXInstance.deploy')
-    @patch('instance.models.mixins.database.MySQLInstanceMixin.provision_mysql')
-    @patch('instance.models.mixins.database.MongoDBInstanceMixin.provision_mongo')
-    def test_provision_with_external_databases(self, os_server_manager, mock_provision_mongo, mock_provision_mysql,
-                                               mock_deploy, mock_set_dns_record, mock_server_reboot,
-                                               mock_sleep_until_status, mock_update_status,
-                                               mock_openstack_create_server):
+    @patch_services
+    def test_provision_with_external_databases(self, mocks):
         """
         Run provisioning sequence, with external databases
         """
-        mock_openstack_create_server.return_value.id = 'test-run-provisioning-server'
-        os_server_manager.add_fixture('test-run-provisioning-server', 'openstack/api_server_2_active.json')
+        mocks.mock_create_server.side_effect = [Mock(id='test-run-provisioning-server'), None]
+        mocks.os_server_manager.add_fixture('test-run-provisioning-server', 'openstack/api_server_2_active.json')
 
         instance = OpenEdXInstanceFactory(sub_domain='run.provisioning', use_ephemeral_databases=False)
 
@@ -944,7 +915,7 @@ class OpenEdXInstanceTestCase(TestCase):
                 self.assertTrue(ansible_settings[setting])
             return (['log'], 0)
 
-        mock_deploy.side_effect = deploy
+        mocks.mock_deploy.side_effect = deploy
         instance.provision()
-        self.assertEqual(mock_provision_mysql.call_count, 1)
-        self.assertEqual(mock_provision_mongo.call_count, 1)
+        self.assertEqual(mocks.mock_provision_mysql.call_count, 1)
+        self.assertEqual(mocks.mock_provision_mongo.call_count, 1)

--- a/instance/tests/models/test_server.py
+++ b/instance/tests/models/test_server.py
@@ -149,7 +149,6 @@ class OpenStackServerTestCase(TestCase):
         self.assertEqual(server.sleep_until_status(ServerStatus.Booted), ServerStatus.Booted)
         self.assertEqual(server.progress, ServerProgress.Success)
         self.assertEqual(server.status, ServerStatus.Booted)
-        self.assertEqual(server.progress, ServerProgress.Success)
         self.assertEqual(mock_sleep.call_count, 3)
         self.assertEqual(status_queue, [server._status_to_terminated])
 

--- a/instance/tests/models/test_utils.py
+++ b/instance/tests/models/test_utils.py
@@ -159,7 +159,7 @@ class SimpleResource:
     reset_to_one = state.transition(from_states=(State2, State3), to_state=State1)
     reset_to_one_alt = state.transition(from_states=BaseState, to_state=State1)
 
-    return_value = True  # Change this to change the expected return value of each method.
+    return_value = True  # Change this to change the expected return value of most of these methods.
 
     @state.only_for(State1)
     def method_one(self):
@@ -438,7 +438,7 @@ class DjangoResource:
     reset_to_one = state.transition(from_states=(State2, State3), to_state=State1)
     reset_to_one_alt = state.transition(from_states=BaseState, to_state=State1)
 
-    return_value = True  # Change this to change the expected return value of each method.
+    return_value = True  # Change this to change the expected return value of most of these methods.
 
     @state.only_for(State1)
     def method_one(self):

--- a/instance/tests/models/test_utils.py
+++ b/instance/tests/models/test_utils.py
@@ -1,0 +1,240 @@
+# -*- coding: utf-8 -*-
+#
+# OpenCraft -- tools to aid developing and hosting free software projects
+# Copyright (C) 2015 OpenCraft <xavier@opencraft.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+"""
+model utils - Tests, mostly for state machine
+"""
+
+# Imports #####################################################################
+
+from unittest import TestCase
+from mock import Mock
+
+from instance.models.utils import ResourceState, ResourceStateDescriptor, WrongStateException
+
+# Tests #######################################################################
+
+class ResourceStateTests(TestCase):
+    def test_state_declarations(self):
+        class Alpha(ResourceState):
+            """ The first letter of the greek alphabet """
+            state_id = 'alpha'
+
+        alpha = Alpha(resource=Mock(), state_manager=Mock())
+
+        self.assertEqual(Alpha.state_id, 'alpha')
+        self.assertEqual(alpha.state_id, 'alpha')
+        self.assertEqual(Alpha.name, 'Alpha')
+        self.assertEqual(alpha.name, 'Alpha')
+        self.assertEqual(alpha.description, "The first letter of the greek alphabet")
+        self.assertEqual(Alpha.description, "The first letter of the greek alphabet")
+
+        class Beta(ResourceState):
+            state_id = 'beta'
+            name = 'Beta!'
+            description = "The second letter of the greek alphabet"
+
+        beta = Beta(resource=Mock(), state_manager=Mock())
+
+        self.assertEqual(Beta.state_id, 'beta')
+        self.assertEqual(beta.state_id, 'beta')
+        self.assertEqual(Beta.name, 'Beta!')
+        self.assertEqual(beta.name, 'Beta!')
+        self.assertEqual(Beta.description, "The second letter of the greek alphabet")
+        self.assertEqual(beta.description, "The second letter of the greek alphabet")
+
+    def test_state_enum(self):
+        class StateSet(ResourceState.Enum):
+            class StateA(ResourceState):
+                state_id = 'a'
+
+            class StateB(ResourceState):
+                state_id = 'b'
+
+        self.assertCountEqual(StateSet.states, [StateSet.StateA, StateSet.StateB])
+
+
+
+class BaseState(ResourceState):
+    pass
+
+
+class State1(BaseState):
+    state_id = 'state1'
+    name = "State 1"
+
+
+class State2(BaseState):
+    state_id = 'state2'
+    name = "State 2"
+
+
+class State3(BaseState):
+    state_id = 'state3'
+    name = "State 3"
+
+
+class SimpleResource:
+    # Define a three-state FSM:
+    state = ResourceStateDescriptor(
+        state_classes=(State1, State2, State3),
+        default_state=State1,
+    )
+    # Define some transitions:
+    done_one = state.transition(from_states=State1, to_state=State2)
+    done_two = state.transition(from_states=State2, to_state=State3)
+    reset_to_one = state.transition(from_states=(State2, State3), to_state=State3)
+    reset_to_one_alt = state.transition(from_states=BaseState, to_state=State3)
+
+    return_value = True
+
+    @state.only_for(State1)
+    def method_one(self):
+        """ A method that only can be called in state 1 """
+        return self.return_value
+
+    @state.only_for(State1)
+    def method_one_with_args(self, a, b, c):
+        """ A method that only can be called in state 1 """
+        return (a * 1) + (b * 2) + (c * 3)
+
+    @state.only_for(State2)
+    def method_two(self):
+        """ A method that only can be called in state 2 """
+        return self.return_value
+
+    @state.only_for(State1, State3)
+    def method_odd(self):
+        """ A method that only can be called in states 1 or 3 """
+        return self.return_value
+
+    @property
+    @state.only_for(State1)
+    def prop_one(self):
+        """ A property whose value is only available in state 1 """
+        return self.return_value
+
+    @property
+    @state.only_for(State2, State3)
+    def prop_two(self):
+        """ A property whose value is only available in state 2 or 3 """
+        return self.return_value
+
+    @state.only_for(State1, State2)
+    def increment_state(self):
+        if isinstance(self.state, State1):
+            self.done_one()
+        else:
+            self.done_two()
+
+
+class SimpleResourceTestCase(TestCase):
+    """
+    ResourceStateDescriptor tests that use the SimpleResource class
+    """
+    def test_comparison_to_state_class(self):
+        """ Test the overloaded comparison operators """
+        res1 = SimpleResource()
+        res2 = SimpleResource()
+        self.assertEqual(res1.state, State1)
+        self.assertEqual(res2.state, State1)
+        self.assertNotEqual(res1.state, State2)
+        self.assertNotEqual(res2.state, State2)
+        self.assertTrue(res1.state == State1)
+        self.assertFalse(res1.state != State1)
+
+    def test_comparison_to_state_instance(self):
+        res1 = SimpleResource()
+        res2 = SimpleResource()
+        self.assertEqual(res1.state, State1)
+        self.assertEqual(res2.state, State1)
+        # States are also equal if their instances are equal:
+        self.assertEqual(res1.state, res1.state)
+        # States are also equal if they are the same type but different resources:
+        self.assertEqual(res1.state, res2.state)
+        res2.increment_state()
+        self.assertNotEqual(res1.state, res2.state)
+
+
+    def test_default_state(self):
+        res = SimpleResource()
+        self.assertIsInstance(res.state, State1)
+        self.assertEqual(res.state.name, "State 1")
+
+    def test_cannot_assign_state(self):
+        res = SimpleResource()
+        with self.assertRaisesRegex(AttributeError, "You cannot assign to a state machine attribute to change the state."):
+            res.state = State2
+
+    def test_mutator(self):
+        res = SimpleResource()
+        self.assertIsInstance(res.state, State1)
+        res.increment_state()
+        self.assertIsInstance(res.state, State2)
+        res.increment_state()
+        self.assertIsInstance(res.state, State3)
+
+    def test_method_only_for(self):
+        res = SimpleResource()
+        self.assertIsInstance(res.state, State1)
+
+        # In State 1, we can call method_one():
+        res.return_value = 'A'
+        self.assertEqual(res.method_one(), 'A')
+        self.assertEqual(res.method_one.is_available(), True)
+
+        # In State 1, we can call method_one_with_args():
+        self.assertEqual(res.method_one_with_args(4, 5, c=6), 32)
+        self.assertEqual(res.method_one_with_args.is_available(), True)
+
+        # But not method_two()
+        with self.assertRaisesRegex(WrongStateException, "The method 'method_two' cannot be called in this state \\(State 1 / State1\\)."):
+            res.method_two()
+        self.assertEqual(res.method_two.is_available(), False)
+
+        # In State 1, we can call method_odd():
+        res.return_value = 'B'
+        self.assertEqual(res.method_odd(), 'B')
+        self.assertEqual(res.method_odd.is_available(), True)
+
+
+        # Go to State 2:
+        res.increment_state()
+        self.assertIsInstance(res.state, State2)
+
+        with self.assertRaisesRegex(WrongStateException, "The method 'method_one' cannot be called in this state \\(State 2 / State2\\)."):
+            res.method_one()
+        self.assertEqual(res.method_one.is_available(), False)
+
+        res.return_value = 'C'
+        self.assertEqual(res.method_two(), 'C')
+        self.assertEqual(res.method_two.is_available(), True)
+
+    def test_property_only_for(self):
+        res = SimpleResource()
+        self.assertIsInstance(res.state, State1)
+
+        # In State 1, we can access .prop_one:
+        res.return_value = 'A'
+        self.assertEqual(res.prop_one, 'A')
+        res.return_value = 'B'
+        self.assertEqual(res.prop_one, 'B')
+
+        # But not .prop_two:
+        with self.assertRaisesRegex(WrongStateException, "The method 'prop_two' cannot be called in this state \\(State 1 / State1\\)."):
+            _unused = res.prop_two


### PR DESCRIPTION
This replaces the `status` and `progress` attributes of the `Server` class with a finite state machine implementation.

The immediate benefits are:
* Strong guarantee that the `Server` instance is always in one of the specified states.
* Transitions between states are clearly defined. One cannot use public methods to change from "New" to "Provisioning" for example.
* Removed states that weren't being used

The future benefits are much greater, but this is just "a step in the right direction". See below for next steps to help give context.

### Features:

* Any "resource" (such as a server) can have finite state machines attached to it
* Each state machine is always in one of a pre-defined number of states
* The value of the state can optionally be saved to the database if the resource is a django model
* The state can only be changed through the use of a *transition*; the allowed transitions ('allow changing from Loading to Ready') are clearly defined, and an attempt to make an invalid transition always raises an exception
* A resource can annotate its methods with annotations like `@status.only_for(Status.Booted)` - this will automatically raise an exception if the method is called when not appropriate, and also gives access to the handy `if method.is_available()` property which can be used to determine if you're allowed to call a method without actually calling it, in a fully generic fashion (you don't need to know what states support the method and what don't). So you can do things like `while not server.run_ssh_command.is_available(): wait()` which will wait until a server is ready to run SSH commands, without you needing to know what state(s) the server is in.
* When reading some state of a resource, you get an *instance* of the state, which has a pointer to the resource instance. This means that you can simplify resources by implementing methods on the state class rather than the resource. This is completely optional though.
    Example:

    ```python
    # Instead of 
    class Resource:
        def update(self):
            if self.status == New:
                ...
            elif self.status == Ready:
                ...
            else:
                raise Exception()

    # You can just use:
    class Resource:
        def update(self):
            self.status.update()
    ```
    When the behavior of an object varies greatly depending on its state, or you want to do cool things with subclassing, this type of abstraction is very powerful. For example, say you have many types of server: OpenStackServer, AWSServer, LinodeServer, and each provider offers different error states such as "network_offline", "alien_attack", etc. If your code has a `server` instance, you could just check the health of the server with `server.state.is_healthy()` rather than `server.state in (Server.State.Booting, Server.State.Running, OpenStackServer.State.RestoringImage, LinodeServer.State.Cloning)`

### Suggested Next Steps

* Change the server states to Unknown, Pending, Building, Booting, Ready, BuildFailed, and Terminated. (Unknown for when the OpenStack API is not responsive, BuildFailed for when OpenStack fails to create the server, e.g. due to a quota issue).
* Rename OpenEdXInstance to SingleVMOpenEdXInstance. Give it a set of states: New, WaitingForServer, ConfiguringServer, Running, ConfigurationFailed, Error.
* Create a new class OpenEdXSandbox, which manages of a collection of SingleVMOpenEdXInstance. When a new instance successfully provisions, the old ones get deleted. When provisioning fails, any  old sandbox that still runs will be kept.
* Give the Server states these properties: is_steady_state (the status is not expected to change, so don't wait for it to do so - e.g. Ready, BuildFailed, Terminated), and accepts_ssh_commands. Then refactor the code so that outside of the Server class we don't need to know what set of server states there are; we can just display `server.status.name` and `server.status.description` in the UI, and we can do things like `sleep() until server.status.accepts_ssh_commands`. This will allow us to do things in the future, like support more of the OpenStack API by adding more possible server states, without being coupled to other parts of the codebase.