### PR TITLE
Make code agnostic to specific server states

### DIFF
--- a/instance/models/instance.py
+++ b/instance/models/instance.py
@@ -426,14 +426,14 @@ class OpenEdXInstance(MySQLInstanceMixin, MongoDBInstanceMixin, AnsibleInstanceM
         server = self.server_set.create()
         server.start()
 
-        def can_proceed():
-            """ Is server in a state from which we can proceed? """
+        def accepts_ssh_commands():
+            """ Does server accept SSH commands? """
             return server.status.accepts_ssh_commands
 
         try:
             # DNS
             self.logger.info('Waiting for IP assignment on server %s...', server)
-            server.sleep_until(can_proceed)
+            server.sleep_until(accepts_ssh_commands)
             self.logger.info('Updating DNS: LMS at %s...', self.domain)
             gandi.set_dns_record(type='A', name=self.sub_domain, value=server.public_ip)
             self.logger.info('Updating DNS: Studio at %s...', self.studio_domain)
@@ -459,7 +459,7 @@ class OpenEdXInstance(MySQLInstanceMixin, MongoDBInstanceMixin, AnsibleInstanceM
             # Reboot
             self.logger.info('Rebooting server %s...', server)
             server.reboot()
-            server.sleep_until(can_proceed)
+            server.sleep_until(accepts_ssh_commands)
             self.logger.info('Provisioning completed')
 
             return (server, log)

--- a/instance/models/utils.py
+++ b/instance/models/utils.py
@@ -33,6 +33,14 @@ class WrongStateException(RuntimeError):
     pass
 
 
+class SteadyStateException(WrongStateException):
+    """
+    Raised when attempting to wait until object reaches a state that fulfills a certain condition
+    but the object's current state is steady, i.e., it is not expected to change.
+    """
+    pass
+
+
 # Classes #####################################################################
 
 class ValidateModelMixin(object):

--- a/instance/serializers/server.py
+++ b/instance/serializers/server.py
@@ -54,4 +54,7 @@ class OpenStackServerSerializer(serializers.ModelSerializer):
         # Convert the state values from objects to strings:
         output['status'] = obj.status.state_id
         output['progress'] = obj.progress.state_id
+        # Add state name and description for display purposes:
+        output['status_name'] = obj.status.name
+        output['status_description'] = obj.status.description
         return output

--- a/instance/static/html/instance/index.html
+++ b/instance/static/html/instance/index.html
@@ -45,8 +45,9 @@
         {{ selected.instance.name }}
         <span ng-repeat="server in selected.instance.active_server_set">
           <span class="status radius label"
-                ng-class="{warning: server.status != 'ready', success: server.status == 'ready'}">
-            {{ server.status }}
+                ng-class="{warning: server.status != 'ready', success: server.status == 'ready'}"
+                title="{{ server.status_description }}">
+            {{ server.status_name }}
           </span>
           <span ng-switch="selected.instance.progress">
             <i class="fa fa-times" tooltip-placement="top" tooltip="Failed" ng-switch-when="failed"></i>


### PR DESCRIPTION
... and use new `name` and `description` properties when displaying information about current state of an instance to a user.

Follows up on https://github.com/open-craft/opencraft/pull/51.

cf. [OC-1535](https://tasks.opencraft.com/browse/OC-1535)

**Update**: As of https://github.com/open-craft/opencraft/pull/52/commits/0378c167170e18c55fe87a18a6201d6e7a0898d6, also addresses [this request](https://github.com/open-craft/opencraft/pull/52#discussion_r59595130) from @bradenmacdonald.