### PR TITLE
Add pending migrations.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,7 @@ collectstatic: clean static_external
 migrate: clean
 	$(HONCHO_MANAGE) migrate
 
+# Check for unapplied migrations
 migration_check: clean
 	!(($(HONCHO_MANAGE) showmigrations | grep '\[ \]') && printf "\n\033[0;31mERROR: Pending migrations found\033[0m\n\n")
 
@@ -92,6 +93,10 @@ test_unit: clean
 	@echo -e "\nCoverage HTML report at file://`pwd`/build/coverage/index.html\n"
 	@coverage report --fail-under 94 || (echo "\nERROR: Coverage is below 95%\n" && exit 2)
 
+# Check whether migrations need to be generated
+test_migrations_missing: clean
+	! honcho -e .env.test run ./manage.py makemigrations --dry-run --exit
+
 test_integration: clean
 	@if [ -a .env.integration ] ; then \
 		echo -e "\nRunning integration tests..." ; \
@@ -106,7 +111,7 @@ test_js: clean static_external
 test_js_web: clean static_external
 	cd instance/tests/js && jasmine --host 0.0.0.0
 
-test: clean test_prospector test_unit test_js test_integration
+test: clean test_prospector test_unit test_migrations_missing test_js test_integration
 	@echo -e "\nAll tests OK!\n"
 
 test_one: clean

--- a/bin/run-circleci-tests
+++ b/bin/run-circleci-tests
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+set -e
+
+case $CIRCLE_NODE_INDEX in
+    0)
+        make test
+        ;;
+    *)
+        make test_integration
+        ;;
+esac

--- a/circle.yml
+++ b/circle.yml
@@ -8,6 +8,6 @@ dependencies:
     - pip install -r requirements.txt
 test:
   override:
-      - case $CIRCLE_NODE_INDEX in 0) make test ;; *) make test_integration ;; esac:
+      - bin/run-circleci-tests:
           timeout: 1800
           parallel: true

--- a/instance/migrations/0039_auto_20160416_1729.py
+++ b/instance/migrations/0039_auto_20160416_1729.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('instance', '0038_merge'),
+    ]
+
+    operations = [
+        migrations.RenameField(
+            model_name='openstackserver',
+            old_name='progress',
+            new_name='_progress',
+        ),
+        migrations.RenameField(
+            model_name='openstackserver',
+            old_name='status',
+            new_name='_status',
+        ),
+        migrations.AlterField(
+            model_name='openstackserver',
+            name='_progress',
+            field=models.CharField(choices=[('failed', 'type'), ('running', 'type'), ('success', 'type')], default='running', db_column='progress', max_length=7),
+        ),
+        migrations.AlterField(
+            model_name='openstackserver',
+            name='_status',
+            field=models.CharField(choices=[('active', 'type'), ('booted', 'type'), ('new', 'type'), ('provisioning', 'type'), ('ready', 'type'), ('rebooting', 'type'), ('started', 'type'), ('terminated', 'type')], default='new', db_column='status', max_length=20, db_index=True),
+        ),
+        migrations.AlterField(
+            model_name='generallogentry',
+            name='level',
+            field=models.CharField(choices=[('DEBUG', 'Debug'), ('INFO', 'Info'), ('WARNING', 'Warning'), ('ERROR', 'Error'), ('CRITICAL', 'Critical')], default='INFO', max_length=9, db_index=True),
+        ),
+        migrations.AlterField(
+            model_name='instancelogentry',
+            name='level',
+            field=models.CharField(choices=[('DEBUG', 'Debug'), ('INFO', 'Info'), ('WARNING', 'Warning'), ('ERROR', 'Error'), ('CRITICAL', 'Critical')], default='INFO', max_length=9, db_index=True),
+        ),
+        migrations.AlterField(
+            model_name='serverlogentry',
+            name='level',
+            field=models.CharField(choices=[('DEBUG', 'Debug'), ('INFO', 'Info'), ('WARNING', 'Warning'), ('ERROR', 'Error'), ('CRITICAL', 'Critical')], default='INFO', max_length=9, db_index=True),
+        ),
+    ]

--- a/instance/models/utils.py
+++ b/instance/models/utils.py
@@ -358,7 +358,7 @@ class ModelResourceStateDescriptor(ResourceStateDescriptor):
 
         Suitable for passing to a django CharField choices parameter.
         """
-        return tuple((state.state_id, state.__class__.__name__) for state in self.state_classes)
+        return sorted((state.state_id, state.__class__.__name__) for state in self.state_classes)
 
     # Internal helper methods:
 


### PR DESCRIPTION
These are migrations currently missing on the master branch.  I also needed to normalise the order of choices for the progress and status fields, since with the randomised order we had before we would get a new migration everytime you run `makemigrations`.

cc @bradenmacdonald

(Shouldn't the tests be able to catch missing migrations?)