### PR TITLE
Support provisioning Swift containers.

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -3,6 +3,7 @@ SECRET_KEY='tests'
 DATABASE_URL='postgres://localhost/opencraft'
 INSTANCE_MYSQL_URL='mysql://root@localhost'
 INSTANCE_MONGO_URL='mongodb://localhost'
+SWIFT_ENABLE=true
 HUEY_ALWAYS_EAGER=true
 OPENSTACK_USER='test'
 OPENSTACK_PASSWORD='pass'

--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,7 @@ collectstatic: clean static_external
 migrate: clean
 	$(HONCHO_MANAGE) migrate
 
+# Check for unapplied migrations
 migration_check: clean
 	!(($(HONCHO_MANAGE) showmigrations | grep '\[ \]') && printf "\n\033[0;31mERROR: Pending migrations found\033[0m\n\n")
 
@@ -92,6 +93,10 @@ test_unit: clean
 	@echo -e "\nCoverage HTML report at file://`pwd`/build/coverage/index.html\n"
 	@coverage report --fail-under 94 || (echo "\nERROR: Coverage is below 95%\n" && exit 2)
 
+# Check whether migrations need to be generated
+test_migrations_missing: clean
+	! honcho -e .env.test run ./manage.py makemigrations --dry-run --exit
+
 test_integration: clean
 	@if [ -a .env.integration ] ; then \
 		echo -e "\nRunning integration tests..." ; \
@@ -106,7 +111,7 @@ test_js: clean static_external
 test_js_web: clean static_external
 	cd instance/tests/js && jasmine --host 0.0.0.0
 
-test: clean test_prospector test_unit test_js test_integration
+test: clean test_prospector test_unit test_migrations_missing test_js test_integration
 	@echo -e "\nAll tests OK!\n"
 
 test_one: clean

--- a/bin/run-circleci-tests
+++ b/bin/run-circleci-tests
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+set -e
+
+case $CIRCLE_NODE_INDEX in
+    0)
+        make test
+        ;;
+    *)
+        make test_integration
+        ;;
+esac

--- a/circle.yml
+++ b/circle.yml
@@ -8,6 +8,6 @@ dependencies:
     - pip install -r requirements.txt
 test:
   override:
-      - case $CIRCLE_NODE_INDEX in 0) make test ;; *) make test_integration ;; esac:
+      - bin/run-circleci-tests:
           timeout: 1800
           parallel: true

--- a/instance/migrations/0035_reset_ansible_settings.py
+++ b/instance/migrations/0035_reset_ansible_settings.py
@@ -1,19 +1,20 @@
 # -*- coding: utf-8 -*-
 import sys
 from django.db import migrations, models
-from instance.models.instance import OpenEdXInstance as OpenEdXInstance
+from instance.models.instance import OpenEdXInstance as CurrentOpenEdXInstance
 
 
 def reset_ansible_settings(apps, schema_editor):
     db_alias = schema_editor.connection.alias
-    # Note that we are using the current version of OpenEdXInstance instead of the historical
-    # version from the app registry, since the faked version from the registry doesn't have any of
-    # the custom fields and methods.  I don't think there is any better way to do this.  Migrations
-    # are a terrible hack.
-    for instance in OpenEdXInstance.objects.using(db_alias).iterator():
+    HistoricalOpenEdXInstance = apps.get_model("instance", "OpenEdXInstance")
+    for instance in HistoricalOpenEdXInstance.objects.using(db_alias).iterator():
         if not instance.ansible_settings:
             try:
-                instance.reset_ansible_settings(commit=True)
+                # Use the current version of OpenEdXInstance instead of the historical version from
+                # the app registry, since the faked version from the registry doesn't have any of
+                # the custom fields and methods.  I don't think there is any better way to do this.
+                current_instance = CurrentOpenEdXInstance.objects.using(db_alias).get(pk=instance.pk)
+                current_instance.reset_ansible_settings(commit=True)
             except Exception as exc:
                 print('Error while migrating {}: {}'.format(instance, exc), file=sys.stderr)
                 print('Ignoring error and carrying on.', file=sys.stderr)

--- a/instance/migrations/0039_auto_20160416_1729.py
+++ b/instance/migrations/0039_auto_20160416_1729.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('instance', '0038_merge'),
+    ]
+
+    operations = [
+        migrations.RenameField(
+            model_name='openstackserver',
+            old_name='progress',
+            new_name='_progress',
+        ),
+        migrations.RenameField(
+            model_name='openstackserver',
+            old_name='status',
+            new_name='_status',
+        ),
+        migrations.AlterField(
+            model_name='openstackserver',
+            name='_progress',
+            field=models.CharField(choices=[('failed', 'type'), ('running', 'type'), ('success', 'type')], default='running', db_column='progress', max_length=7),
+        ),
+        migrations.AlterField(
+            model_name='openstackserver',
+            name='_status',
+            field=models.CharField(choices=[('active', 'type'), ('booted', 'type'), ('new', 'type'), ('provisioning', 'type'), ('ready', 'type'), ('rebooting', 'type'), ('started', 'type'), ('terminated', 'type')], default='new', db_column='status', max_length=20, db_index=True),
+        ),
+        migrations.AlterField(
+            model_name='generallogentry',
+            name='level',
+            field=models.CharField(choices=[('DEBUG', 'Debug'), ('INFO', 'Info'), ('WARNING', 'Warning'), ('ERROR', 'Error'), ('CRITICAL', 'Critical')], default='INFO', max_length=9, db_index=True),
+        ),
+        migrations.AlterField(
+            model_name='instancelogentry',
+            name='level',
+            field=models.CharField(choices=[('DEBUG', 'Debug'), ('INFO', 'Info'), ('WARNING', 'Warning'), ('ERROR', 'Error'), ('CRITICAL', 'Critical')], default='INFO', max_length=9, db_index=True),
+        ),
+        migrations.AlterField(
+            model_name='serverlogentry',
+            name='level',
+            field=models.CharField(choices=[('DEBUG', 'Debug'), ('INFO', 'Info'), ('WARNING', 'Warning'), ('ERROR', 'Error'), ('CRITICAL', 'Critical')], default='INFO', max_length=9, db_index=True),
+        ),
+    ]

--- a/instance/migrations/0040_auto_20160416_1735.py
+++ b/instance/migrations/0040_auto_20160416_1735.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('instance', '0039_auto_20160416_1729'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='openedxinstance',
+            name='swift_openstack_auth_url',
+            field=models.URLField(blank=True),
+        ),
+        migrations.AddField(
+            model_name='openedxinstance',
+            name='swift_openstack_password',
+            field=models.CharField(max_length=64, blank=True),
+        ),
+        migrations.AddField(
+            model_name='openedxinstance',
+            name='swift_openstack_region',
+            field=models.CharField(max_length=16, blank=True),
+        ),
+        migrations.AddField(
+            model_name='openedxinstance',
+            name='swift_openstack_tenant',
+            field=models.CharField(max_length=32, blank=True),
+        ),
+        migrations.AddField(
+            model_name='openedxinstance',
+            name='swift_openstack_user',
+            field=models.CharField(max_length=32, blank=True),
+        ),
+        migrations.AddField(
+            model_name='openedxinstance',
+            name='swift_provisioned',
+            field=models.BooleanField(default=False),
+        ),
+    ]

--- a/instance/models/utils.py
+++ b/instance/models/utils.py
@@ -358,7 +358,7 @@ class ModelResourceStateDescriptor(ResourceStateDescriptor):
 
         Suitable for passing to a django CharField choices parameter.
         """
-        return tuple((state.state_id, state.__class__.__name__) for state in self.state_classes)
+        return sorted((state.state_id, state.__class__.__name__) for state in self.state_classes)
 
     # Internal helper methods:
 

--- a/instance/templates/instance/ansible/swift.yml
+++ b/instance/templates/instance/ansible/swift.yml
@@ -1,0 +1,8 @@
+# The following line is commented out until the openstack role has been merged upstream.
+# EDXAPP_DEFAULT_FILE_STORAGE: 'swift.storage.SwiftStorage'
+EDXAPP_SWIFT_AUTH_VERSION: '2'
+EDXAPP_SWIFT_USERNAME: '{{ user }}'
+EDXAPP_SWIFT_KEY: '{{ password }}'
+EDXAPP_SWIFT_TENANT_NAME: '{{ tenant }}'
+EDXAPP_SWIFT_AUTH_URL: '{{ auth_url }}'
+EDXAPP_SWIFT_REGION_NAME: '{{ region }}'

--- a/instance/templates/instance/ansible/vars.yml
+++ b/instance/templates/instance/ansible/vars.yml
@@ -14,6 +14,12 @@ EDXAPP_PREVIEW_LMS_BASE: '{{ instance.domain }}'
 EDXAPP_CMS_SITE_NAME: '{{ instance.studio_domain }}'
 EDXAPP_CMS_BASE: '{{ instance.studio_domain }}'
 
+# Enable OpenStack settings to be able to use Swift.  These three variables are ignored in versions
+# of the configuration repo that don't have the openstack role yet, so it's safe to include them.
+EDXAPP_SETTINGS: 'openstack'
+XQUEUE_SETTINGS: 'openstack_settings'
+COMMON_VHOST_ROLE_NAME: 'openstack'
+
 # Forum environment settings
 FORUM_RACK_ENV: 'production'
 FORUM_SINATRA_ENV: 'production'

--- a/instance/tests/base.py
+++ b/instance/tests/base.py
@@ -100,6 +100,7 @@ class TestCase(DjangoTestCase):
 
     def tearDown(self):
         huey.djhuey.connection.close = self.orig_db_connection_close
+        super().tearDown()
 
 
 class WithUserTestCase(DjangoTestCase):

--- a/opencraft/settings.py
+++ b/opencraft/settings.py
@@ -230,6 +230,16 @@ OPENSTACK_SANDBOX_BASE_IMAGE = env.json('OPENSTACK_SANDBOX_BASE_IMAGE', default=
 OPENSTACK_SANDBOX_SSH_KEYNAME = env('OPENSTACK_SANDBOX_SSH_KEYNAME', default='opencraft')
 OPENSTACK_SANDBOX_SSH_USERNAME = env('OPENSTACK_SANDBOX_SSH_USERNAME', default='ubuntu')
 
+# Separate credentials for Swift.  These credentials are currently passed on to each instance
+# when Swift is enabled and INSTANCE_EPHEMERAL_DATABASES is disabled.
+
+SWIFT_ENABLE = env.bool('SWIFT_ENABLE', default=True)
+SWIFT_OPENSTACK_USER = env('SWIFT_OPENSTACK_USER', default=OPENSTACK_USER)
+SWIFT_OPENSTACK_PASSWORD = env('SWIFT_OPENSTACK_PASSWORD', default=OPENSTACK_PASSWORD)
+SWIFT_OPENSTACK_TENANT = env('SWIFT_OPENSTACK_TENANT', default=OPENSTACK_TENANT)
+SWIFT_OPENSTACK_AUTH_URL = env('SWIFT_OPENSTACK_AUTH_URL', default=OPENSTACK_AUTH_URL)
+SWIFT_OPENSTACK_REGION = env('SWIFT_OPENSTACK_REGION', default=OPENSTACK_REGION)
+
 
 # DNS (Gandi) #################################################################
 
@@ -371,8 +381,8 @@ if 'file' in HANDLERS:
 
 # Instances ###################################################################
 
-# By default, instances use local mysql and mongo databases. Set this to False
-# to use external databases instead
+# By default, instances use local mysql and mongo databases and local file storage.
+# Set this to False to use external databases and Swift object storage instead.
 INSTANCE_EPHEMERAL_DATABASES = env.bool('INSTANCE_EPHEMERAL_DATABASES', default=True)
 
 # Configure external databases here

--- a/pylintrc
+++ b/pylintrc
@@ -340,7 +340,7 @@ max-attributes=7
 min-public-methods=2
 
 # Maximum number of public methods for a class (see R0904).
-max-public-methods=20
+max-public-methods=22
 
 
 [CLASSES]

--- a/requirements.txt
+++ b/requirements.txt
@@ -80,6 +80,7 @@ python-dateutil==2.4.2
 python-keystoneclient==1.7.1
 python-neutronclient==3.1.0
 python-novaclient==2.31.0
+python-swiftclient==3.0.0
 pytz==2015.6
 PyYAML==3.10
 redis==2.10.3


### PR DESCRIPTION
Add support to provision Swift containers.  This is implemented analogously to MySQL and MongoDB provisioning (see #11).  Swift containers are only provisioned for instances with persistent databases, but I also added a separate flag to disable Swift provisioning if it's unwanted for some reason.

Unlike MySQL and MongoDB provisioning, Swift provisioning can't be tested locally with reasonable effort (see the [Swift All-In-One documentation](http://docs.openstack.org/developer/swift/development_saio.html) to get an idea of the complexity of setting up a local Swift cluster.), so the unit tests only test whether the API call to the Swift API is made.  The integration test will provision Swift containers though.  They aren't cleaned up when the instance is terminated (which is kind of the point of persistent databases).  In the long run we need some clean-up process to remove unused Swift containers. (The same holds for unused MongoDB and MySQL databases, which aren't cleaned up either.)

I had to modify the hack I implemented in one of the migrations, since it didn't work anymore for the latest version of `OpenEdXInstance`.  The new version of the hack should be more resilient, though it will fail to migrate instances correctly for people with a very old version of the instance manager installed, which shouldn't be a problem in practice.

As discussed on Jira, the full OpenStack credentials are passed on to the instance.  We should get a separate OpenStack project that doesn't have the permission to provision VMs soon, so we at least don't have the OpenStack credentials used to provision the VMs themselves on the servers.

**Testing instructions**

On the development Vagrant instance, run `pip install -r requirements.txt` to make sure the Swift client is installed.  Make sure OpenStack credentials are configured in `.env`, and provision a new instance from the development installation, e.g. by running `make shell` and entering

    In [1]: from instance.tasks import provision_instance
    In [2]: instance = OpenEdXInstance(sub_domain='swift-test', name='Swift Test')
    In [3]: provision_instance(instance.pk)

Once the provisioning finishes, verify the value of `instance.swift_provisioned` and copy the value of `instance.swift_container_name`.  In the shell, set the environment variables `OS_USERNAME`, `OS_TENANT_NAME`, `OS_PASSWORD`, `OS_AUTH_URL` and `OS_REGION_NAME` to the corresponding values from the `.env` file (note that the variable names in that file are different), and run

    swift stat <container_name>

with the container name noted above.  Verify that the container has the `.r:*` read ACL.

An even better test would be to provision an instance using the branch from https://github.com/edx/edx-platform/pull/11286, and then test the instance actually works with the container (which I didn't test yet).