### PR TITLE
Speed up unit test for "provisioned" to "rebooting" status update

### DIFF
--- a/instance/models/server.py
+++ b/instance/models/server.py
@@ -436,8 +436,8 @@ class OpenStackServer(Server):
         """
         Reboot the server
 
-        This requires to switch the status to 'rebooting', which is first attempted via the
-        `update_status` method. If the current state doesn't allow to switch to this status,
+        This requires to switch the status to 'rebooting'.
+        If the current state doesn't allow to switch to this status,
         a WrongStateException exception is thrown.
         """
         if self.status == Status.Rebooting:


### PR DESCRIPTION
cf. [OC-1547](https://tasks.opencraft.com/browse/OC-1547)

**Test instructions**

1. Run unit tests via `make test_unit` on current `master` (https://github.com/open-craft/opencraft/commit/14f1eeb46da78303bc836a431e289c920f0f305c). Observe that the process takes about two minutes, with the majority of time being spent on a single test.
2. Check out `speed-up-tests`.
3. Run unit tests again. Observe that the process takes about 5-7 seconds.
