### PR TITLE
Improve storage backend clean up after running the unit and integration tests.

### DIFF
--- a/instance/models/mixins/database.py
+++ b/instance/models/mixins/database.py
@@ -24,8 +24,22 @@ from django.conf import settings
 from django.db import models
 import MySQLdb as mysql
 import pymongo
+from swiftclient.exceptions import ClientException as SwiftClientException
 
-from instance.openstack import create_swift_container
+from instance import openstack
+
+
+def _get_mysql_cursor():
+    """
+    Get a database cursor.
+    """
+    connection = mysql.connect(
+        host=settings.INSTANCE_MYSQL_URL_OBJ.hostname,
+        user=settings.INSTANCE_MYSQL_URL_OBJ.username,
+        passwd=settings.INSTANCE_MYSQL_URL_OBJ.password or '',
+        port=settings.INSTANCE_MYSQL_URL_OBJ.port or 3306,
+    )
+    return connection.cursor(), connection
 
 
 class MySQLInstanceMixin(models.Model):
@@ -51,14 +65,7 @@ class MySQLInstanceMixin(models.Model):
         Create mysql user and databases
         """
         if settings.INSTANCE_MYSQL_URL_OBJ and not self.mysql_provisioned:
-            connection = mysql.connect(
-                host=settings.INSTANCE_MYSQL_URL_OBJ.hostname,
-                user=settings.INSTANCE_MYSQL_URL_OBJ.username,
-                passwd=settings.INSTANCE_MYSQL_URL_OBJ.password or '',
-                port=settings.INSTANCE_MYSQL_URL_OBJ.port or 3306,
-            )
-            cursor = connection.cursor()
-
+            cursor, connection = _get_mysql_cursor()
             for database in self.mysql_database_names:
                 # We can't use the database name in a parameterized query, the
                 # driver doesn't escape it properly. Se we escape it here instead
@@ -66,8 +73,22 @@ class MySQLInstanceMixin(models.Model):
                 cursor.execute('CREATE DATABASE `{0}` DEFAULT CHARACTER SET utf8'.format(database_name))
                 cursor.execute('GRANT ALL ON `{0}`.* TO %s IDENTIFIED BY %s'.format(database_name),
                                (self.mysql_user, self.mysql_pass))
-
             self.mysql_provisioned = True
+            self.save()
+
+    def deprovision_mysql(self):
+        """
+        Drop all MySQL databases.
+        """
+        if settings.INSTANCE_MYSQL_URL_OBJ and self.mysql_provisioned:
+            cursor, connection = _get_mysql_cursor()
+            for database in self.mysql_database_names:
+                # We can't use the database name in a parameterized query, the
+                # driver doesn't escape it properly. Se we escape it here instead
+                database_name = connection.escape_string(database).decode()
+                cursor.execute('DROP DATABASE IF EXISTS `{0}`'.format(database_name))
+            cursor.execute('DROP USER %s', (self.mysql_user,))
+            self.mysql_provisioned = False
             self.save()
 
 
@@ -97,8 +118,19 @@ class MongoDBInstanceMixin(models.Model):
             mongo = pymongo.MongoClient(settings.INSTANCE_MONGO_URL)
             for database in self.mongo_database_names:
                 mongo[database].add_user(self.mongo_user, self.mongo_pass)
-
             self.mongo_provisioned = True
+            self.save()
+
+    def deprovision_mongo(self):
+        """
+        Drop Mongo databases.
+        """
+        if settings.INSTANCE_MONGO_URL and self.mongo_provisioned:
+            mongo = pymongo.MongoClient(settings.INSTANCE_MONGO_URL)
+            for database in self.mongo_database_names:
+                # Dropping a non-existing database is a no-op.  Users are dropped together with the DB.
+                mongo.drop_database(database)
+            self.mongo_provisioned = False
             self.save()
 
 
@@ -129,7 +161,7 @@ class SwiftContainerInstanceMixin(models.Model):
         """
         if settings.SWIFT_ENABLE and not self.swift_provisioned:
             for container_name in self.swift_container_names:
-                create_swift_container(
+                openstack.create_swift_container(
                     container_name,
                     user=self.swift_openstack_user,
                     password=self.swift_openstack_password,
@@ -138,4 +170,27 @@ class SwiftContainerInstanceMixin(models.Model):
                     region=self.swift_openstack_region,
                 )
             self.swift_provisioned = True
+            self.save()
+
+    def deprovision_swift(self):
+        """
+        Delete the Swift containers.
+        """
+        if settings.SWIFT_ENABLE and self.swift_provisioned:
+            for container_name in self.swift_container_names:
+                try:
+                    openstack.delete_swift_container(
+                        container_name,
+                        user=self.swift_openstack_user,
+                        password=self.swift_openstack_password,
+                        tenant=self.swift_openstack_tenant,
+                        auth_url=self.swift_openstack_auth_url,
+                        region=self.swift_openstack_region,
+                    )
+                except SwiftClientException:
+                    # If deleting a Swift container fails, we still want to continue.
+                    self.logger.exception(
+                        'Could not delete Swift container "%s".', container_name, exc_info=True
+                    )
+            self.swift_provisioned = False
             self.save()

--- a/instance/models/mixins/database.py
+++ b/instance/models/mixins/database.py
@@ -189,8 +189,6 @@ class SwiftContainerInstanceMixin(models.Model):
                     )
                 except SwiftClientException:
                     # If deleting a Swift container fails, we still want to continue.
-                    self.logger.exception(
-                        'Could not delete Swift container "%s".', container_name, exc_info=True
-                    )
+                    self.logger.exception('Could not delete Swift container "%s".', container_name)
             self.swift_provisioned = False
             self.save()

--- a/instance/openstack.py
+++ b/instance/openstack.py
@@ -127,3 +127,11 @@ def create_swift_container(container_name, **kwargs):
         container_name,
         headers={'X-Container-Read': '.r:*'},  # Allow public read access given the URL.
     )
+
+
+def delete_swift_container(container_name, **kwargs):
+    """
+    Delete a Swift container.
+    """
+    connection = get_swift_connection(**kwargs)
+    connection.delete_container(container_name)

--- a/instance/tests/integration/base.py
+++ b/instance/tests/integration/base.py
@@ -24,6 +24,7 @@ Tests - Integration - Base
 
 from huey import djhuey
 
+from instance.models.instance import OpenEdXInstance
 from instance.models.server import OpenStackServer
 from instance.tests.base import TestCase
 
@@ -41,4 +42,8 @@ class IntegrationTestCase(TestCase):
 
     def tearDown(self):
         OpenStackServer.objects.terminate()
+        for instance in OpenEdXInstance.objects.iterator():
+            instance.deprovision_swift()
+            instance.deprovision_mongo()
+            instance.deprovision_mysql()
         super().tearDown()

--- a/instance/tests/integration/integration_instance.py
+++ b/instance/tests/integration/integration_instance.py
@@ -74,7 +74,6 @@ class InstanceIntegrationTestCase(IntegrationTestCase):
         connection = get_swift_connection()
         header = connection.head_container(instance.swift_container_name)
         self.assertEqual(header['x-container-read'], '.r:*')
-        connection.delete_container(instance.swift_container_name)
 
     @shard(1)
     def test_provision_instance(self):


### PR DESCRIPTION
This change introduces `deprovision_*()` methods for deprovisioning storage backends, and calls these functions in the `tearDown()` methods for applicable unit and integration tests.

The unit tests already did a clean-up, but not in `tearDown()`, so they would leak the databases if they errored out earlier.

This is implemented on top of #54.  Only the last two commits need to be reviewed here.