### PR TITLE
Combine log entries (Prereq for OC-1541)

### DIFF
--- a/betatest/forms.py
+++ b/betatest/forms.py
@@ -40,7 +40,7 @@ class BetaTestApplicationForm(NgModelFormMixin, NgFormValidationMixin, NgModelFo
     Application form for beta testers. Creates instances of User, UserProfile,
     and BetaTestApplication models on submit.
     """
-    class Meta: #pylint: disable=missing-docstring
+    class Meta:
         model = BetaTestApplication
         exclude = ('user', 'status')
         widgets = {

--- a/instance/admin.py
+++ b/instance/admin.py
@@ -25,22 +25,14 @@ Admin for the instance app
 from django.contrib import admin
 
 from instance.models.instance import SingleVMOpenEdXInstance
-from instance.models.log_entry import GeneralLogEntry, InstanceLogEntry, ServerLogEntry
+from instance.models.log_entry import LogEntry
 from instance.models.server import OpenStackServer
 
 
 # ModelAdmins #################################################################
 
-class GeneralLogEntryAdmin(admin.ModelAdmin): #pylint: disable=missing-docstring
+class LogEntryAdmin(admin.ModelAdmin): #pylint: disable=missing-docstring
     list_display = ('created', 'level', 'text', 'modified')
-
-
-class InstanceLogEntryAdmin(admin.ModelAdmin): #pylint: disable=missing-docstring
-    list_display = ('obj', 'created', 'level', 'text', 'modified')
-
-
-class ServerLogEntryAdmin(admin.ModelAdmin): #pylint: disable=missing-docstring
-    list_display = ('obj', 'created', 'level', 'text', 'modified')
 
 
 class OpenStackServerAdmin(admin.ModelAdmin): #pylint: disable=missing-docstring
@@ -51,8 +43,6 @@ class SingleVMOpenEdXInstanceAdmin(admin.ModelAdmin): #pylint: disable=missing-d
     list_display = ('sub_domain', 'base_domain', 'name', 'created', 'modified')
 
 
-admin.site.register(GeneralLogEntry, GeneralLogEntryAdmin)
-admin.site.register(InstanceLogEntry, InstanceLogEntryAdmin)
-admin.site.register(ServerLogEntry, ServerLogEntryAdmin)
+admin.site.register(LogEntry, LogEntryAdmin)
 admin.site.register(OpenStackServer, OpenStackServerAdmin)
 admin.site.register(SingleVMOpenEdXInstance, SingleVMOpenEdXInstanceAdmin)

--- a/instance/logging.py
+++ b/instance/logging.py
@@ -69,11 +69,14 @@ class DBHandler(logging.Handler):
         obj = record.__dict__.get('obj', None)
 
         if obj is None or not isinstance(obj, models.Model) or obj.pk is None:
-            log_entry_set = apps.get_model('instance', 'GeneralLogEntry').objects
+            content_type, object_id = None, None
         else:
-            log_entry_set = obj.log_entry_set
+            content_type = apps.get_model('contenttypes', 'ContentType').objects.get_for_model(obj)
+            object_id = obj.pk
 
-        log_entry = log_entry_set.create(level=record.levelname, text=self.format(record))
+        log_entry = apps.get_model('instance', 'LogEntry').objects.create(
+            level=record.levelname, text=self.format(record), content_type=content_type, object_id=object_id
+        )
 
         log_event = {
             'type': 'instance_log',

--- a/instance/migrations/0045_generic_logging1.py
+++ b/instance/migrations/0045_generic_logging1.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import django_extensions.db.fields
+import instance.models.utils
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('contenttypes', '0002_remove_content_type_name'),
+        ('instance', '0044_remove_server_progress'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='LogEntry',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, primary_key=True, auto_created=True)),
+                ('created', django_extensions.db.fields.CreationDateTimeField(verbose_name='created', auto_now_add=True)),
+                ('modified', django_extensions.db.fields.ModificationDateTimeField(verbose_name='modified', auto_now=True)),
+                ('text', models.TextField(blank=True)),
+                ('level', models.CharField(db_index=True, choices=[('DEBUG', 'Debug'), ('INFO', 'Info'), ('WARNING', 'Warning'), ('ERROR', 'Error'), ('CRITICAL', 'Critical')], default='INFO', max_length=9)),
+                ('content_type', models.ForeignKey(to='contenttypes.ContentType', related_name='+', null=True, blank=True)),
+                ('object_id', models.PositiveIntegerField(null=True, blank=True)),
+            ],
+            options={
+                'ordering': ('-created',),
+                'verbose_name_plural': 'Log Entries',
+                'permissions': (('read_log_entry', 'Can read LogEntry'),),
+            },
+            bases=(instance.models.utils.ValidateModelMixin, models.Model),
+        ),
+    ]

--- a/instance/migrations/0046_generic_logging2.py
+++ b/instance/migrations/0046_generic_logging2.py
@@ -1,0 +1,83 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import connection, migrations, models
+import django_extensions.db.fields
+import instance.models.utils
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('contenttypes', '0002_remove_content_type_name'),
+        ('instance', '0045_generic_logging1'),
+    ]
+
+    def data_forward(apps, schema_editor):
+        """
+        Copy log entries from GeneralLogEntry, InstanceLogEntry, and ServerLogEntry into the new
+        combined LogEntry table.
+        """
+        ContentType = apps.get_model("contenttypes", "ContentType")
+        instance_type = ContentType.objects.get_for_model(apps.get_model('instance', 'singlevmopenedxinstance'))
+        server_type = ContentType.objects.get_for_model(apps.get_model('instance', 'openstackserver'))
+        cursor = connection.cursor()
+
+        cursor.execute(
+            """
+            INSERT INTO instance_logentry (created, modified, text, level)
+            SELECT created, modified, text, level FROM instance_generallogentry
+            """
+        )
+
+        cursor.execute(
+            """
+            INSERT INTO instance_logentry (created, modified, text, level, content_type_id, object_id)
+            SELECT created, modified, text, level, %s, obj_id FROM instance_instancelogentry
+            """,
+            [instance_type.pk]
+        )
+
+        cursor.execute(
+            """
+            INSERT INTO instance_logentry (created, modified, text, level, content_type_id, object_id)
+            SELECT created, modified, text, level, %s, obj_id FROM instance_serverlogentry
+            """,
+            [server_type.pk]
+        )
+
+    def data_backward(apps, schema_editor):
+        """
+        Reverse the data migration
+        """
+        ContentType = apps.get_model("contenttypes", "ContentType")
+        instance_type = ContentType.objects.get_for_model(apps.get_model('instance', 'singlevmopenedxinstance'))
+        server_type = ContentType.objects.get_for_model(apps.get_model('instance', 'openstackserver'))
+        cursor = connection.cursor()
+
+        cursor.execute(
+            """
+            INSERT INTO instance_generallogentry (created, modified, text, level)
+            SELECT created, modified, text, level FROM instance_logentry WHERE content_type_id IS NULL
+            """
+        )
+
+        cursor.execute(
+            """
+            INSERT INTO instance_instancelogentry (created, modified, text, level, obj_id)
+            SELECT created, modified, text, level, object_id FROM instance_logentry WHERE content_type_id = %s
+            """,
+            [instance_type.pk]
+        )
+
+        cursor.execute(
+            """
+            INSERT INTO instance_serverlogentry (created, modified, text, level, obj_id)
+            SELECT created, modified, text, level, object_id FROM instance_logentry WHERE content_type_id = %s
+            """,
+            [server_type.pk]
+        )
+
+    operations = [
+        migrations.RunPython(data_forward, data_backward),
+    ]

--- a/instance/migrations/0047_generic_logging3.py
+++ b/instance/migrations/0047_generic_logging3.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import django_extensions.db.fields
+import instance.models.utils
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('contenttypes', '0002_remove_content_type_name'),
+        ('instance', '0046_generic_logging2'),
+    ]
+
+    operations = [
+        migrations.DeleteModel(
+            name='GeneralLogEntry',
+        ),
+        migrations.RemoveField(
+            model_name='instancelogentry',
+            name='obj',
+        ),
+        migrations.RemoveField(
+            model_name='serverlogentry',
+            name='obj',
+        ),
+        migrations.DeleteModel(
+            name='InstanceLogEntry',
+        ),
+        migrations.DeleteModel(
+            name='ServerLogEntry',
+        ),
+    ]

--- a/instance/models/instance.py
+++ b/instance/models/instance.py
@@ -22,7 +22,6 @@ Instance app models - Instance
 
 # Imports #####################################################################
 
-from functools import partial
 import logging
 import string
 
@@ -268,36 +267,6 @@ class Instance(ValidateModelMixin, TimeStampedModel):
             self.base_domain = settings.INSTANCES_BASE_DOMAIN
         super().save(**kwargs)
 
-    @staticmethod
-    def _sort_log_entries(server_logs, instance_logs):
-        """
-        Helper method to combine the instance and server log outputs in chronological order
-        """
-        next_server_log_entry = partial(next, server_logs, None)
-        next_instance_log_entry = partial(next, instance_logs, None)
-
-        log = []
-        instance_log_entry = next_instance_log_entry()
-        server_log_entry = next_server_log_entry()
-
-        while instance_log_entry is not None and server_log_entry is not None:
-            if server_log_entry.created < instance_log_entry.created:
-                log.append(server_log_entry)
-                server_log_entry = next_server_log_entry()
-            else:
-                log.append(instance_log_entry)
-                instance_log_entry = next_instance_log_entry()
-
-        while instance_log_entry is not None:
-            log.append(instance_log_entry)
-            instance_log_entry = next_instance_log_entry()
-
-        while server_log_entry is not None:
-            log.append(server_log_entry)
-            server_log_entry = next_server_log_entry()
-
-        return log
-
     def _get_log_entries(self, level_list=None, limit=None):
         """
         Return the list of log entry instances for the instance and its current active server,
@@ -305,16 +274,13 @@ class Instance(ValidateModelMixin, TimeStampedModel):
         returned.
         """
         # TODO: Filter out log entries for which the user doesn't have view rights
-        server_log_entry_set = self._current_server.log_entry_set
-        if level_list:
-            server_log_entry_set = server_log_entry_set.filter(level__in=level_list)
-        server_log_entry_set = server_log_entry_set.order_by('pk')
-        if limit:
-            server_log_entry_set = reversed(server_log_entry_set.reverse()[:limit])
-        else:
-            server_log_entry_set = server_log_entry_set.iterator()
-
-        instance_log_entry_set = self.log_entry_set
+        instance_type = ContentType.objects.get_for_model(self)
+        server_type = ContentType.objects.get_by_natural_key(app_label='instance', model='openstackserver')
+        server_ids = [server.pk for server in self.server_set.all()]
+        entries = LogEntry.objects.filter(
+            (Q(content_type=instance_type) & Q(object_id=self.pk)) |
+            (Q(content_type=server_type) & Q(object_id__in=server_ids))
+        )
         if level_list:
             instance_log_entry_set = instance_log_entry_set.filter(level__in=level_list)
         instance_log_entry_set = instance_log_entry_set.order_by('pk')

--- a/instance/models/log_entry.py
+++ b/instance/models/log_entry.py
@@ -24,13 +24,14 @@ Instance app models - LogEntry
 
 import logging
 
+from django.contrib.contenttypes.models import ContentType
+from django.contrib.contenttypes.fields import GenericForeignKey
+from django.core.exceptions import ValidationError
 from django.db import models
+from django.db.models.signals import post_delete
 from django_extensions.db.models import TimeStampedModel
 
-from instance.models.instance import SingleVMOpenEdXInstance
-from instance.models.server import OpenStackServer
-from instance.models.utils import ValidateModelMixin
-
+from .utils import ValidateModelMixin
 
 # Logging #####################################################################
 
@@ -38,6 +39,7 @@ logger = logging.getLogger(__name__)
 
 
 # Models ######################################################################
+
 
 class LogEntry(ValidateModelMixin, TimeStampedModel):
     """
@@ -52,41 +54,52 @@ class LogEntry(ValidateModelMixin, TimeStampedModel):
     )
 
     text = models.TextField(blank=True)
+    content_type = models.ForeignKey(ContentType, on_delete=models.CASCADE, null=True, blank=True, related_name='+')
+    object_id = models.PositiveIntegerField(null=True, blank=True)
+    content_object = GenericForeignKey('content_type', 'object_id')
     level = models.CharField(max_length=9, db_index=True, default='INFO', choices=LOG_LEVEL_CHOICES)
 
     class Meta:
-        abstract = True
+        ordering = ('-created', )
         permissions = (
             ("read_log_entry", "Can read LogEntry"),
         )
+        verbose_name_plural = "Log Entries"
 
     def __str__(self):
         return '{0.created:%Y-%m-%d %H:%M:%S} | {0.level:>8s} | {0.text}'.format(self)
 
+    def clean_fields(self, **kwargs):
+        """
+        Clean fields, including the 'object_id' field
+        """
+        super().clean_fields(**kwargs)  # pylint: disable=no-member
+        # This check is here rather than in clean() because it must come after the built-in
+        # validation of the content_type field, and we should only check object_id if
+        # content_type has passed validation.
+        if self.content_type_id or self.object_id:
+            # If either of these fields are set, both should be:
+            if not self.content_type_id or not self.object_id:
+                raise ValidationError('LogEntry content_type and object_id must both be set or both be None.')
+            # Ensure that the object_id (primary key) is valid:
+            if not self.content_type.get_all_objects_for_this_type(pk=self.object_id).exists():
+                raise ValidationError({'object_id': 'Object attached to LogEntry has bad content_type or primary key'})
 
-class GeneralLogEntry(LogEntry):
-    """
-    Single log entry that isn't attached to a specific model, such as instances or servers
-    """
-    class Meta:
-        verbose_name_plural = "General Log Entries"
+    @staticmethod
+    def on_post_delete(sender, instance, **kwargs):
+        """
+        Whenever an object is deleted, check if there are corresponding log entries to delete.
+        """
+        if isinstance(instance, LogEntry) or instance._meta.app_label == 'migrations':
+            return  # Avoid pointless database queries when deleting log entries themselves or saving migration history
+        if not isinstance(instance.pk, int):
+            return  # Current LogEntry schema requires integer objects IDs, so we know this object isn't in the table
+        content_type = ContentType.objects.get_for_model(instance)
+        num_deleted, dummy = LogEntry.objects.filter(content_type=content_type, object_id=instance.pk).delete()
+        if num_deleted > 0:
+            logger.info(
+                'Deleted %d log entries for deleted %s instance with ID %d',
+                num_deleted, content_type.name, instance.pk
+            )
 
-
-class InstanceLogEntry(LogEntry):
-    """
-    Single log entry for instances
-    """
-    obj = models.ForeignKey(SingleVMOpenEdXInstance, related_name='log_entry_set')
-
-    class Meta:
-        verbose_name_plural = "Instance Log Entries"
-
-
-class ServerLogEntry(LogEntry):
-    """
-    Single log entry for servers
-    """
-    obj = models.ForeignKey(OpenStackServer, related_name='log_entry_set')
-
-    class Meta:
-        verbose_name_plural = "Server Log Entries"
+post_delete.connect(LogEntry.on_post_delete)

--- a/instance/tests/factories/pr.py
+++ b/instance/tests/factories/pr.py
@@ -33,7 +33,7 @@ class PRFactory(factory.Factory):
     """
     Factory for PR instances
     """
-    class Meta: #pylint: disable=missing-docstring
+    class Meta:
         model = github.PR
 
     number = factory.Sequence(int)

--- a/instance/tests/integration/factories/instance.py
+++ b/instance/tests/integration/factories/instance.py
@@ -36,7 +36,7 @@ class SingleVMOpenEdXInstanceFactory(DjangoModelFactory):
     """
     Factory for SingleVMOpenEdXInstance
     """
-    class Meta: #pylint: disable=missing-docstring
+    class Meta:
         model = SingleVMOpenEdXInstance
 
     sub_domain = factory.LazyAttribute(lambda o: '{}.integration'.format(str(uuid.uuid4())[:8]))

--- a/instance/tests/models/factories/instance.py
+++ b/instance/tests/models/factories/instance.py
@@ -34,7 +34,7 @@ class SingleVMOpenEdXInstanceFactory(DjangoModelFactory):
     """
     Factory for SingleVMOpenEdXInstance
     """
-    class Meta: #pylint: disable=missing-docstring
+    class Meta:
         model = SingleVMOpenEdXInstance
 
     sub_domain = factory.Sequence('instance{}.test'.format)

--- a/instance/tests/models/factories/server.py
+++ b/instance/tests/models/factories/server.py
@@ -96,7 +96,7 @@ class OpenStackServerFactory(DjangoModelFactory):
     """
     Factory for OpenStackServer
     """
-    class Meta: #pylint: disable=missing-docstring
+    class Meta:
         model = OpenStackServer
 
     instance = factory.SubFactory(SingleVMOpenEdXInstanceFactory)

--- a/pylintrc
+++ b/pylintrc
@@ -260,7 +260,7 @@ function-name-hint=[a-z_][a-z0-9_]{2,50}$
 
 # Regular expression which should only match function or class names that do
 # not require a docstring.
-no-docstring-rgx=__.*__
+no-docstring-rgx=(__.*__)|Meta
 
 # Minimum line length for functions/classes that require docstrings, shorter
 # ones are exempt.


### PR DESCRIPTION
This change combines `GeneralLogEntry`, `InstanceLogEntry`, `ServerLogEntry` into a single `LogEntry` class that uses [the contenttypes framework](https://docs.djangoproject.com/en/1.9/ref/contrib/contenttypes/) to hold a reference to the object that "owns" each log entry.

This change is required in order to accommodate the refactoring in #63. Specifically, there is a new intermediate class, `AppServer`, which would need a new table to hold its logs. And `AppServer` is abstract (since multi-table inheritance in django gets very messy), so there are potentially a number of concrete `AppServer` subclasses that we may have, and we can't expect to create a separate logging table for each one. Luckily, django already has a wonderful and longstanding solution to this problem, which is the contenttypes framework.

Pros:
* Code is way simpler
* Loading logs way faster/simpler
* Less load on app server
* Ignoring the migrations, this change resulting in a net reduction of 77 lines of code :)
* ~~Log entries not deleted when instance/server is deleted.~~
* Includes a fully reversible data migration, so this can be tested, deployed, or even reverted without any loss of data.
* The various existing logging test cases cover this code and pass with (almost) no modifications.

Cons:
* Foreign keys not enforced at DB level.
* ~~(As a result:) Log entries not deleted when instance/server is deleted. (Not sure if this is a pro or a con)~~

Also, while I was at it I fixed an occasional pylint warning about undocumented Meta classes: We don't need docstrings on Meta, and now pylint knows that, without inline disable comments