### PR TITLE
Run browser tests headlessly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,7 +101,7 @@ test_migrations_missing: clean
 
 test_browser: clean static_external
 	@echo -e "\nRunning browser tests..."
-	honcho -e .env.test run ./manage.py test --pattern=browser_*.py --noinput
+	xvfb-run --auto-servernum honcho -e .env.test run ./manage.py test --pattern=browser_*.py --noinput
 
 test_integration: clean
 ifneq ($(wildcard .env.integration),)


### PR DESCRIPTION
Because the way that Firefox pops up and steals focus for each test is really annoying.