### PR TITLE
Remove `--periodic` option from Huey (unavailable in the latest version)

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,4 +1,4 @@
 web: gunicorn opencraft.wsgi --log-file -
 websocket: python3 websocket.py
 worker: python3 manage.py run_huey --no-periodic
-periodic: python3 manage.py run_huey --periodic --workers=0
+periodic: python3 manage.py run_huey --workers=0


### PR DESCRIPTION
This was preivously a no-op option (since this is the default), but kept in the command-line for clarity. The latest version of Huey removed the command altogether, so we do too.

@bradenmacdonald @smarnach 