### PR TITLE
Add factory functions for creating sandbox and production instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ flavor:
 
 ### Open edX specific settings
 
-* `DEFAULT_OPENEDX_RELEASE` Set this to a release tag like 
+* `DEFAULT_OPENEDX_RELEASE` Set this to a release tag like
   `named-release/dogwood` to specify the default release of Open edX to use.
   This setting becomes the default value for `edx_platform_version`,
   `forum_version`, `notifier_version`, `xqueue_version`, and `certs_version` so
@@ -252,6 +252,9 @@ flavor:
   not set, the value of `DEFAULT_OPENEDX_RELEASE` will be used.
 * `DEFAULT_FORK`: The fork of `edx-platform` to use by default. Defaults to the
   main repository, `edx/edx-platform`.
+* `OPENEDX_RELEASE_STABLE_REF` Set this to a tag or branch for a stable
+  Open edX release. It is used as a default value for `configuration_version`
+  and `openedx_release` fields when creating production instances.
 
 Migrations
 ----------
@@ -397,7 +400,43 @@ Note: You need to match the above format exactly.
 ### Manual provisioning
 
 If you want to create an instance outside of a GitHub pull request, you can do
-so from the shell:
+so from the shell. There are two options:
+
+**Factory methods**
+
+OpenCraft IM provides two factory methods for creating instances:
+
+```python
+from instance.factories import instance_factory, production_instance_factory
+
+# Creating an instance with defaults appropriate for sandboxes:
+instance = instance_factory(name="Sandbox instance", sub_domain="sandbox")
+
+# Creating an instance with defaults appropriate for production:
+production_instance = production_instance_factory(name="Production instance", sub_domain="production")
+```
+
+The only mandatory keyword argument for both functions is `sub_domain`.
+You can use additional keyword arguments to pass in non-default values
+for any field that is defined on the `OpenEdXInstance` model.
+Since both functions return a newly created instance in the form of an
+`OpenEdXInstance` object, you can also customize field values later on:
+
+```python
+instance.email = 'myname@opencraft.com'
+instance.configuration_version = 'named-release/dogwood'
+instance.save()
+```
+
+If you pass custom `configuration_extra_settings` to `production_instance_factory`,
+they will be merged with the settings in [prod-vars.yml](https://github.com/open-craft/opencraft/blob/master/instance/templates/instance/ansible/prod-vars.yml).
+Settings that you pass in will take precedence over settings in prod-vars.yml,
+that is, if a variable is present in both `configuration_extra_settings` and prod-vars.yml,
+the instance manager will use the value from `configuration_extra_settings` for it.
+
+**Django API**
+
+You can also use the Django API to create an instance:
 
 ```python
 from instance.models.openedx_instance import OpenEdXInstance

--- a/README.md
+++ b/README.md
@@ -463,16 +463,6 @@ AppServers and their virtual machines, run:
 instance.delete()
 ```
 
-You can use the same approach for creating, reprovisioning, and deleting
-production instances, but you'll need to work with a different model:
-
-```python
-from instance.models.openedx_instance import OpenEdXProductionInstance
-from instance.tasks import provision_instance
-
-instance = SingleVMOpenEdXInstance.objects.create(...)
-```
-
 
 manage.py
 ---------

--- a/README.md
+++ b/README.md
@@ -463,6 +463,16 @@ AppServers and their virtual machines, run:
 instance.delete()
 ```
 
+You can use the same approach for creating, reprovisioning, and deleting
+production instances, but you'll need to work with a different model:
+
+```python
+from instance.models.openedx_instance import OpenEdXProductionInstance
+from instance.tasks import provision_instance
+
+instance = SingleVMOpenEdXInstance.objects.create(...)
+```
+
 
 manage.py
 ---------

--- a/instance/factories.py
+++ b/instance/factories.py
@@ -70,8 +70,13 @@ def instance_factory(**kwargs):
     # Ensure caller provided required arguments
     assert "sub_domain" in kwargs
 
+    # Ensure instance uses ephemeral databases by default,
+    # irrespective of current value of INSTANCE_EPHEMERAL_DATABASES setting
+    instance_kwargs = dict(use_ephemeral_databases=True)
+    instance_kwargs.update(kwargs)
+
     # Create instance
-    instance = OpenEdXInstance.objects.create(**kwargs)
+    instance = OpenEdXInstance.objects.create(**instance_kwargs)
     return instance
 
 

--- a/instance/factories.py
+++ b/instance/factories.py
@@ -115,8 +115,8 @@ def production_instance_factory(**kwargs):
     extra_settings = ansible.yaml_merge(production_settings, configuration_extra_settings)
     instance_kwargs = dict(
         use_ephemeral_databases=False,
-        configuration_version=settings.LATEST_OPENEDX_RELEASE,
-        openedx_release=settings.LATEST_OPENEDX_RELEASE,
+        configuration_version=settings.OPENEDX_RELEASE_STABLE_REF,
+        openedx_release=settings.OPENEDX_RELEASE_STABLE_REF,
         configuration_extra_settings=extra_settings,
     )
     instance_kwargs.update(kwargs)

--- a/instance/factories.py
+++ b/instance/factories.py
@@ -1,0 +1,79 @@
+# -*- coding: utf-8 -*-
+#
+# OpenCraft -- tools to aid developing and hosting free software projects
+# Copyright (C) 2015-2016 OpenCraft <contact@opencraft.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+"""
+Instance app - Factory functions for creating instances
+"""
+
+# Imports #####################################################################
+
+from django.conf import settings
+from django.template import loader
+
+from instance.models.openedx_instance import OpenEdXInstance
+
+
+# Functions ###################################################################
+
+def instance_factory(**kwargs):
+    """
+    Factory function for creating instances.
+
+    Returns a newly created OpenEdXInstance.
+
+    Callers can use keyword arguments to pass in non-default values
+    for any field that is defined on the OpenEdXInstance model.
+
+    When called without any arguments, the instance that is returned
+    will have its fields set to default values that are appropriate
+    for *sandbox* instances.
+
+    To create an instance with default settings that are suitable for production,
+    use `production_instance_factory`.
+    """
+    return OpenEdXInstance.objects.create(**kwargs)
+
+
+def production_instance_factory(**kwargs):
+    """
+    Factory function for creating production instances.
+
+    Returns a newly created OpenEdXInstance.
+
+    Callers can use keyword arguments to pass in non-default values
+    for any field that is defined on the OpenEdXInstance model.
+
+    When called without any arguments, the instance that is returned
+    will have its fields set to default values that are appropriate
+    for *production* instances.
+
+    To create an instance with default settings that are suitable for sandboxes,
+    use `instance_factory`.
+    """
+    production_instance = OpenEdXInstance.objects.create(**kwargs)
+    if "use_ephemeral_databases" not in kwargs:
+        production_instance.use_ephemeral_databases = False
+    if "configuration_version" not in kwargs:
+        production_instance.configuration_version = settings.LATEST_OPENEDX_RELEASE
+    if "openedx_release" not in kwargs:
+        production_instance.openedx_release = settings.LATEST_OPENEDX_RELEASE
+    if "configuration_extra_settings" not in kwargs:
+        template = loader.get_template('instance/ansible/prod-vars.yml')
+        production_instance.configuration_extra_settings = template.render({})
+    production_instance.save()
+    return production_instance

--- a/instance/factories.py
+++ b/instance/factories.py
@@ -65,6 +65,9 @@ def production_instance_factory(**kwargs):
     To create an instance with default settings that are suitable for sandboxes,
     use `instance_factory`.
     """
+    # NOTE: The long-term goal is to eliminate differences between sandboxes
+    # and production instances, and for this function to disappear.
+    # Please do not add behavior that is specific to production instances here.
     production_instance = OpenEdXInstance.objects.create(**kwargs)
     if "use_ephemeral_databases" not in kwargs:
         production_instance.use_ephemeral_databases = False

--- a/instance/factories.py
+++ b/instance/factories.py
@@ -39,14 +39,18 @@ def instance_factory(**kwargs):
     Callers can use keyword arguments to pass in non-default values
     for any field that is defined on the OpenEdXInstance model.
 
-    When called without any arguments, the instance that is returned
+    The only mandatory argument is `sub_domain`.
+
+    When called without any additional arguments, the instance that is returned
     will have its fields set to default values that are appropriate
     for *sandbox* instances.
 
     To create an instance with default settings that are suitable for production,
     use `production_instance_factory`.
     """
-    return OpenEdXInstance.objects.create(**kwargs)
+    assert "sub_domain" in kwargs
+    instance = OpenEdXInstance.objects.create(**kwargs)
+    return instance
 
 
 def production_instance_factory(**kwargs):
@@ -58,7 +62,9 @@ def production_instance_factory(**kwargs):
     Callers can use keyword arguments to pass in non-default values
     for any field that is defined on the OpenEdXInstance model.
 
-    When called without any arguments, the instance that is returned
+    The only mandatory argument is `sub_domain`.
+
+    When called without any additional arguments, the instance that is returned
     will have its fields set to default values that are appropriate
     for *production* instances.
 
@@ -68,7 +74,8 @@ def production_instance_factory(**kwargs):
     # NOTE: The long-term goal is to eliminate differences between sandboxes
     # and production instances, and for this function to disappear.
     # Please do not add behavior that is specific to production instances here.
-    production_instance = OpenEdXInstance.objects.create(**kwargs)
+    assert "sub_domain" in kwargs
+    production_instance = OpenEdXInstance(**kwargs)
     if "use_ephemeral_databases" not in kwargs:
         production_instance.use_ephemeral_databases = False
     if "configuration_version" not in kwargs:

--- a/instance/models/mixins/openedx_database.py
+++ b/instance/models/mixins/openedx_database.py
@@ -75,23 +75,16 @@ class OpenEdXDatabaseMixin(MySQLInstanceMixin, MongoDBInstanceMixin):
         """
         return [self.mongo_database_name, self.forum_database_name]
 
-    def provision_mysql(self):
+    def set_field_defaults(self):
         """
-        Set mysql credentials and provision the database.
+        Set default values for mysql and mongo credentials.
         """
         if not self.mysql_provisioned:
             self.mysql_user = get_random_string(length=16, allowed_chars=string.ascii_lowercase)
             self.mysql_pass = get_random_string(length=32)
-        return super().provision_mysql()
-
-    def provision_mongo(self):
-        """
-        Set mongo credentials and provision the database.
-        """
         if not self.mongo_provisioned:
             self.mongo_user = get_random_string(length=16, allowed_chars=string.ascii_lowercase)
             self.mongo_pass = get_random_string(length=32)
-        return super().provision_mongo()
 
     def get_database_settings(self):
         """

--- a/instance/models/mixins/openedx_database.py
+++ b/instance/models/mixins/openedx_database.py
@@ -78,14 +78,19 @@ class OpenEdXDatabaseMixin(MySQLInstanceMixin, MongoDBInstanceMixin):
     def set_field_defaults(self):
         """
         Set default values for mysql and mongo credentials.
+
+        Don't change existing values on subsequent calls.
+
+        Credentials are only used for persistent databases (cf. get_database_settings).
+        We generate them for all instances to ensure that app servers can be spawned successfully
+        even if an instance is edited to change 'use_ephemeral_databases' from True to False.
         """
-        if not self.use_ephemeral_databases:
-            if not self.mysql_provisioned:
-                self.mysql_user = get_random_string(length=16, allowed_chars=string.ascii_lowercase)
-                self.mysql_pass = get_random_string(length=32)
-            if not self.mongo_provisioned:
-                self.mongo_user = get_random_string(length=16, allowed_chars=string.ascii_lowercase)
-                self.mongo_pass = get_random_string(length=32)
+        if not self.mysql_user:
+            self.mysql_user = get_random_string(length=16, allowed_chars=string.ascii_lowercase)
+            self.mysql_pass = get_random_string(length=32)
+        if not self.mongo_user:
+            self.mongo_user = get_random_string(length=16, allowed_chars=string.ascii_lowercase)
+            self.mongo_pass = get_random_string(length=32)
 
     def get_database_settings(self):
         """

--- a/instance/models/mixins/openedx_database.py
+++ b/instance/models/mixins/openedx_database.py
@@ -79,12 +79,13 @@ class OpenEdXDatabaseMixin(MySQLInstanceMixin, MongoDBInstanceMixin):
         """
         Set default values for mysql and mongo credentials.
         """
-        if not self.mysql_provisioned:
-            self.mysql_user = get_random_string(length=16, allowed_chars=string.ascii_lowercase)
-            self.mysql_pass = get_random_string(length=32)
-        if not self.mongo_provisioned:
-            self.mongo_user = get_random_string(length=16, allowed_chars=string.ascii_lowercase)
-            self.mongo_pass = get_random_string(length=32)
+        if not self.use_ephemeral_databases:
+            if not self.mysql_provisioned:
+                self.mysql_user = get_random_string(length=16, allowed_chars=string.ascii_lowercase)
+                self.mysql_pass = get_random_string(length=32)
+            if not self.mongo_provisioned:
+                self.mongo_user = get_random_string(length=16, allowed_chars=string.ascii_lowercase)
+                self.mongo_pass = get_random_string(length=32)
 
     def get_database_settings(self):
         """

--- a/instance/models/mixins/openedx_storage.py
+++ b/instance/models/mixins/openedx_storage.py
@@ -57,8 +57,14 @@ class OpenEdXStorageMixin(SwiftContainerInstanceMixin):
     def set_field_defaults(self):
         """
         Set default values for Swift credentials.
+
+        Don't change existing values on subsequent calls.
+
+        Credentials are only used for persistent databases (cf. get_storage_settings).
+        We generate them for all instances to ensure that app servers can be spawned successfully
+        even if an instance is edited to change 'use_ephemeral_databases' from True to False.
         """
-        if not self.use_ephemeral_databases and settings.SWIFT_ENABLE and not self.swift_provisioned:
+        if settings.SWIFT_ENABLE and not self.swift_openstack_user:
             # TODO: Figure out a way to use separate credentials for each instance.  Access control
             # on Swift containers is granted to users, and there doesn't seem to be a way to create
             # Keystone users in OpenStack public clouds.

--- a/instance/models/mixins/openedx_storage.py
+++ b/instance/models/mixins/openedx_storage.py
@@ -54,9 +54,9 @@ class OpenEdXStorageMixin(SwiftContainerInstanceMixin):
         """
         return [self.swift_container_name]
 
-    def provision_swift(self):
+    def set_field_defaults(self):
         """
-        Set Swift credentials and create the Swift container.
+        Set default values for Swift credentials.
         """
         if settings.SWIFT_ENABLE and not self.swift_provisioned:
             # TODO: Figure out a way to use separate credentials for each instance.  Access control
@@ -67,7 +67,6 @@ class OpenEdXStorageMixin(SwiftContainerInstanceMixin):
             self.swift_openstack_tenant = settings.SWIFT_OPENSTACK_TENANT
             self.swift_openstack_auth_url = settings.SWIFT_OPENSTACK_AUTH_URL
             self.swift_openstack_region = settings.SWIFT_OPENSTACK_REGION
-        return super().provision_swift()
 
     def get_storage_settings(self):
         """

--- a/instance/models/mixins/openedx_storage.py
+++ b/instance/models/mixins/openedx_storage.py
@@ -58,7 +58,7 @@ class OpenEdXStorageMixin(SwiftContainerInstanceMixin):
         """
         Set default values for Swift credentials.
         """
-        if settings.SWIFT_ENABLE and not self.swift_provisioned:
+        if not self.use_ephemeral_databases and settings.SWIFT_ENABLE and not self.swift_provisioned:
             # TODO: Figure out a way to use separate credentials for each instance.  Access control
             # on Swift containers is granted to users, and there doesn't seem to be a way to create
             # Keystone users in OpenStack public clouds.

--- a/instance/models/openedx_instance.py
+++ b/instance/models/openedx_instance.py
@@ -133,6 +133,7 @@ class OpenEdXInstance(Instance, OpenEdXAppConfiguration, OpenEdXDatabaseMixin, O
         """
         Set default values.
         """
+        # Main settings
         if not self.openedx_release:
             self.openedx_release = settings.DEFAULT_OPENEDX_RELEASE
         if not self.configuration_source_repo_url:
@@ -143,6 +144,14 @@ class OpenEdXInstance(Instance, OpenEdXAppConfiguration, OpenEdXDatabaseMixin, O
             self.edx_platform_repository_url = DEFAULT_EDX_PLATFORM_REPO_URL
         if not self.edx_platform_commit:
             self.edx_platform_commit = self.openedx_release
+
+        # Database settings
+        OpenEdXDatabaseMixin.set_field_defaults(self)
+
+        # Storage settings
+        OpenEdXStorageMixin.set_field_defaults(self)
+
+        # Other settings
         super().set_field_defaults()
 
     def save(self, **kwargs):

--- a/instance/models/openedx_instance.py
+++ b/instance/models/openedx_instance.py
@@ -129,6 +129,22 @@ class OpenEdXInstance(Instance, OpenEdXAppConfiguration, OpenEdXDatabaseMixin, O
         escaped = ''.join(char for char in name if char in allowed)
         return truncate_name(escaped, length=64)
 
+    def set_field_defaults(self):
+        """
+        Set default values.
+        """
+        if not self.openedx_release:
+            self.openedx_release = settings.DEFAULT_OPENEDX_RELEASE
+        if not self.configuration_source_repo_url:
+            self.configuration_source_repo_url = settings.DEFAULT_CONFIGURATION_REPO_URL
+        if not self.configuration_version:
+            self.configuration_version = settings.DEFAULT_CONFIGURATION_VERSION
+        if not self.edx_platform_repository_url:
+            self.edx_platform_repository_url = DEFAULT_EDX_PLATFORM_REPO_URL
+        if not self.edx_platform_commit:
+            self.edx_platform_commit = self.openedx_release
+        super().set_field_defaults()
+
     def save(self, **kwargs):
         """
         Set default values before saving the instance.
@@ -222,22 +238,6 @@ class OpenEdXInstance(Instance, OpenEdXAppConfiguration, OpenEdXDatabaseMixin, O
                 **instance_config
             )
         return app_server
-
-    def set_field_defaults(self):
-        """
-        Set default values.
-        """
-        if not self.openedx_release:
-            self.openedx_release = settings.DEFAULT_OPENEDX_RELEASE
-        if not self.configuration_source_repo_url:
-            self.configuration_source_repo_url = settings.DEFAULT_CONFIGURATION_REPO_URL
-        if not self.configuration_version:
-            self.configuration_version = settings.DEFAULT_CONFIGURATION_VERSION
-        if not self.edx_platform_repository_url:
-            self.edx_platform_repository_url = DEFAULT_EDX_PLATFORM_REPO_URL
-        if not self.edx_platform_commit:
-            self.edx_platform_commit = self.openedx_release
-        super().set_field_defaults()
 
 
 post_save.connect(Instance.on_post_save, sender=OpenEdXInstance)

--- a/instance/models/openedx_instance.py
+++ b/instance/models/openedx_instance.py
@@ -25,6 +25,7 @@ from django.conf import settings
 from django.db import models, transaction
 from django.db.backends.utils import truncate_name
 from django.db.models.signals import post_save
+from django.template import loader
 
 from instance.gandi import GandiAPI
 from instance.logging import log_exception
@@ -129,6 +130,12 @@ class OpenEdXInstance(Instance, OpenEdXAppConfiguration, OpenEdXDatabaseMixin, O
         escaped = ''.join(char for char in name if char in allowed)
         return truncate_name(escaped, length=64)
 
+    def get_extra_settings(self):
+        """
+        Get configuration_extra_settings to pass to a new AppServer
+        """
+        return ""
+
     def save(self, **kwargs):
         """
         Set default values before saving the instance.
@@ -219,6 +226,7 @@ class OpenEdXInstance(Instance, OpenEdXAppConfiguration, OpenEdXDatabaseMixin, O
                 # Copy the current value of each setting into the AppServer, preserving it permanently:
                 configuration_database_settings=self.get_database_settings(),
                 configuration_storage_settings=self.get_storage_settings(),
+                configuration_extra_settings=self.get_extra_settings(),
                 **instance_config
             )
         return app_server
@@ -238,5 +246,36 @@ class OpenEdXInstance(Instance, OpenEdXAppConfiguration, OpenEdXDatabaseMixin, O
         if not self.edx_platform_commit:
             self.edx_platform_commit = self.openedx_release
         super().set_field_defaults()
+
+
+class OpenEdXProductionInstance(OpenEdXInstance):
+    """
+    OpenEdXProductionInstance: An OpenEdXInstance using production settings
+    """
+
+    LATEST_RELEASE = "named-release/dogwood.rc"
+
+    def save(self, **kwargs):
+        """
+        Set default field values specific to production instances before saving.
+        """
+        # Ansible-specific settings:
+        self.configuration_version = self.LATEST_RELEASE
+        self.openedx_release = self.LATEST_RELEASE
+        # Also set edx_platform_commit in case behavior of "set_field_defaults" changes
+        self.edx_platform_commit = self.LATEST_RELEASE
+
+        # Misc settings:
+        self.use_ephemeral_databases = False
+
+        super().save(**kwargs)
+
+    def get_extra_settings(self):
+        """
+        Get configuration_extra_settings to pass to a new AppServer
+        """
+        template = loader.get_template('instance/ansible/prod-vars.yml')
+        return template.render({})
+
 
 post_save.connect(Instance.on_post_save, sender=OpenEdXInstance)

--- a/instance/templates/instance/ansible/prod-vars.yml
+++ b/instance/templates/instance/ansible/prod-vars.yml
@@ -1,0 +1,3 @@
+# Don't create default users on production instances
+DEMO_CREATE_STAFF_USER: false
+demo_test_users: []

--- a/instance/tests/models/test_openedx_instance.py
+++ b/instance/tests/models/test_openedx_instance.py
@@ -49,6 +49,7 @@ class OpenEdXInstanceTestCase(TestCase):
     """
     Test cases for OpenEdXInstance models
     """
+    @override_settings(INSTANCE_EPHEMERAL_DATABASES=True)
     def test_create_defaults(self):
         """
         Create an instance without specifying additional fields,

--- a/instance/tests/models/test_openedx_instance.py
+++ b/instance/tests/models/test_openedx_instance.py
@@ -25,6 +25,7 @@ OpenEdXInstance model - Tests
 from unittest.mock import call, patch, Mock
 
 import ddt
+from django.conf import settings
 from django.test import override_settings
 import yaml
 
@@ -48,7 +49,6 @@ class OpenEdXInstanceTestCase(TestCase):
     """
     Test cases for OpenEdXInstance models
     """
-    @override_settings(INSTANCE_EPHEMERAL_DATABASES=False)
     def test_create_defaults(self):
         """
         Create an instance without specifying additional fields,
@@ -65,6 +65,25 @@ class OpenEdXInstanceTestCase(TestCase):
         self.assertFalse(instance.swift_openstack_tenant)
         self.assertFalse(instance.swift_openstack_auth_url)
         self.assertFalse(instance.swift_openstack_region)
+        self.assertEqual(instance.github_admin_organization_name, '')
+
+    @override_settings(INSTANCE_EPHEMERAL_DATABASES=False)
+    def test_create_defaults_persistent_databases(self):
+        """
+        Create an instance without specifying additional fields,
+        leaving it up to the create method to set them
+        """
+        instance = OpenEdXInstance.objects.create(sub_domain='create.defaults')
+        self.assertEqual(instance.name, 'Instance')
+        self.assertTrue(instance.mysql_user)
+        self.assertTrue(instance.mysql_pass)
+        self.assertTrue(instance.mongo_user)
+        self.assertTrue(instance.mongo_pass)
+        self.assertEqual(instance.swift_openstack_user, settings.SWIFT_OPENSTACK_USER)
+        self.assertEqual(instance.swift_openstack_password, settings.SWIFT_OPENSTACK_PASSWORD)
+        self.assertEqual(instance.swift_openstack_tenant, settings.SWIFT_OPENSTACK_TENANT)
+        self.assertEqual(instance.swift_openstack_auth_url, settings.SWIFT_OPENSTACK_AUTH_URL)
+        self.assertEqual(instance.swift_openstack_region, settings.SWIFT_OPENSTACK_REGION)
         self.assertEqual(instance.github_admin_organization_name, '')
 
     def test_id_different_from_ref_id(self):

--- a/instance/tests/test_factories.py
+++ b/instance/tests/test_factories.py
@@ -131,9 +131,7 @@ class FactoriesTestCase(TestCase):
 
             log_entries = LogEntry.objects.all()
             self.assertEqual(len(log_entries), 3)
-            self.assertEqual(log_entries[0].level, "WARNING")
+            self.assertTrue(all(log_entry.level == "WARNING" for log_entry in log_entries))
             self.assertIn("Adjust INSTANCE_MONGO_URL setting.", log_entries[0].text)
-            self.assertEqual(log_entries[1].level, "WARNING")
             self.assertIn("Adjust INSTANCE_MYSQL_URL setting.", log_entries[1].text)
-            self.assertEqual(log_entries[2].level, "WARNING")
             self.assertIn("Adjust SWIFT_ENABLE setting.", log_entries[2].text)

--- a/instance/tests/test_factories.py
+++ b/instance/tests/test_factories.py
@@ -1,0 +1,139 @@
+# -*- coding: utf-8 -*-
+#
+# OpenCraft -- tools to aid developing and hosting free software projects
+# Copyright (C) 2015-2016 OpenCraft <contact@opencraft.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+"""
+Factories module - Tests
+"""
+
+# Imports #####################################################################
+
+from unittest.mock import Mock, patch
+
+from django.conf import settings
+
+from instance.factories import instance_factory, production_instance_factory
+from instance.models.log_entry import LogEntry
+from instance.models.openedx_instance import OpenEdXInstance
+from instance.tests.base import TestCase
+
+
+# Tests #######################################################################
+
+class FactoriesTestCase(TestCase):
+    """
+    Test cases for functions in the factories module
+    """
+
+    CONFIGURATION_EXTRA_SETTINGS = "EXTRA_SETTINGS: true"
+    SANDBOX_DEFAULTS = {
+        "use_ephemeral_databases": True,
+        "configuration_version": settings.DEFAULT_CONFIGURATION_VERSION,
+        "openedx_release": settings.DEFAULT_OPENEDX_RELEASE,
+        "configuration_extra_settings": "",
+    }
+    PRODUCTION_DEFAULTS = {
+        "use_ephemeral_databases": False,
+        "configuration_version": settings.LATEST_OPENEDX_RELEASE,
+        "openedx_release": settings.LATEST_OPENEDX_RELEASE,
+        "configuration_extra_settings": CONFIGURATION_EXTRA_SETTINGS,
+    }
+
+    def _assert_field_values(
+            self,
+            instance,
+            sub_domain,
+            use_ephemeral_databases=SANDBOX_DEFAULTS["use_ephemeral_databases"],
+            configuration_version=SANDBOX_DEFAULTS["configuration_version"],
+            openedx_release=SANDBOX_DEFAULTS["openedx_release"],
+            configuration_extra_settings=SANDBOX_DEFAULTS["configuration_extra_settings"]
+    ):
+        """
+        Assert that field values of `instance` match expected values
+        """
+        self.assertEqual(instance.sub_domain, sub_domain)
+        self.assertEqual(instance.use_ephemeral_databases, use_ephemeral_databases)
+        self.assertEqual(instance.configuration_version, configuration_version)
+        self.assertEqual(instance.openedx_release, openedx_release)
+        self.assertEqual(instance.configuration_extra_settings, configuration_extra_settings)
+
+    def test_instance_factory(self):
+        """
+        Test that factory function for creating instances produces expected results
+        """
+        # Create instance without changing defaults
+        sub_domain = "sandbox-with-defaults"
+        instance = instance_factory(sub_domain=sub_domain)
+        instance = OpenEdXInstance.objects.get(pk=instance.pk)
+        self._assert_field_values(instance, sub_domain)
+
+        # Create instance with custom field values
+        sub_domain = "sandbox-customized"
+        custom_instance = instance_factory(sub_domain=sub_domain, **self.PRODUCTION_DEFAULTS)
+        custom_instance = OpenEdXInstance.objects.get(pk=custom_instance.pk)
+        self._assert_field_values(custom_instance, sub_domain, **self.PRODUCTION_DEFAULTS)
+
+        # Calling factory without specifying "sub_domain" should result in an error
+        with self.assertRaises(AssertionError):
+            instance_factory()
+
+    @patch("instance.factories.loader")
+    def test_production_instance_factory(self, patched_loader):
+        """
+        Test that factory function for creating production instances produces expected results
+        """
+        mock_template = Mock()
+        mock_template.render.return_value = self.CONFIGURATION_EXTRA_SETTINGS
+        patched_loader.get_template.return_value = mock_template
+
+        # Create instance without changing defaults
+        sub_domain = "production-instance-with-defaults"
+        instance = production_instance_factory(sub_domain=sub_domain)
+        instance = OpenEdXInstance.objects.get(pk=instance.pk)
+        self._assert_field_values(instance, sub_domain, **self.PRODUCTION_DEFAULTS)
+        patched_loader.get_template.assert_called_once_with("instance/ansible/prod-vars.yml")
+        mock_template.render.assert_called_once_with({})
+
+        # Create instance with custom field values
+        sub_domain = "production-instance-customized"
+        custom_instance = instance_factory(sub_domain=sub_domain, **self.SANDBOX_DEFAULTS)
+        custom_instance = OpenEdXInstance.objects.get(pk=custom_instance.pk)
+        self._assert_field_values(custom_instance, sub_domain, **self.SANDBOX_DEFAULTS)
+
+        # Calling factory without specifying "sub_domain" should result in an error
+        with self.assertRaises(AssertionError):
+            production_instance_factory()
+
+        # Calling factory with settings that are problematic for production instances should produce warnings
+        with patch("instance.factories.settings") as patched_settings:
+            patched_settings.SWIFT_ENABLE = False
+            patched_settings.INSTANCE_MYSQL_URL = None
+            patched_settings.INSTANCE_MONGO_URL = None
+
+            # Ensure that validation passes for configuration_version:
+            patched_settings.LATEST_OPENEDX_RELEASE = settings.LATEST_OPENEDX_RELEASE
+
+            production_instance_factory(sub_domain="production-instance-doomed")
+
+            log_entries = LogEntry.objects.all()
+            self.assertEqual(len(log_entries), 3)
+            self.assertEqual(log_entries[0].level, "WARNING")
+            self.assertIn("Adjust INSTANCE_MONGO_URL setting.", log_entries[0].text)
+            self.assertEqual(log_entries[1].level, "WARNING")
+            self.assertIn("Adjust INSTANCE_MYSQL_URL setting.", log_entries[1].text)
+            self.assertEqual(log_entries[2].level, "WARNING")
+            self.assertIn("Adjust SWIFT_ENABLE setting.", log_entries[2].text)

--- a/instance/tests/test_factories.py
+++ b/instance/tests/test_factories.py
@@ -49,8 +49,8 @@ class FactoriesTestCase(TestCase):
     }
     PRODUCTION_DEFAULTS = {
         "use_ephemeral_databases": False,
-        "configuration_version": settings.LATEST_OPENEDX_RELEASE,
-        "openedx_release": settings.LATEST_OPENEDX_RELEASE,
+        "configuration_version": settings.OPENEDX_RELEASE_STABLE_REF,
+        "openedx_release": settings.OPENEDX_RELEASE_STABLE_REF,
         "configuration_extra_settings": CONFIGURATION_EXTRA_SETTINGS,
     }
 
@@ -141,7 +141,7 @@ class FactoriesTestCase(TestCase):
             patched_settings.INSTANCE_MONGO_URL = None
 
             # Ensure that validation passes for configuration_version:
-            patched_settings.LATEST_OPENEDX_RELEASE = settings.LATEST_OPENEDX_RELEASE
+            patched_settings.OPENEDX_RELEASE_STABLE_REF = settings.OPENEDX_RELEASE_STABLE_REF
 
             production_instance_factory(sub_domain="production-instance-doomed")
 

--- a/opencraft/settings.py
+++ b/opencraft/settings.py
@@ -295,9 +295,9 @@ DEFAULT_OPENEDX_RELEASE = env('DEFAULT_OPENEDX_RELEASE', default='master')
 # for provisioning Open edX app servers.
 DEFAULT_CONFIGURATION_VERSION = env('DEFAULT_CONFIGURATION_VERSION', default=DEFAULT_OPENEDX_RELEASE)
 
-# Git tag for latest Open edX release. Used as a default refspec for
+# Git ref for stable Open edX release. Used as a default refspec for
 # configuration, edx-platform, forum, notifier, xqueue, and certs when creating production instances.
-LATEST_OPENEDX_RELEASE = env('LATEST_OPENEDX_RELEASE', default='named-release/dogwood.rc')
+OPENEDX_RELEASE_STABLE_REF = env('OPENEDX_RELEASE_STABLE_REF', default='named-release/dogwood.rc')
 
 # Ansible #####################################################################
 

--- a/opencraft/settings.py
+++ b/opencraft/settings.py
@@ -295,6 +295,10 @@ DEFAULT_OPENEDX_RELEASE = env('DEFAULT_OPENEDX_RELEASE', default='master')
 # for provisioning Open edX app servers.
 DEFAULT_CONFIGURATION_VERSION = env('DEFAULT_CONFIGURATION_VERSION', default=DEFAULT_OPENEDX_RELEASE)
 
+# Git tag for latest Open edX release. Used as a default refspec for
+# configuration, edx-platform, forum, notifier, xqueue, and certs when creating production instances.
+LATEST_OPENEDX_RELEASE = env('LATEST_OPENEDX_RELEASE', default='named-release/dogwood.rc')
+
 # Ansible #####################################################################
 
 # Ansible requires a Python 2 interpreter


### PR DESCRIPTION
cf. [OC-1554](https://tasks.opencraft.com/browse/OC-1554).

**Changes**

Adds two factory functions for creating instances from the shell:

- `instance_factory` creates instances with settings that are appropriate for sandboxes.
- `production_instance_factory` creates instances with settings that are appropriate for production instances.

The only mandatory argument for each function is `sub_domain`. Defaults for other fields can be overridden by passing additional keyword arguments to the functions. If necessary it is also possible to modify instances after they have been created by the functions (before starting the provisioning process).

**Test instructions**

1. Start the shell via `make shell`.

2. Import the new functions via:

   ```python
   from instance.factories import instance_factory, production_instance_factory
   ```

3. Create a new sandbox instance via:

   ```python
   sandbox = instance_factory(sub_domain="hello.sandbox")
   ```

4. Check that `sandbox` has 
   * `use_ephemeral_databases` set to `True`
   * `configuration_version` set to `master`
   * `openedx_release` set to `master`
   * `configuration_extra_settings` set to `""`

5. Create a new production instance via:

   ```python
   production_instance = production_instance_factory(sub_domain="hello.production")
   ```

6. Check that `production_instance` has 
   * `use_ephemeral_databases` set to `False`
   * `configuration_version` set to `named-releases/dogwood.rc`
   * `openedx_release` set to `named-releases/dogwood.rc`
   * `configuration_extra_settings` set to the contents of [prod-vars.yml](https://github.com/open-craft/opencraft/blob/production-instance/instance/templates/instance/ansible/prod-vars.yml)

7. Create a few more instances, passing in non-default values for some fields. Check that relevant fields are set to correct values on the resulting instances.
