### PR TITLE
Eliminate warnings

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -6,6 +6,13 @@ machine:
 dependencies:
   pre:
     - pip install --upgrade pip
+    - pip install --upgrade virtualenv
+    # Update python to latest 2.6.* release from the deadsnakes PPA.
+    # Ubuntu 14.04 which we currently use on CircleCI comes with 2.7.6 preinstalled,
+    # which does not support SNI. When CircleCI starts providing Ubuntu 16.04 images,
+    # this won't be needed anymore.
+    - sudo add-apt-repository ppa:fkrull/deadsnakes-python2.7 -y
+    - sudo apt-get update; sudo apt-get install python2.7 python2.7-dev
   override:
     - pip install -r requirements.txt
 test:

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,8 @@
 machine:
   python:
     version: 3.5.1
+  services:
+    - redis
 dependencies:
   pre:
     - pip install --upgrade pip

--- a/instance/models/mixins/database.py
+++ b/instance/models/mixins/database.py
@@ -77,8 +77,8 @@ class MySQLInstanceMixin(models.Model):
                 # driver doesn't escape it properly. Se we escape it here instead
                 database_name = connection.escape_string(database).decode()
                 cursor.execute('CREATE DATABASE `{0}` DEFAULT CHARACTER SET utf8'.format(database_name))
-                cursor.execute('GRANT ALL ON `{0}`.* TO %s IDENTIFIED BY %s'.format(database_name),
-                               (self.mysql_user, self.mysql_pass))
+                cursor.execute('CREATE USER %s IDENTIFIED BY %s', (self.mysql_user, self.mysql_pass,))
+                cursor.execute('GRANT ALL ON `{0}`.* TO %s'.format(database_name), (self.mysql_user,))
             self.mysql_provisioned = True
             self.save()
 

--- a/instance/tests/base.py
+++ b/instance/tests/base.py
@@ -25,11 +25,9 @@ Tests - Base Class & Utils
 import json
 import os.path
 import re
-from unittest.mock import Mock
 
 from django.contrib.auth.models import User
 from django.test import Client, TestCase as DjangoTestCase
-import huey
 
 
 # Functions ###################################################################
@@ -90,16 +88,6 @@ class TestCase(DjangoTestCase):
     def setUp(self):
         super().setUp()
         self.maxDiff = None #pylint: disable=invalid-name
-
-        # Don't close tasks DB connections in tests, this conflicts with the atomic transaction blocks
-        # used by the test runner to isolate DB operations from each test
-        self.orig_db_connection_close = huey.contrib.djhuey.connection.close
-        self.mock_db_connection_close = Mock()
-        huey.contrib.djhuey.connection.close = self.mock_db_connection_close
-
-    def tearDown(self):
-        huey.contrib.djhuey.connection.close = self.orig_db_connection_close
-        super().tearDown()
 
 
 class WithUserTestCase(DjangoTestCase):

--- a/instance/tests/models/test_instance_mixins.py
+++ b/instance/tests/models/test_instance_mixins.py
@@ -381,12 +381,14 @@ class MySQLInstanceTestCase(TestCase):
         databases = subprocess.check_output("mysql -u root -e 'SHOW DATABASES'", shell=True).decode()
         for database in self.instance.mysql_database_names:
             self.assertIn(database, databases)
-            mysql_cmd = "mysql -u {user} --password={password} -e 'SHOW TABLES' {db_name}".format(
+            # Pass password using MYSQ_PWD environment variable rather than the --password
+            # parameter so that mysql command doesn't print a security warning.
+            env = {'MYSQL_PWD': self.instance.mysql_pass}
+            mysql_cmd = "mysql -u {user} -e 'SHOW TABLES' {db_name}".format(
                 user=self.instance.mysql_user,
-                password=self.instance.mysql_pass,
                 db_name=database,
             )
-            tables = subprocess.call(mysql_cmd, shell=True)
+            tables = subprocess.call(mysql_cmd, shell=True, env=env)
             self.assertEqual(tables, 0)
 
     def test_provision_mysql(self):

--- a/instance/tests/test_tasks.py
+++ b/instance/tests/test_tasks.py
@@ -50,7 +50,6 @@ class TasksTestCase(TestCase):
         tasks.provision_instance(instance.pk)
         self.assertEqual(mock_instance_provision.call_count, 1)
         self.assertEqual(mock_instance_provision.mock_calls[0][1][0].pk, instance.pk)
-        self.mock_db_connection_close.assert_called_once_with()
 
     @patch('instance.models.mixins.version_control.github.get_commit_id_from_ref')
     @patch('instance.tasks.provision_instance')
@@ -97,4 +96,3 @@ class TasksTestCase(TestCase):
         self.assertEqual(
             instance.name,
             'PR#234: Watched PR title which ... (bradenmacdonald) - fork/watch-branch (7777777)')
-        self.mock_db_connection_close.assert_called_once_with()

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ django-appconf==1.0.2
 django-compressor==2.0
 django-debug-toolbar==1.4
 django-environ==0.4.0
-django-extensions==1.6.1
+django-extensions==1.6.6
 django-filter==0.13.0
 django-grappelli==2.8.1
 django-libsass==0.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,8 @@ debtcollector==1.3.0
 decorator==4.0.9
 dj-static==0.0.6
 Django==1.9.5
-django-angular==0.8.2
+# Can be replaced with django-angular==0.8.3 when released to PyPI.
+git+https://github.com/jrief/django-angular.git@c21d7f013fa5108ba7ecc3c7a33de0251aafc604#egg=django-angular==0.8.3
 django-appconf==1.0.2
 django-compressor==2.0
 django-debug-toolbar==1.4
@@ -39,7 +40,8 @@ GitPython==2.0.0
 glob2==0.4.1
 gunicorn==19.4.5
 honcho==0.7.1
-huey==1.1.1
+# Can be replaced with huey==1.1.2 when released to PyPI.
+git+https://github.com/coleifer/huey.git@7fb322880a16e87c659c38746e59d66c8e5f3db7#egg=huey==1.1.2
 ipdb==0.9.3
 ipython==4.2.0
 ipython-genutils==0.1.0


### PR DESCRIPTION
Removes the following warnings:

**djangular_tags deprecation** (`make test_unit` or `make rundev`)
```
/home/vagrant/.virtualenvs/opencraft/lib/python3.5/site-packages/djng/templatetags/djangular_tags.py:4: UserWarning: Templatetags `djangular_tags` have been renamed to `djng_tags`.
  "Templatetags `djangular_tags` have been renamed to `djng_tags`."
```

**MySQL auth warnings** (`make test_unit`):

```
/home/vagrant/opencraft/instance/models/mixins/database.py:68: Warning: Using GRANT for creating new user is deprecated and will be removed in future release. Create new user with CREATE USER statement.
  (self.mysql_user, self.mysql_pass))

mysql: [Warning] Using a password on the command line interface can be insecure.
.mysql: [Warning] Using a password on the command line interface can be insecure.
..mysql: [Warning] Using a password on the command line interface can be insecure.
```

**OptionParser -> ArgumentParser warning** (`make rundev`)

```
09:58:17 worker.1    | /home/vagrant/.virtualenvs/opencraft/lib/python3.5/site-packages/django/core/management/__init__.py:345: RemovedInDjango110Warning: OptionParser usage for Django management commands is deprecated, use ArgumentParser instead
09:58:17 worker.1    |   self.fetch_command(subcommand).run_from_argv(self.argv)
```

**NoArgsCommand -> BaseCommand** (`make shell`)

```
/home/vagrant/.virtualenvs/opencraft/lib/python3.5/site-packages/django/core/management/base.py:577: RemovedInDjango110Warning: NoArgsCommand class is deprecated and will be removed in Django 1.10. Use BaseCommand instead, which takes no arguments by default.
  RemovedInDjango110Warning
```