### PR TITLE
Fix flaky pylint warning

### DIFF
--- a/betatest/tests/test_views.py
+++ b/betatest/tests/test_views.py
@@ -109,8 +109,8 @@ class BetaTestApplicationViewTestMixin:
         for email_address in (user.email, application.public_contact_email):
             email = EmailAddress.objects.get(email=email_address) #pylint: disable=no-member
             self.assertEqual(email.is_confirmed, False)
-        self.assertEqual(len(mail.outbox), 2)
-        for verification_email in mail.outbox:
+        self.assertEqual(len(mail.outbox), 2)  # fix flaky pylint: disable=no-member,useless-suppression
+        for verification_email in mail.outbox:  # fix flaky pylint: disable=no-member,useless-suppression
             verify_url = re.search(r'https?://[^\s]+',
                                    verification_email.body).group(0)
             self.client.get(verify_url)
@@ -130,7 +130,7 @@ class BetaTestApplicationViewTestMixin:
             self.assertEqual(self.get_error_messages(response),
                              expected_errors)
         self.assertEqual(BetaTestApplication.objects.count(), original_count)
-        self.assertEqual(len(mail.outbox), 0)
+        self.assertEqual(len(mail.outbox), 0)  # fix flaky pylint: disable=no-member,useless-suppression
 
     def test_valid_application(self):
         """


### PR DESCRIPTION
I am getting flaky pylint warnings with the django mail `.outbox` property. I'm not sure why it sometimes is a warning and sometimes not, but I think because Django creates that attribute dynamically, it sometimes exists and sometimes doesn't.

What I see ([example build](https://circleci.com/gh/open-craft/opencraft/713)):
```
betatest/tests/test_views.py
  Line: 112
    pylint: no-member / Module 'django.core.mail' has no 'outbox' member (col 29)
  Line: 113
    pylint: no-member / Module 'django.core.mail' has no 'outbox' member (col 34)
  Line: 133
    pylint: no-member / Module 'django.core.mail' has no 'outbox' member (col 29)`
```

But if I put a `disable=no-member`, then it sometimes works but sometimes I get:

```
  Line: 112
    pylint: useless-suppression / Useless suppression of 'no-member'
  Line: 113
    pylint: useless-suppression / Useless suppression of 'no-member'
  Line: 133
    pylint: useless-suppression / Useless suppression of 'no-member'
```

So this is the only fix that seems to consistently work.