### PR TITLE
Run integration tests with credentials from environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,12 +104,15 @@ test_browser: clean static_external
 	honcho -e .env.test run ./manage.py test --pattern=browser_*.py --noinput
 
 test_integration: clean
-	@if [ -a .env.integration ] ; then \
-		echo -e "\nRunning integration tests..." ; \
-		honcho -e .env.integration run ./manage.py test --pattern=integration_*.py --noinput ; \
-	else \
-		echo -e "\nIntegration tests skipped (create a '.env.integration' file to run them)" ; \
-	fi
+ifneq ($(wildcard .env.integration),)
+	echo -e "\nRunning integration tests with credentials from .env.integration file..."
+	honcho -e .env.integration run ./manage.py test --pattern=integration_*.py --noinput
+else ifdef OPENSTACK_USER
+	echo -e "\nRunning integration tests with credentials from environment variables..."
+	./manage.py test --pattern=integration_*.py --noinput
+else
+	echo -e "\nIntegration tests skipped (create a '.env.integration' file to run them)"
+endif
 
 test_js: clean static_external
 	cd instance/tests/js && $(RUN_JS_TESTS)

--- a/bin/run-circleci-tests
+++ b/bin/run-circleci-tests
@@ -2,6 +2,8 @@
 
 set -e
 
+make install_system_dependencies
+
 case $CIRCLE_NODE_INDEX in
     0)
         make test

--- a/circle.yml
+++ b/circle.yml
@@ -3,6 +3,13 @@ machine:
     version: 3.5.1
   services:
     - redis
+  environment:
+    DEBUG: 'true'
+    DEFAULT_FORK: 'open-craft/edx-platform'
+    INSTANCE_EPHEMERAL_DATABASES: 'false'
+    TEST_RUNNER: 'opencraft.tests.utils.CircleCIParallelTestRunner'
+    WATCH_FORK: 'open-craft/edx-platform'
+    WATCH_ORGANIZATION: 'open-craft'
 dependencies:
   pre:
     - pip install --upgrade pip
@@ -17,6 +24,6 @@ dependencies:
     - pip install -r requirements.txt
 test:
   override:
-      - bin/run-circleci-tests:
-          timeout: 1800
-          parallel: true
+    - bin/run-circleci-tests:
+        timeout: 1800
+        parallel: true

--- a/instance/tests/models/test_instance.py
+++ b/instance/tests/models/test_instance.py
@@ -187,11 +187,12 @@ class SingleVMOpenEdXInstanceTestCase(TestCase):
         """
         mock_get_commit_id_from_ref.return_value = '9' * 40
         instance = SingleVMOpenEdXInstance.objects.create(sub_domain='create.defaults')
+        org, repo = settings.DEFAULT_FORK.split('/')
         self.assertEqual(instance.status, Instance.Status.New)
-        self.assertEqual(instance.github_organization_name, 'edx')
-        self.assertEqual(instance.github_repository_name, 'edx-platform')
+        self.assertEqual(instance.github_organization_name, org)
+        self.assertEqual(instance.github_repository_name, repo)
         self.assertEqual(instance.commit_id, '9' * 40)
-        self.assertEqual(instance.name, 'edx/master (9999999)')
+        self.assertEqual(instance.name, '{org}/{branch} (9999999)'.format(org=org, branch=instance.branch_name))
         self.assertFalse(instance.mysql_user)
         self.assertFalse(instance.mysql_pass)
         self.assertFalse(instance.mongo_user)

--- a/instance/tests/models/test_instance_mixins.py
+++ b/instance/tests/models/test_instance_mixins.py
@@ -27,6 +27,7 @@ import subprocess
 from unittest.mock import patch, call
 
 import pymongo
+import yaml
 from django.conf import settings
 from django.core import mail as django_mail
 from django.test.utils import override_settings
@@ -84,8 +85,11 @@ class GitHubInstanceTestCase(TestCase):
         instance = SingleVMOpenEdXInstanceFactory(github_admin_organization_name='test-admin-org')
         instance.reset_ansible_settings()
         self.assertEqual(instance.github_admin_username_list, ['admin1', 'admin2'])
-        self.assertIn('COMMON_USER_INFO:\n  - name: admin1\n    github: true\n    type: admin\n'
-                      '  - name: admin2\n    github: true\n    type: admin', instance.ansible_settings)
+        ansible_settings = yaml.load(instance.ansible_settings)
+        self.assertEqual(ansible_settings['COMMON_USER_INFO'], [
+            {'name': 'admin1', 'github': True, 'type': 'admin'},
+            {'name': 'admin2', 'github': True, 'type': 'admin'},
+        ])
 
     def test_set_fork_name_commit(self):
         """
@@ -266,18 +270,19 @@ class AnsibleInstanceTestCase(TestCase):
             certs_version='test-cert-ver',
         )
         instance.reset_ansible_settings()
-        self.assertIn('EDXAPP_PLATFORM_NAME: "Vars Instance"', instance.ansible_settings)
-        self.assertIn("EDXAPP_SITE_NAME: 'vars.test.example.com", instance.ansible_settings)
-        self.assertIn("EDXAPP_CMS_SITE_NAME: 'studio.vars.test.example.com'", instance.ansible_settings)
-        self.assertIn("EDXAPP_CONTACT_EMAIL: 'vars@example.com'", instance.ansible_settings)
-        self.assertIn("edx_platform_repo: 'https://github.com/vars-org/vars-repo.git'", instance.ansible_settings)
-        self.assertIn("edx_platform_version: '{}'".format('9' * 40), instance.ansible_settings)
-        self.assertIn("edx_ansible_source_repo: 'http://example.org/config/repo'", instance.ansible_settings)
-        self.assertIn("configuration_version: 'test-config-ver'", instance.ansible_settings)
-        self.assertIn("forum_version: 'test-forum-ver'", instance.ansible_settings)
-        self.assertIn("notifier_version: 'test-notif-ver'", instance.ansible_settings)
-        self.assertIn("xqueue_version: 'test-xq-ver'", instance.ansible_settings)
-        self.assertIn("certs_version: 'test-cert-ver'", instance.ansible_settings)
+        ansible_settings = yaml.load(instance.ansible_settings)
+        self.assertEqual(ansible_settings['EDXAPP_PLATFORM_NAME'], 'Vars Instance')
+        self.assertEqual(ansible_settings['EDXAPP_SITE_NAME'], 'vars.test.example.com')
+        self.assertEqual(ansible_settings['EDXAPP_CMS_SITE_NAME'], 'studio.vars.test.example.com')
+        self.assertEqual(ansible_settings['EDXAPP_CONTACT_EMAIL'], 'vars@example.com')
+        self.assertEqual(ansible_settings['edx_platform_repo'], 'https://github.com/vars-org/vars-repo.git')
+        self.assertEqual(ansible_settings['edx_platform_version'], '9' * 40)
+        self.assertEqual(ansible_settings['edx_ansible_source_repo'], 'http://example.org/config/repo')
+        self.assertEqual(ansible_settings['configuration_version'], 'test-config-ver')
+        self.assertEqual(ansible_settings['forum_version'], 'test-forum-ver')
+        self.assertEqual(ansible_settings['notifier_version'], 'test-notif-ver')
+        self.assertEqual(ansible_settings['xqueue_version'], 'test-xq-ver')
+        self.assertEqual(ansible_settings['certs_version'], 'test-cert-ver')
 
     def test_ansible_extra_settings(self):
         """

--- a/instance/tests/models/test_server.py
+++ b/instance/tests/models/test_server.py
@@ -27,6 +27,7 @@ import io
 from unittest.mock import Mock, call, patch
 
 from ddt import ddt, data, unpack
+from django.conf import settings
 import novaclient
 
 from instance.models.server import OpenStackServer, Status as ServerStatus
@@ -88,9 +89,9 @@ class OpenStackServerTestCase(TestCase):
         mock_create_server.assert_called_once_with(
             server.nova,
             AnyStringMatching(r'instance\d+\.test'),
-            {"ram": 4096, "disk": 40},
-            {"name": "Ubuntu 12.04"},
-            key_name='opencraft',
+            settings.OPENSTACK_SANDBOX_FLAVOR,
+            settings.OPENSTACK_SANDBOX_BASE_IMAGE,
+            key_name=settings.OPENSTACK_SANDBOX_SSH_KEYNAME,
         )
 
         server = OpenStackServer.objects.get(pk=server.pk)


### PR DESCRIPTION
The integration tests are currently only run if a `.env.integration` file is present. We run integration tests on CircleCI by copying this file over from the stage server before running the tests. We would like to store credentials on CircleCI directly, but for that to work the integration tests must be able to run without a `.env.integration` file. This pull request updates the Makefile to allow the integration tests to run with credentials from the environment, if the `OPENSTACK_USER` environment variable is set.