### PR TITLE
Make instance deletion more robust (part of OC-1541)

### DIFF
--- a/README.md
+++ b/README.md
@@ -448,11 +448,18 @@ Then use the "Launch new AppServer" button in the web UI to provision a server
 with the updated settings, and click "Activate this app server" to use the new
 server when it's ready.
 
-**To delete an instance**, ensuring that all virtual machines are terminated, run:
+**To terminate all VMs associated with an instance**, but still preserve the
+information about the AppServers and their configuration, run:
 
 ```python
 for appserver in instance.appserver_set.all():
     appserver.terminate_vm()
+```
+
+**To completely delete an instance**, which will also terminate all associated
+AppServers and their virtual machines, run:
+
+```python
 instance.delete()
 ```
 

--- a/instance/models/openedx_instance.py
+++ b/instance/models/openedx_instance.py
@@ -141,6 +141,14 @@ class OpenEdXInstance(Instance, OpenEdXAppConfiguration, OpenEdXDatabaseMixin, O
             self.use_ephemeral_databases = settings.INSTANCE_EPHEMERAL_DATABASES
         super().save(**kwargs)
 
+    def delete(self, *args, **kwargs):
+        """
+        Delete this Open edX Instance and its associated AppServers.
+        """
+        for appserver in self.appserver_set.all():
+            appserver.terminate_vm()
+        super().delete(*args, **kwargs)
+
     @property
     def appserver_set(self):
         """


### PR DESCRIPTION
I noticed that after my refactor in #63, it's possible to delete an `OpenEdXInstance` but leave behind an `InstanceReference`, or vice versa. The syntax for deleting all of an instance's VMs was also more complicated.

With this changeset, deleting either an `Instance` or an `InstanceReference` always deletes the other object (unless using bulk deletion through the ORM). Also, calling `instance.delete()` will delete the instance as well as the VMs of all of its appservers.

**Author Concerns**
Is it too dangerous that one method can delete an instance and terminate all of its VMs?