### PR TITLE
Add postgresql-client

### DIFF
--- a/debian_packages.lst
+++ b/debian_packages.lst
@@ -7,3 +7,4 @@ python3-pip
 redis-server
 subversion
 xvfb
+postgresql-client


### PR DESCRIPTION
Because otherwise you can't run `manage.py dbshell`.
