### PR TITLE
Fix "Update Instance from PR" button when PR source and target forks are different (OC-1541)

### DIFF
--- a/instance/static/html/instance/details.html
+++ b/instance/static/html/instance/details.html
@@ -97,7 +97,7 @@
   </tab>
   <tab heading="Pull Request (#{{pr.github_pr_number}})" ng-if="instance.source_pr" ng-init="pr = instance.source_pr" active="instance_active_tabs.pr_tab">
     <h4>Pull Request Details</h4>
-    <p>This instance was automatically generated for the GitHub pull request <a href="{{pr.github_pr_url}}">{{ pr.fork_name }} #{{ pr.github_pr_number }} ({{ pr.branch_name }})</a></p>
+    <p>This instance was automatically generated for the GitHub pull request <a href="{{pr.github_pr_url}}">{{ pr.target_fork_name }} #{{ pr.github_pr_number }} ({{ pr.branch_name }})</a></p>
 
     <p>If the PR has changed, you can update the instance settings based on the PR:</p>
     <button ng-click="update_from_pr()" ng-disabled="is_updating_from_pr">

--- a/pr_watch/api.py
+++ b/pr_watch/api.py
@@ -53,7 +53,7 @@ class WatchedPullRequestViewSet(viewsets.ReadOnlyModelViewSet):
         obj = self.get_object()
         # TODO: Make update_from_pr() fetch the PR, rather than us having to do it first, then
         # that method making a redundant second call to fetch the branch tip.
-        pr = github.get_pr_by_number(obj.fork_name, obj.github_pr_number)
+        pr = github.get_pr_by_number(obj.target_fork_name, obj.github_pr_number)
         try:
             obj.update_instance_from_pr(pr)
         except github.ObjectDoesNotExist:

--- a/pr_watch/models.py
+++ b/pr_watch/models.py
@@ -97,8 +97,6 @@ class WatchedPullRequest(models.Model):
     Represents a single watched pull request; holds the ID of the Instance created for that PR,
     if any
     """
-    # TODO: Store ID instead of URL, since URL and github_organization/repository_name contain
-    # redundant information.
     # TODO: Remove 'ref_type' ?
     # TODO: Remove parameters from 'update_instance_from_pr'; make it fetch PR details from the
     # api (including the head commit sha hash, which does not require a separate API call as
@@ -153,6 +151,16 @@ class WatchedPullRequest(models.Model):
         if not self.github_pr_url:
             return None
         return int(self.github_pr_url.split('/')[-1])
+
+    @property
+    def target_fork_name(self):
+        """
+        Get the full name of the target repo/fork (e.g. 'edx/edx-platform')
+        """
+        # Split up a URL like https://github.com/edx/edx-platform/pull/12345678
+        org, repo, pull, dummy = self.github_pr_url.split('/')[-4:]
+        assert pull == "pull"
+        return "{}/{}".format(org, repo)
 
     @property
     def repository_url(self):

--- a/pr_watch/serializers.py
+++ b/pr_watch/serializers.py
@@ -38,6 +38,7 @@ class WatchedPullRequestSerializer(serializers.ModelSerializer):
         fields = (
             'id',
             'fork_name',
+            'target_fork_name',
             'branch_name',
             'github_pr_number',
             'github_pr_url',

--- a/pr_watch/tests/test_api.py
+++ b/pr_watch/tests/test_api.py
@@ -75,6 +75,7 @@ class APITestCase(WithUserTestCase):
             data = data.items()
             self.assertIn(('id', watched_pr.pk), data)
             self.assertIn(('fork_name', 'fork/repo'), data)
+            self.assertIn(('target_fork_name', 'source/repo'), data)
             self.assertIn(('branch_name', 'api-test-branch'), data)
             self.assertIn(('github_pr_number', watched_pr.github_pr_number), data)
             self.assertIn(('github_pr_url', watched_pr.github_pr_url), data)

--- a/pr_watch/tests/test_models.py
+++ b/pr_watch/tests/test_models.py
@@ -66,11 +66,12 @@ class WatchedPullRequestTestCase(TestCase):
         """
         watched_pr = WatchedPullRequest(
             github_organization_name='open-craft',
-            github_pr_url='https://github.com/edx/edx/pull/234',
+            github_pr_url='https://github.com/edx/edx-dest/pull/234',
             github_repository_name='edx',
             branch_name='test-branch',
         )
         self.assertEqual(watched_pr.fork_name, 'open-craft/edx')
+        self.assertEqual(watched_pr.target_fork_name, 'edx/edx-dest')
         self.assertEqual(watched_pr.github_base_url, 'https://github.com/open-craft/edx')
         self.assertEqual(watched_pr.github_pr_number, 234)
         self.assertEqual(watched_pr.github_branch_url, 'https://github.com/open-craft/edx/tree/test-branch')


### PR DESCRIPTION
I noticed on our stage server that this button wasn't working:
![screen shot 2016-05-18 at 8 25 12 pm](https://cloud.githubusercontent.com/assets/945577/15381702/b38234dc-1d36-11e6-8ec7-99f10bdee33a.png)

It seems that I confused the PR source fork with the PR target fork at some point, which caused this bug when using the API to update an instance based on its PR settings. (This did not affect the automatic creation of instances when a new PR was detected.)

I have in mind a nicer way to refactor this code, but for now this is a quick fix.