### PR TITLE
Set up databases for different services when using persistent databases

### DIFF
--- a/instance/models/mixins/database.py
+++ b/instance/models/mixins/database.py
@@ -48,7 +48,7 @@ def _create_database(cursor, database):
     """
     Create MySQL database
     """
-    cursor.execute('CREATE DATABASE `{0}` DEFAULT CHARACTER SET utf8'.format(database))
+    cursor.execute('CREATE DATABASE `{database}` DEFAULT CHARACTER SET utf8'.format(database=database))
 
 
 def _create_user(cursor, user, password):
@@ -65,15 +65,15 @@ def _grant_privileges(cursor, database, user, privileges):
     if database == "*":
         tables = "*.*"
     else:
-        tables = "`{0}`.*".format(database)
-    cursor.execute('GRANT %s ON {0} TO %s'.format(tables), (privileges, user,))
+        tables = "`{database}`.*".format(database=database)
+    cursor.execute('GRANT {privileges} ON {tables} TO %s'.format(privileges=privileges, tables=tables), (user,))
 
 
 def _drop_database(cursor, database):
     """
     Drop MySQL database
     """
-    cursor.execute('DROP DATABASE IF EXISTS `{0}`'.format(database))
+    cursor.execute('DROP DATABASE IF EXISTS `{database}`'.format(database=database))
 
 
 def _drop_user(cursor, user):

--- a/instance/models/mixins/database.py
+++ b/instance/models/mixins/database.py
@@ -23,11 +23,18 @@ Instance app model mixins - Database
 # Imports #####################################################################
 
 import inspect
+from warnings import filterwarnings
 
 from django.conf import settings
 from django.db import models
 import MySQLdb as mysql
 import pymongo
+
+
+# Warnings ####################################################################
+
+filterwarnings("ignore", category=mysql.Warning, module=__name__, message="User .+ already exists.")
+filterwarnings("ignore", category=mysql.Warning, module=__name__, message="User .+ does not exist.")
 
 
 # Functions ###################################################################
@@ -79,7 +86,7 @@ def _create_user(cursor, user, password):
     """
     Create MySQL user identified by password
     """
-    cursor.execute('CREATE USER %s IDENTIFIED BY %s', (user, password,))
+    cursor.execute('CREATE USER IF NOT EXISTS %s IDENTIFIED BY %s', (user, password,))
 
 
 def _grant_privileges(cursor, database, user, privileges):
@@ -105,7 +112,7 @@ def _drop_user(cursor, user):
     """
     Drop MySQL user
     """
-    cursor.execute('DROP USER %s', (user,))
+    cursor.execute('DROP USER IF EXISTS %s', (user,))
 
 
 # Classes #####################################################################

--- a/instance/models/mixins/openedx_database.py
+++ b/instance/models/mixins/openedx_database.py
@@ -62,10 +62,6 @@ class OpenEdXDatabaseMixin(MySQLInstanceMixin, MongoDBInstanceMixin):
                 "user": self._get_mysql_user_name("rosencrantz"),
             },
             {
-                "name": self._get_mysql_database_name("ora"),
-                "user": self._get_mysql_user_name("ora001"),
-            },
-            {
                 "name": self._get_mysql_database_name("xqueue"),
                 "user": self._get_mysql_user_name("xqueue001"),
             },
@@ -83,10 +79,6 @@ class OpenEdXDatabaseMixin(MySQLInstanceMixin, MongoDBInstanceMixin):
                 "priv": "SELECT,INSERT,UPDATE,DELETE",
             },
             {
-                "name": self._get_mysql_database_name("programs"),
-                "user": self._get_mysql_user_name("programs001"),
-            },
-            {
                 "name": self._get_mysql_database_name("analytics-api"),
                 "user": self._get_mysql_user_name("api001"),
             },
@@ -100,14 +92,6 @@ class OpenEdXDatabaseMixin(MySQLInstanceMixin, MongoDBInstanceMixin):
                         "priv": "SELECT",
                     }
                 ],
-            },
-            {
-                "name": self._get_mysql_database_name("credentials"),
-                "user": self._get_mysql_user_name("credentials001"),
-            },
-            {
-                "name": self._get_mysql_database_name("discovery"),
-                "user": self._get_mysql_user_name("discov001"),
             },
         ]
 

--- a/instance/models/mixins/openedx_database.py
+++ b/instance/models/mixins/openedx_database.py
@@ -28,7 +28,6 @@ from django.template import loader
 from django.utils.crypto import get_random_string
 
 from .database import MySQLInstanceMixin, MongoDBInstanceMixin
-from .utilities import remove_prefix
 
 
 # Classes #####################################################################
@@ -171,6 +170,7 @@ class OpenEdXDatabaseMixin(MySQLInstanceMixin, MongoDBInstanceMixin):
         to the mysql_user of this instance.
 
         mysql_user is 6 characters long.
+        The maximum length of usernames in MySQL is 16 characters.
         To ensure that the generated name does not exceed that length,
         suffix must not consist of more than 9 characters.
         """
@@ -191,7 +191,8 @@ class OpenEdXDatabaseMixin(MySQLInstanceMixin, MongoDBInstanceMixin):
         """
         Return suffix that differentiates database identified by name from databases for other services.
         """
-        return remove_prefix(self.mysql_database_name, name)
+        prefix = "{prefix}_".format(prefix=self.mysql_database_name)
+        return name[len(prefix):]
 
     def _get_template_vars(self, database):
         """

--- a/instance/models/mixins/openedx_database.py
+++ b/instance/models/mixins/openedx_database.py
@@ -197,6 +197,8 @@ class OpenEdXDatabaseMixin(MySQLInstanceMixin, MongoDBInstanceMixin):
             new_settings += template.render({
                 'user': self.mysql_user,
                 'pass': self.mysql_pass,
+                'migrate_user': self.migrate_user,
+                'migrate_pass': self._get_mysql_pass(self.migrate_user),
                 'host': settings.INSTANCE_MYSQL_URL_OBJ.hostname,
                 'port': settings.INSTANCE_MYSQL_URL_OBJ.port or 3306,
                 'database': self.mysql_database_name

--- a/instance/models/mixins/openedx_database.py
+++ b/instance/models/mixins/openedx_database.py
@@ -48,11 +48,68 @@ class OpenEdXDatabaseMixin(MySQLInstanceMixin, MongoDBInstanceMixin):
         return self.database_name
 
     @property
-    def mysql_database_names(self):
+    def mysql_databases(self):
         """
-        List of mysql database names
+        List of mysql databases
         """
-        return [self.mysql_database_name]
+        return [
+            {
+                "name": self._get_mysql_database_name("ecommerce"),
+                "user": self._get_mysql_user_name("ecomm001"),
+            },
+            {
+                "name": self._get_mysql_database_name("dashboard"),
+                "user": self._get_mysql_user_name("rosencrantz"),
+            },
+            {
+                "name": self._get_mysql_database_name("ora"),
+                "user": self._get_mysql_user_name("ora001"),
+            },
+            {
+                "name": self._get_mysql_database_name("xqueue"),
+                "user": self._get_mysql_user_name("xqueue001"),
+            },
+            {
+                "name": self._get_mysql_database_name("edxapp"),
+                "user": self._get_mysql_user_name("edxapp001"),
+            },
+            {
+                "name": self._get_mysql_database_name("edxapp_csmh"),
+                "user": self._get_mysql_user_name("edxapp_csmh001"),
+            },
+            {
+                "name": self._get_mysql_database_name("edx_notes_api"),
+                "user": self._get_mysql_user_name("notes001"),
+                "priv": "SELECT,INSERT,UPDATE,DELETE",
+            },
+            {
+                "name": self._get_mysql_database_name("programs"),
+                "user": self._get_mysql_user_name("programs001"),
+            },
+            {
+                "name": self._get_mysql_database_name("analytics-api"),
+                "user": self._get_mysql_user_name("api001"),
+            },
+            {
+                "name": self._get_mysql_database_name("reports"),
+                "user": self._get_mysql_user_name("reports001"),
+                "priv": "SELECT",
+                "additional_users": [
+                    {
+                        "name": self._get_mysql_user_name("api001"),
+                        "priv": "SELECT",
+                    }
+                ],
+            },
+            {
+                "name": self._get_mysql_database_name("credentials"),
+                "user": self._get_mysql_user_name("credentials001"),
+            },
+            {
+                "name": self._get_mysql_database_name("discovery"),
+                "user": self._get_mysql_user_name("discov001"),
+            },
+        ]
 
     @property
     def mongo_database_name(self):
@@ -74,6 +131,46 @@ class OpenEdXDatabaseMixin(MySQLInstanceMixin, MongoDBInstanceMixin):
         List of mongo database names
         """
         return [self.mongo_database_name, self.forum_database_name]
+
+    @property
+    def migrate_user(self):
+        """
+        Name of migration user
+        """
+        return self._get_mysql_user_name("migrate")
+
+    @property
+    def read_only_user(self):
+        """
+        Name of read_only user
+        """
+        return self._get_mysql_user_name("read_only")
+
+    @property
+    def admin_user(self):
+        """
+        Name of admin user
+        """
+        return self._get_mysql_user_name("admin")
+
+    @property
+    def global_users(self):
+        """
+        List of MySQL users with global privileges (i.e., privileges spanning multiple databases)
+        """
+        return self.migrate_user, self.read_only_user, self.admin_user
+
+    def _get_mysql_database_name(self, suffix):
+        """
+        Build unique name for MySQL database using suffix
+        """
+        return "{0}_{1}".format(self.mysql_database_name, suffix)
+
+    def _get_mysql_user_name(self, suffix):
+        """
+        Build unique name for MySQL user using suffix
+        """
+        return "{0}_{1}".format(self.mysql_user, suffix)
 
     def set_field_defaults(self):
         """

--- a/instance/models/mixins/openedx_database.py
+++ b/instance/models/mixins/openedx_database.py
@@ -60,7 +60,7 @@ class OpenEdXDatabaseMixin(MySQLInstanceMixin, MongoDBInstanceMixin):
             },
             {
                 "name": self._get_mysql_database_name("dashboard"),
-                "user": self._get_mysql_user_name("rosencrantz"),
+                "user": self._get_mysql_user_name("dash001"),
             },
             {
                 "name": self._get_mysql_database_name("xqueue"),
@@ -72,7 +72,7 @@ class OpenEdXDatabaseMixin(MySQLInstanceMixin, MongoDBInstanceMixin):
             },
             {
                 "name": self._get_mysql_database_name("edxapp_csmh"),
-                "user": self._get_mysql_user_name("edxapp_csmh001"),
+                "user": self._get_mysql_user_name("csmh001"),
             },
             {
                 "name": self._get_mysql_database_name("edx_notes_api"),
@@ -85,7 +85,7 @@ class OpenEdXDatabaseMixin(MySQLInstanceMixin, MongoDBInstanceMixin):
             },
             {
                 "name": self._get_mysql_database_name("reports"),
-                "user": self._get_mysql_user_name("reports001"),
+                "user": self._get_mysql_user_name("rep001"),
                 "priv": "SELECT",
                 "additional_users": [
                     {
@@ -174,7 +174,7 @@ class OpenEdXDatabaseMixin(MySQLInstanceMixin, MongoDBInstanceMixin):
         even if an instance is edited to change 'use_ephemeral_databases' from True to False.
         """
         if not self.mysql_user:
-            self.mysql_user = get_random_string(length=16, allowed_chars=string.ascii_lowercase)
+            self.mysql_user = get_random_string(length=6, allowed_chars=string.ascii_lowercase)
             self.mysql_pass = get_random_string(length=32)
         if not self.mongo_user:
             self.mongo_user = get_random_string(length=16, allowed_chars=string.ascii_lowercase)

--- a/instance/models/mixins/openedx_database.py
+++ b/instance/models/mixins/openedx_database.py
@@ -20,6 +20,7 @@
 Open edX instance database mixin
 """
 import string
+import uuid
 
 from django.conf import settings
 from django.template import loader
@@ -155,6 +156,12 @@ class OpenEdXDatabaseMixin(MySQLInstanceMixin, MongoDBInstanceMixin):
         Build unique name for MySQL user using suffix
         """
         return "{0}_{1}".format(self.mysql_user, suffix)
+
+    def _get_mysql_pass(self, user):
+        """
+        Build unique password for user, derived from MySQL password for this instance and user
+        """
+        return str(uuid.uuid5(uuid.NAMESPACE_DNS, self.mysql_pass + user))
 
     def set_field_defaults(self):
         """

--- a/instance/models/mixins/utilities.py
+++ b/instance/models/mixins/utilities.py
@@ -29,6 +29,16 @@ from django.core.mail.message import EmailMultiAlternatives
 from django.views.debug import ExceptionReporter
 
 
+# Functions ###################################################################
+
+def remove_prefix(prefix, string):
+    """
+    Chop off prefix from name and return result.
+    """
+    prefix = "{prefix}_".format(prefix=prefix)
+    return string[len(prefix):]
+
+
 # Classes #####################################################################
 
 class EmailMixin:

--- a/instance/models/mixins/utilities.py
+++ b/instance/models/mixins/utilities.py
@@ -29,16 +29,6 @@ from django.core.mail.message import EmailMultiAlternatives
 from django.views.debug import ExceptionReporter
 
 
-# Functions ###################################################################
-
-def remove_prefix(prefix, string):
-    """
-    Chop off prefix from name and return result.
-    """
-    prefix = "{prefix}_".format(prefix=prefix)
-    return string[len(prefix):]
-
-
 # Classes #####################################################################
 
 class EmailMixin:

--- a/instance/models/openedx_instance.py
+++ b/instance/models/openedx_instance.py
@@ -128,7 +128,10 @@ class OpenEdXInstance(Instance, OpenEdXAppConfiguration, OpenEdXDatabaseMixin, O
         The database name used for external databases/storages, if any.
         """
         name = self.domain.replace('.', '_')
-        # Escape all non-ascii characters and truncate to 64 chars, the maximum for mysql:
+        # Escape all non-ascii characters and truncate to 50 chars.
+        # The maximum length for the name of a MySQL database is 64 characters.
+        # But since we add suffixes to database_name to generate unique database names
+        # for different services (e.g. xqueue) we don't want to use the maximum length here.
         allowed = string.ascii_letters + string.digits + '_'
         escaped = ''.join(char for char in name if char in allowed)
         return truncate_name(escaped, length=50)

--- a/instance/models/openedx_instance.py
+++ b/instance/models/openedx_instance.py
@@ -131,7 +131,7 @@ class OpenEdXInstance(Instance, OpenEdXAppConfiguration, OpenEdXDatabaseMixin, O
         # Escape all non-ascii characters and truncate to 64 chars, the maximum for mysql:
         allowed = string.ascii_letters + string.digits + '_'
         escaped = ''.join(char for char in name if char in allowed)
-        return truncate_name(escaped, length=64)
+        return truncate_name(escaped, length=50)
 
     def set_field_defaults(self):
         """

--- a/instance/models/openedx_instance.py
+++ b/instance/models/openedx_instance.py
@@ -175,10 +175,13 @@ class OpenEdXInstance(Instance, OpenEdXAppConfiguration, OpenEdXDatabaseMixin, O
 
     def delete(self, *args, **kwargs):
         """
-        Delete this Open edX Instance and its associated AppServers.
+        Delete this Open edX Instance and its associated AppServers, and deprovision external databases and storage.
         """
         for appserver in self.appserver_set.all():
             appserver.terminate_vm()
+        self.deprovision_mysql()
+        self.deprovision_mongo()
+        self.deprovision_swift()
         super().delete(*args, **kwargs)
 
     @property

--- a/instance/templates/instance/ansible/mysql.yml
+++ b/instance/templates/instance/ansible/mysql.yml
@@ -1,8 +1,76 @@
-EDXAPP_MYSQL_USER: '{{ user }}'
-EDXAPP_MYSQL_PASSWORD: '{{ pass }}'
+# edxapp
+EDXAPP_MYSQL_DB_NAME: '{{ edxapp_database }}'
+EDXAPP_MYSQL_USER: '{{ edxapp_user }}'
+EDXAPP_MYSQL_PASSWORD: '{{ edxapp_pass }}'
 EDXAPP_MYSQL_HOST: '{{ host }}'
 EDXAPP_MYSQL_PORT: {{ port }}
-EDXAPP_MYSQL_DB_NAME: '{{ database }}'
 
+# ecommerce
+ECOMMERCE_DEFAULT_DB_NAME: '{{ ecommerce_database }}'
+ECOMMERCE_DATABASES:
+  default:
+    ENGINE: 'django.db.backends.mysql'
+    NAME: '{{ ecommerce_database }}'
+    USER: '{{ ecommerce_user }}'
+    PASSWORD: '{{ ecommerce_pass }}'
+    HOST: '{{ host }}'
+    PORT: {{ port }}
+    ATOMIC_REQUESTS: true
+    CONN_MAX_AGE: 60
+
+# insights
+INSIGHTS_DATABASE_NAME: '{{ dashboard_database }}'
+INSIGHTS_DATABASES:
+  default:
+    ENGINE: 'django.db.backends.mysql'
+    NAME: '{{ dashboard_database }}'
+    USER: '{{ dashboard_user }}'
+    PASSWORD: '{{ dashboard_pass }}'
+    HOST: '{{ host }}'
+    PORT: {{ port }}
+
+# xqueue
+XQUEUE_MYSQL_DB_NAME: '{{ xqueue_database }}'
+XQUEUE_MYSQL_USER: '{{ xqueue_user }}'
+XQUEUE_MYSQL_PASSWORD: '{{ xqueue_pass }}'
+XQUEUE_MYSQL_HOST: '{{ host }}'
+XQUEUE_MYSQL_PORT: {{ port }}
+
+# edxapp_csmh
+EDXAPP_MYSQL_CSMH_DB_NAME: '{{ edxapp_csmh_database }}'
+EDXAPP_MYSQL_CSMH_USER: '{{ edxapp_csmh_user }}'
+EDXAPP_MYSQL_CSMH_PASSWORD: '{{ edxapp_csmh_pass }}'
+EDXAPP_MYSQL_CSMH_HOST: '{{ host }}'
+EDXAPP_MYSQL_CSMH_PORT: {{ port }}
+
+# edx_notes_api
+EDX_NOTES_API_MYSQL_DB_NAME: '{{ edx_notes_api_database }}'
+EDX_NOTES_API_MYSQL_DB_USER: '{{ edx_notes_api_user }}'
+EDX_NOTES_API_MYSQL_DB_PASS: '{{ edx_notes_api_pass }}'
+
+# analytics_api
+ANALYTICS_API_DEFAULT_DB_NAME: '{{ analytics_api_database }}'
+ANALYTICS_API_REPORTS_DB_NAME: '{{ reports_database }}'
+ANALYTICS_API_DATABASES:
+  default:
+    ENGINE: 'django.db.backends.mysql'
+    NAME: '{{ analytics_api_database }}'
+    USER: '{{ analytics_api_user }}'
+    PASSWORD: '{{ analytics_api_pass }}'
+    HOST: '{{ host }}'
+    PORT: {{ port }}
+  reports:
+    ENGINE: 'django.db.backends.mysql'
+    NAME: '{{ reports_database }}'
+    USER: '{{ reports_user }}'
+    PASSWORD: '{{ reports_pass }}'
+    HOST: '{{ host }}'
+    PORT: {{ port }}
+
+# Common users
 COMMON_MYSQL_MIGRATE_USER: '{{ migrate_user }}'
 COMMON_MYSQL_MIGRATE_PASS: '{{ migrate_pass }}'
+COMMON_MYSQL_READ_ONLY_USER: '{{ read_only_user }}'
+COMMON_MYSQL_READ_ONLY_PASS: '{{ read_only_pass }}'
+COMMON_MYSQL_ADMIN_USER: '{{ admin_user }}'
+COMMON_MYSQL_ADMIN_PASS: '{{ admin_pass }}'

--- a/instance/templates/instance/ansible/mysql.yml
+++ b/instance/templates/instance/ansible/mysql.yml
@@ -47,6 +47,7 @@ EDXAPP_MYSQL_CSMH_PORT: {{ port }}
 EDX_NOTES_API_MYSQL_DB_NAME: '{{ edx_notes_api_database }}'
 EDX_NOTES_API_MYSQL_DB_USER: '{{ edx_notes_api_user }}'
 EDX_NOTES_API_MYSQL_DB_PASS: '{{ edx_notes_api_pass }}'
+EDX_NOTES_API_MYSQL_HOST: '{{ host }}'
 
 # analytics_api
 ANALYTICS_API_DEFAULT_DB_NAME: '{{ analytics_api_database }}'

--- a/instance/templates/instance/ansible/mysql.yml
+++ b/instance/templates/instance/ansible/mysql.yml
@@ -4,5 +4,5 @@ EDXAPP_MYSQL_HOST: '{{ host }}'
 EDXAPP_MYSQL_PORT: {{ port }}
 EDXAPP_MYSQL_DB_NAME: '{{ database }}'
 
-COMMON_MYSQL_MIGRATE_USER: '{{ user }}'
-COMMON_MYSQL_MIGRATE_PASS: '{{ pass }}'
+COMMON_MYSQL_MIGRATE_USER: '{{ migrate_user }}'
+COMMON_MYSQL_MIGRATE_PASS: '{{ migrate_pass }}'

--- a/instance/tests/models/test_openedx_database_mixins.py
+++ b/instance/tests/models/test_openedx_database_mixins.py
@@ -164,8 +164,8 @@ class MySQLInstanceTestCase(TestCase):
         self.assertEqual(db_vars['EDXAPP_MYSQL_HOST'], 'mysql.opencraft.com')
         self.assertEqual(db_vars['EDXAPP_MYSQL_PORT'], 3306)
         self.assertEqual(db_vars['EDXAPP_MYSQL_DB_NAME'], instance.mysql_database_name)
-        self.assertEqual(db_vars['COMMON_MYSQL_MIGRATE_USER'], instance.mysql_user)
-        self.assertEqual(db_vars['COMMON_MYSQL_MIGRATE_PASS'], instance.mysql_pass)
+        self.assertEqual(db_vars['COMMON_MYSQL_MIGRATE_USER'], instance.migrate_user)
+        self.assertEqual(db_vars['COMMON_MYSQL_MIGRATE_PASS'], instance._get_mysql_pass(instance.migrate_user))
 
     @patch_services
     @override_settings(INSTANCE_MYSQL_URL_OBJ=None)

--- a/instance/tests/models/test_openedx_database_mixins.py
+++ b/instance/tests/models/test_openedx_database_mixins.py
@@ -23,6 +23,7 @@ OpenEdXInstance Database Mixins - Tests
 # Imports #####################################################################
 
 import subprocess
+from unittest.mock import patch
 from urllib.parse import urlparse
 
 import pymongo
@@ -101,6 +102,28 @@ class MySQLInstanceTestCase(TestCase):
                     'COMMON_MYSQL_MIGRATE_PASS'):
             self.assertNotIn(var, db_vars_str)
 
+    def check_common_users(self, instance, db_vars):
+        """
+        Check that instance settings contain correct information about common users.
+        """
+        self.assertEqual(db_vars['COMMON_MYSQL_MIGRATE_USER'], instance.migrate_user)
+        self.assertEqual(db_vars['COMMON_MYSQL_MIGRATE_PASS'], instance._get_mysql_pass(instance.migrate_user))
+        self.assertEqual(db_vars['COMMON_MYSQL_READ_ONLY_USER'], instance.read_only_user)
+        self.assertEqual(db_vars['COMMON_MYSQL_READ_ONLY_PASS'], instance._get_mysql_pass(instance.read_only_user))
+        self.assertEqual(db_vars['COMMON_MYSQL_ADMIN_USER'], instance.admin_user)
+        self.assertEqual(db_vars['COMMON_MYSQL_ADMIN_PASS'], instance._get_mysql_pass(instance.admin_user))
+
+    def check_vars(self, instance, db_vars, prefix, var_names=None, values=None):
+        """
+        Check that instance settings contain correct values for vars that start with prefix.
+        """
+        if var_names is None:
+            var_names = ["DB_NAME", "USER", "PASSWORD", "HOST", "PORT"]
+        instance_settings = zip(var_names, values)
+        for var_name, value in instance_settings:
+            var_name = prefix + var_name
+            self.assertEqual(db_vars[var_name], value)
+
     def test__get_mysql_database_name(self):
         """
         Test that _get_mysql_database_name correctly builds database names.
@@ -134,6 +157,62 @@ class MySQLInstanceTestCase(TestCase):
         suffix = "long-long-long-suffix"
         with self.assertRaises(AssertionError):
             self.instance._get_mysql_user_name(suffix)
+
+    def test__get_mysql_pass(self):
+        """
+        Test behavior of _get_mysql_pass.
+
+        It should:
+
+        - generate passwords of appropriate length
+        - generate different passwords for different users
+        - behave deterministically, i.e., return the same password for a given user
+          every time it is called with that user
+        """
+        self.instance = OpenEdXInstanceFactory()
+        user1 = "user1"
+        pass1 = self.instance._get_mysql_pass(user1)
+        user2 = "user2"
+        pass2 = self.instance._get_mysql_pass(user2)
+        self.assertEqual(len(pass1), 64)
+        self.assertEqual(len(pass2), 64)
+        self.assertFalse(pass1 == pass2)
+        self.assertEqual(pass1, self.instance._get_mysql_pass(user1))
+        self.assertEqual(pass2, self.instance._get_mysql_pass(user2))
+
+    def test__get_database_suffix(self):
+        """
+        Test that _get_database_suffix returns correct suffix for a given database.
+        """
+        self.instance = OpenEdXInstanceFactory()
+        suffix = "test"
+        database_name = self.instance._get_mysql_database_name(suffix)
+        self.assertEqual(self.instance._get_database_suffix(database_name), suffix)
+
+        with patch(
+            "instance.models.mixins.openedx_database.remove_prefix", return_value="dummy"
+        ) as patched_remove_prefix:
+            suffix = self.instance._get_database_suffix(database_name)
+            self.assertEqual(suffix, patched_remove_prefix.return_value)
+            patched_remove_prefix.assert_called_once_with(self.instance.mysql_database_name, database_name)
+
+    def test__get_template_vars(self):
+        """
+        Test that _get_template_vars returns correct settings for a given database.
+        """
+        self.instance = OpenEdXInstanceFactory()
+        suffix = "test-db"
+        database = {
+            "name": self.instance._get_mysql_database_name(suffix),
+            "user": self.instance._get_mysql_user_name(suffix),
+        }
+        template_vars = self.instance._get_template_vars(database)
+        expected_template_vars = {
+            "{}_database".format(suffix): database["name"],
+            "{}_user".format(suffix): database["user"],
+            "{}_pass".format(suffix): self.instance._get_mysql_pass(database["user"])
+        }
+        self.assertEqual(template_vars, expected_template_vars)
 
     def test_provision_mysql(self):
         """
@@ -185,21 +264,91 @@ class MySQLInstanceTestCase(TestCase):
     @override_settings(INSTANCE_MYSQL_URL_OBJ=urlparse('mysql://user:pass@mysql.opencraft.com'))
     def test_ansible_settings_mysql(self, mocks):
         """
-        Add mysql ansible vars if INSTANCE_MYSQL_URL is set and not using ephemeral databases
+        Test that get_database_settings produces correct settings for MySQL databases
         """
         instance = OpenEdXInstanceFactory(use_ephemeral_databases=False)
-        instance.provision_mysql()
+        expected_host = "mysql.opencraft.com"
+        expected_port = 3306
 
+        def make_flat_group_info(var_names=None, database=None, include_general_settings=True):
+            """ Return dict containing info for a flat group of variables """
+            group_info = {}
+            if var_names:
+                group_info["vars"] = var_names
+            # Compute and insert values
+            name = instance._get_mysql_database_name(database["name"])
+            user = instance._get_mysql_user_name(database["user"])
+            password = instance._get_mysql_pass(user)
+            values = [name, user, password]
+            if include_general_settings:
+                values += [expected_host, expected_port]
+            group_info["values"] = values
+            return group_info
+
+        def make_nested_group_info(var_names, databases):
+            """ Return dict containing info for a nested group of variables """
+            group_info = {
+                "vars": var_names
+            }
+            # Compute and insert values
+            for database in databases:
+                database["name"] = instance._get_mysql_database_name(database["name"])
+                database["user"] = instance._get_mysql_user_name(database["user"])
+                database["password"] = instance._get_mysql_pass(database["user"])
+            values = [database["name"] for database in databases]
+            values.append({
+                database.get("id", "default"): dict(
+                    ENGINE='django.db.backends.mysql',
+                    NAME=database["name"],
+                    USER=database["user"],
+                    PASSWORD=database["password"],
+                    HOST=expected_host,
+                    PORT=expected_port,
+                    **database.get("additional_settings", {}),
+                )
+                for database in databases
+            })
+            group_info["values"] = values
+            return group_info
+
+        # Load instance settings
         db_vars = yaml.load(instance.get_database_settings())
-        self.assertGreater(len(instance.mysql_user), 5)
-        self.assertGreater(len(instance.mysql_pass), 10)
-        self.assertEqual(db_vars['EDXAPP_MYSQL_USER'], instance.mysql_user)
-        self.assertEqual(db_vars['EDXAPP_MYSQL_PASSWORD'], instance.mysql_pass)
-        self.assertEqual(db_vars['EDXAPP_MYSQL_HOST'], 'mysql.opencraft.com')
-        self.assertEqual(db_vars['EDXAPP_MYSQL_PORT'], 3306)
-        self.assertEqual(db_vars['EDXAPP_MYSQL_DB_NAME'], instance.mysql_database_name)
-        self.assertEqual(db_vars['COMMON_MYSQL_MIGRATE_USER'], instance.migrate_user)
-        self.assertEqual(db_vars['COMMON_MYSQL_MIGRATE_PASS'], instance._get_mysql_pass(instance.migrate_user))
+
+        # Check instance settings for common users
+        self.check_common_users(instance, db_vars)
+
+        # Check service-specific instance settings
+        var_groups = {
+            "EDXAPP_MYSQL_": make_flat_group_info(database={"name": "edxapp", "user": "edxapp"}),
+            "XQUEUE_MYSQL_": make_flat_group_info(database={"name": "xqueue", "user": "xqueue"}),
+            "EDXAPP_MYSQL_CSMH_": make_flat_group_info(database={"name": "edxapp_csmh", "user": "edxapp"}),
+            "EDX_NOTES_API_MYSQL_": make_flat_group_info(
+                var_names=["DB_NAME", "DB_USER", "DB_PASS"],
+                database={"name": "edx_notes_api", "user": "notes"},
+                include_general_settings=False
+            ),
+            "ECOMMERCE_": make_nested_group_info(
+                ["DEFAULT_DB_NAME", "DATABASES"],
+                [{"name": "ecommerce", "user": "ecommerce", "additional_settings": {
+                    "ATOMIC_REQUESTS": True,
+                    "CONN_MAX_AGE": 60,
+                }}]
+            ),
+            "INSIGHTS_": make_nested_group_info(
+                ["DATABASE_NAME", "DATABASES"],
+                [{"name": "dashboard", "user": "dashboard"}]
+            ),
+            "ANALYTICS_API_": make_nested_group_info(
+                ["DEFAULT_DB_NAME", "REPORTS_DB_NAME", "DATABASES"],
+                [{"name": "analytics_api", "user": "api"}, {"id": "reports", "name": "reports", "user": "reports"}]
+            ),
+        }
+        for group_prefix, group_info in var_groups.items():
+            values = group_info["values"]
+            if "vars" in group_info:
+                self.check_vars(instance, db_vars, group_prefix, var_names=group_info["vars"], values=values)
+            else:
+                self.check_vars(instance, db_vars, group_prefix, values=values)
 
     @patch_services
     @override_settings(INSTANCE_MYSQL_URL_OBJ=None)

--- a/instance/tests/models/test_openedx_database_mixins.py
+++ b/instance/tests/models/test_openedx_database_mixins.py
@@ -23,7 +23,6 @@ OpenEdXInstance Database Mixins - Tests
 # Imports #####################################################################
 
 import subprocess
-from unittest.mock import patch
 from urllib.parse import urlparse
 
 import pymongo
@@ -188,13 +187,6 @@ class MySQLInstanceTestCase(TestCase):
         suffix = "test"
         database_name = self.instance._get_mysql_database_name(suffix)
         self.assertEqual(self.instance._get_database_suffix(database_name), suffix)
-
-        with patch(
-            "instance.models.mixins.openedx_database.remove_prefix", return_value="dummy"
-        ) as patched_remove_prefix:
-            suffix = self.instance._get_database_suffix(database_name)
-            self.assertEqual(suffix, patched_remove_prefix.return_value)
-            patched_remove_prefix.assert_called_once_with(self.instance.mysql_database_name, database_name)
 
     def test__get_template_vars(self):
         """

--- a/instance/tests/models/test_openedx_database_mixins.py
+++ b/instance/tests/models/test_openedx_database_mixins.py
@@ -270,7 +270,7 @@ class MySQLInstanceTestCase(TestCase):
         expected_host = "mysql.opencraft.com"
         expected_port = 3306
 
-        def make_flat_group_info(var_names=None, database=None, include_general_settings=True):
+        def make_flat_group_info(var_names=None, database=None, include_port=True):
             """ Return dict containing info for a flat group of variables """
             group_info = {}
             if var_names:
@@ -279,9 +279,9 @@ class MySQLInstanceTestCase(TestCase):
             name = instance._get_mysql_database_name(database["name"])
             user = instance._get_mysql_user_name(database["user"])
             password = instance._get_mysql_pass(user)
-            values = [name, user, password]
-            if include_general_settings:
-                values += [expected_host, expected_port]
+            values = [name, user, password, expected_host]
+            if include_port:
+                values.append(expected_port)
             group_info["values"] = values
             return group_info
 
@@ -323,9 +323,9 @@ class MySQLInstanceTestCase(TestCase):
             "XQUEUE_MYSQL_": make_flat_group_info(database={"name": "xqueue", "user": "xqueue"}),
             "EDXAPP_MYSQL_CSMH_": make_flat_group_info(database={"name": "edxapp_csmh", "user": "edxapp"}),
             "EDX_NOTES_API_MYSQL_": make_flat_group_info(
-                var_names=["DB_NAME", "DB_USER", "DB_PASS"],
+                var_names=["DB_NAME", "DB_USER", "DB_PASS", "HOST"],
                 database={"name": "edx_notes_api", "user": "notes"},
-                include_general_settings=False
+                include_port=False
             ),
             "ECOMMERCE_": make_nested_group_info(
                 ["DEFAULT_DB_NAME", "DATABASES"],

--- a/instance/tests/models/test_openedx_database_mixins.py
+++ b/instance/tests/models/test_openedx_database_mixins.py
@@ -101,6 +101,40 @@ class MySQLInstanceTestCase(TestCase):
                     'COMMON_MYSQL_MIGRATE_PASS'):
             self.assertNotIn(var, db_vars_str)
 
+    def test__get_mysql_database_name(self):
+        """
+        Test that _get_mysql_database_name correctly builds database names.
+        """
+        self.instance = OpenEdXInstanceFactory()
+
+        # Database name should be a combination of database_name and custom suffix
+        suffix = "test"
+        database_name = self.instance._get_mysql_database_name(suffix)
+        expected_database_name = "{0}_{1}".format(self.instance.database_name, suffix)
+        self.assertEqual(database_name, expected_database_name)
+
+        # Using suffix that exceeds maximum length should raise an error
+        suffix = "long-long-long-long-long-long-long-long-long-long-long-long-suffix"
+        with self.assertRaises(AssertionError):
+            self.instance._get_mysql_database_name(suffix)
+
+    def test__get_mysql_user_name(self):
+        """
+        Test that _get_mysql_user_name correctly builds user names.
+        """
+        self.instance = OpenEdXInstanceFactory()
+
+        # User name should be a combination of mysql_user and custom suffix
+        suffix = "test"
+        user_name = self.instance._get_mysql_user_name(suffix)
+        expected_user_name = "{0}_{1}".format(self.instance.mysql_user, suffix)
+        self.assertEqual(user_name, expected_user_name)
+
+        # Using suffix that exceeds maximum length should raise an error
+        suffix = "long-long-long-suffix"
+        with self.assertRaises(AssertionError):
+            self.instance._get_mysql_user_name(suffix)
+
     def test_provision_mysql(self):
         """
         Provision mysql database

--- a/registration/tests/browser/browser_registration.py
+++ b/registration/tests/browser/browser_registration.py
@@ -29,6 +29,7 @@ import time
 from django.core.urlresolvers import reverse
 from django.contrib.staticfiles.testing import StaticLiveServerTestCase
 from selenium import webdriver
+from selenium.common.exceptions import WebDriverException
 from selenium.webdriver.support import expected_conditions
 from selenium.webdriver.support.ui import WebDriverWait
 
@@ -44,7 +45,11 @@ class BetaTestBrowserTestCase(BetaTestApplicationViewTestMixin,
     """
     def setUp(self):
         super().setUp()
-        self.client = webdriver.Firefox()
+        try:
+            self.client = webdriver.Firefox()
+        except WebDriverException:
+            time.sleep(1)
+            self.client = webdriver.Firefox()
 
     def tearDown(self):
         self.client.quit()


### PR DESCRIPTION
cf. [OC-1610](https://tasks.opencraft.com/browse/OC-1610)

**Dependencies**

* https://github.com/edx/configuration/pull/3052 (fixes issue where `edxlocal` role would fail due to missing dependencies when using non-local databases)
* https://github.com/open-craft/configuration/pull/5 (fixes issue affecting creation of user for ecommerce database in integration tests; *should merge before this PR* so we can go back to using [open-craft:integration](https://github.com/open-craft/configuration/tree/integration) branch for integration tests)

**Test instructions**

1. Prepare your `.env` by setting `INSTANCE_MYSQL_URL` and `INSTANCE_MONGO_URL` to values from corresponding settings from stage.console.opencraft.com `.env` file. Make sure your `.env` sets `SWIFT_ENABLE=true` (if it doesn't contain the `SWIFT_ENABLE` setting, that's fine too since it defaults to `true`).

2. Log in to https://horizon.cloud.ovh.net using credentials for "OVH - OpenStack - Horizon - Databases" (stored in KeePassX database). Go to "Access & Security" and add a rule to the `databases-mysql-im-stage` and `databases-mongodb-stage` security groups that grants your IP access to the corresponding databases.

3. Create a new instance from the shell using the following settings:

   ```python
   from instance.factories import production_instance_factory

   instance = production_instance_factory(
       sub_domain="databases-test.sandbox",
       name='Databases Test',
       edx_platform_repository_url="https://github.com/edx/edx-platform.git",
       configuration_source_repo_url="https://github.com/open-craft/configuration.git",
       configuration_version="jill/edx-sandbox-remote",  # branch from related PR
       edx_platform_commit="master",
       openedx_release="master",
   )
   ```

4. Run the development server, go to http://localhost:5000/instance, find the instance created in the previous step and click "Launch new AppServer".

5. Once the status of the app server switches to "Configuring VM", copy its "VM IP Address" from the "Status" section. Using this IP address, repeat step 2 to grant the VM access to the external MySQL and MongoDB databases.

6. Wait for the provisioning process to finish.