### PR TITLE
Don't trigger an instance list update in the UI for each PR every minute (OC-1541)

### DIFF
--- a/pr_watch/models.py
+++ b/pr_watch/models.py
@@ -50,16 +50,17 @@ class WatchedPullRequestQuerySet(models.QuerySet):
     Additional methods for WatchedPullRequest querysets
     Also used as the standard manager for the WatchedPullRequest model
     """
-    def update_or_create_from_pr(self, pr):
+    def get_or_create_from_pr(self, pr):
         """
-        Create or update an instance for the given pull request
+        Get or create an instance for the given pull request
         """
         watched_pr, created = self.get_or_create(
             fork_name=pr.fork_name,
             branch_name=pr.branch_name,
             github_pr_url=pr.github_pr_url,
         )
-        watched_pr.update_instance_from_pr(pr)
+        if created:
+            watched_pr.update_instance_from_pr(pr)
         return watched_pr.instance, created
 
     def create(self, *args, **kwargs):

--- a/pr_watch/tasks.py
+++ b/pr_watch/tasks.py
@@ -49,7 +49,7 @@ def watch_pr():
 
     for username in team_username_list:
         for pr in get_pr_list_from_username(username, settings.WATCH_FORK):
-            instance, created = WatchedPullRequest.objects.update_or_create_from_pr(pr)
+            instance, created = WatchedPullRequest.objects.get_or_create_from_pr(pr)
             if created:
                 logger.info('New PR found, creating sandbox: %s', pr)
                 spawn_appserver(instance.ref.pk, mark_active_on_success=True, num_attempts=2)

--- a/pr_watch/tests/factories.py
+++ b/pr_watch/tests/factories.py
@@ -56,5 +56,5 @@ def make_watched_pr_and_instance(**kwargs):
     """
     pr = PRFactory(**kwargs)
     with patch('pr_watch.github.get_commit_id_from_ref', return_value=('5' * 40)):
-        instance, dummy = WatchedPullRequest.objects.update_or_create_from_pr(pr)
+        instance, dummy = WatchedPullRequest.objects.get_or_create_from_pr(pr)
     return instance.watchedpullrequest

--- a/pr_watch/tests/test_models.py
+++ b/pr_watch/tests/test_models.py
@@ -132,7 +132,7 @@ class WatchedPullRequestTestCase(TestCase):
         Create an instance from a pull request
         """
         pr = PRFactory()
-        instance, created = WatchedPullRequest.objects.update_or_create_from_pr(pr)
+        instance, created = WatchedPullRequest.objects.get_or_create_from_pr(pr)
         self.assertTrue(created)
 
         watched_pr = instance.watchedpullrequest
@@ -146,13 +146,17 @@ class WatchedPullRequestTestCase(TestCase):
         self.assertEqual(instance.edx_platform_commit, '9' * 40)
         self.assertTrue(instance.use_ephemeral_databases)
 
+        same_instance, created = WatchedPullRequest.objects.get_or_create_from_pr(pr)
+        self.assertEqual(instance, same_instance)
+        self.assertFalse(created)
+
     @override_settings(INSTANCE_EPHEMERAL_DATABASES=False)
     def test_create_from_pr_ephemeral_databases(self):
         """
         Instances should use ephemeral databases if requested in the PR
         """
         pr = PRFactory(body='pr123.sandbox.example.com (ephemeral databases)', number=123)
-        instance, _ = WatchedPullRequest.objects.update_or_create_from_pr(pr)
+        instance, _ = WatchedPullRequest.objects.get_or_create_from_pr(pr)
         self.assertTrue(instance.use_ephemeral_databases)
 
     @override_settings(INSTANCE_EPHEMERAL_DATABASES=True)
@@ -161,5 +165,5 @@ class WatchedPullRequestTestCase(TestCase):
         Instances should use persistent databases if requested in the PR
         """
         pr = PRFactory(body='pr123.sandbox.example.com (persistent databases)', number=123)
-        instance, _ = WatchedPullRequest.objects.update_or_create_from_pr(pr)
+        instance, _ = WatchedPullRequest.objects.get_or_create_from_pr(pr)
         self.assertFalse(instance.use_ephemeral_databases)


### PR DESCRIPTION
I noticed on our stage server that whenever the GitHub watcher checks the status of a PR, the "Loading..." indicator appears in the web UI and the instance list is refreshed. This is because after #63, the PR watcher ends up updating instance properties and calling `.save()` on each time it checks a PR.

With this change, the periodic PR watcher only updates the instance when the PR is new. To update an instance from an existing PR, you have to do it manually by clicking the "Update instance settings from PR" button in the web UI.

This should reduce load on the server slightly and eliminate the "Loading..." flicker, while also making behavior more predictable.


Alternative: The alternative would be to keep the current behavior of automatically updating instance settings from the PR every minute, but only call `.save()` when the new settings are different. However that is trickier to implement. I also don't like it as much conceptually, because then it's less clear if/when settings get updated from a PR.