### PR TITLE
Don't break dns if an instance's base domain includes a subdomain part

### DIFF
--- a/instance/tests/models/test_openedx_instance.py
+++ b/instance/tests/models/test_openedx_instance.py
@@ -206,6 +206,25 @@ class OpenEdXInstanceTestCase(TestCase):
         ])
 
     @patch_services
+    def test_set_appserver_active_base_subdomain(self, mocks):
+        """
+        Test set_appserver_active() with a base domain that includes part of a
+        subdomain. Ensure that the dns records include the part of the subdomain
+        in the base domain of the instance.
+        """
+        instance = OpenEdXInstanceFactory(sub_domain='test.activate',
+                                          base_domain='stage.opencraft.hosting',
+                                          use_ephemeral_databases=True)
+        appserver_id = instance.spawn_appserver()
+        instance.set_appserver_active(appserver_id)
+        self.assertEqual(instance.active_appserver.pk, appserver_id)
+        self.assertEqual(mocks.mock_set_dns_record.mock_calls, [
+            call(name='test.activate.stage', type='A', value='1.1.1.1'),
+            call(name='preview-test.activate.stage', type='CNAME', value='test.activate.stage'),
+            call(name='studio-test.activate.stage', type='CNAME', value='test.activate.stage'),
+        ])
+
+    @patch_services
     @patch('instance.models.openedx_instance.OpenEdXAppServer.provision', return_value=True)
     def test_spawn_appserver_names(self, mocks, mock_provision):
         """

--- a/requirements.txt
+++ b/requirements.txt
@@ -118,6 +118,7 @@ sqlparse==0.1.19
 static3==0.6.1
 stevedore==1.12.0
 -e git+https://github.com/jonashagstedt/swampdragon.git@061b2b1e4a57b7aa32d2fbc0824f070a52c1e300#egg=SwampDragon
+tldextract==2.0.1
 tlslite==0.4.9
 tornado==4.3
 tornado-redis==2.4.18


### PR DESCRIPTION
#### Background

Sandboxes provisioned on stage.console.opencraft.com cannot be accessed by url, only by ip address. On investigation, it turns out that the dns records are being set incorrectly, as they ignore any part of the subdomain that has been set as part of the instance's base domain. For example:

The `INSTANCES_BASE_DOMAIN` setting is set to `stage.opencraft.com`. When a new instance is created with a subdomain of `pr12338-2.sandbox`, 3 gandi DNS records are added:

- A: `pr12338-2.sandbox.opencraft.com` -> public IP
- CNAME: `preview-pr12338-2.sandbox.opencraft.com` -> `pr12338-2.sandbox.opencraft.com`
- CNAME: `studio-pr12338-2.sandbox.opencraft.com` -> `pr12338-2.sandbox.opencraft.com`

However, the instance expects to be reached at pr12338-2.sandbox.**stage.**opencraft.com.

#### Proposal

This pull request modifies `OpenEdXInstance.set_appserver_active` to use the [tldextract](https://github.com/john-kurkowski/tldextract) package to correctly separate the subdomain from the base domain when adding DNS records.