### PR TITLE
Fix registration for existing users

### DIFF
--- a/instance/templates/instance/index.html
+++ b/instance/templates/instance/index.html
@@ -13,21 +13,6 @@
 
 {% block content %}
 <div class="container content instance-app" ng-app="InstanceApp">
-    <top-bar>
-      <ul class="title-area">
-        <li class="name">
-          <h1><a href="#">OpenCraft Instance Manager</a></h1>
-        </li>
-      </ul>
-
-      <section class="top-bar-section">
-        <!-- Right Nav Section -->
-        <ul class="right">
-          <li class="active"><a href="/admin/logout/?next=/">Logout</a></li>
-        </ul>
-      </section>
-    </top-bar>
-
     <div ui-view>Loading...</div>
 </div>
 {% endblock content %}

--- a/registration/api.py
+++ b/registration/api.py
@@ -27,22 +27,24 @@ from rest_framework.response import Response
 from rest_framework.viewsets import ViewSet
 
 from registration.forms import BetaTestApplicationForm
+from registration.views import BetaTestApplicationMixin
 
 
 # Views #######################################################################
 
-class BetaTestApplicationViewSet(ViewSet):
+class BetaTestApplicationViewSet(BetaTestApplicationMixin, ViewSet):
     """
     ViewSet for ajax validation of the beta test registration form.
     """
     permission_classes = (AllowAny,)
 
-    def list(self, request): #pylint: disable=no-self-use
+    def list(self, request):
         """
         Validate the given form input, and return any errors as json.
 
         Not really a list view, but we have to use `list` to fit into ViewSet
         semantics so this can be part of the browsable api.
         """
-        form = BetaTestApplicationForm(request.query_params)
+        form = BetaTestApplicationForm(request.query_params,
+                                       instance=self.get_object())
         return Response(form.errors)

--- a/registration/tests/browser/browser_registration.py
+++ b/registration/tests/browser/browser_registration.py
@@ -113,7 +113,7 @@ class BetaTestBrowserTestCase(BetaTestApplicationViewTestMixin,
         self.fill_form(form_data)
 
         # Wait for ajax validation to complete
-        time.sleep(1)
+        time.sleep(2)
 
         if self.form_valid():
             self.submit_form()


### PR DESCRIPTION
I noticed a bug in the beta registration after I deployed it to stage. If you are already logged in, but have not yet registered, the form will not allow you to register ('username is already taken'). This pull request fixes the bug by ignoring the logged in user when checking for existing usernames and emails.

#### Testing

1. Create a new user in the admin or the shell
2. Log in as that user
3. Go to `/registration/`. The username and email fields should be prepopulated and read only, and the password fields should not appear.
4. Fill in and submit the form