### PR TITLE
Redirect staff users to instance manager on login

### DIFF
--- a/opencraft/urls.py
+++ b/opencraft/urls.py
@@ -26,6 +26,8 @@ from django.conf.urls import include, url
 from django.contrib import admin
 from django.views.generic.base import RedirectView
 
+from opencraft import views
+
 
 # URL Patterns ################################################################
 
@@ -37,5 +39,5 @@ urlpatterns = [
     url(r'^registration/', include('registration.urls', namespace='registration')),
     url(r'^email-verification/', include('email_verification.urls', namespace='email-verification')),
     url(r'^favicon\.ico$', RedirectView.as_view(url='/static/img/favicon/favicon.ico', permanent=False)),
-    url(r'^$', RedirectView.as_view(pattern_name='registration:register', permanent=False), name='index'),
+    url(r'^$', views.index, name='index'),
 ]

--- a/opencraft/views.py
+++ b/opencraft/views.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+#
+# OpenCraft -- tools to aid developing and hosting free software projects
+# Copyright (C) 2015 OpenCraft <xavier@opencraft.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+"""
+Index view
+"""
+
+# Imports #####################################################################
+
+from django.shortcuts import redirect
+
+
+# Views @@@####################################################################
+
+def index(request):
+    """
+    Landing page. Redirects staff to the instance manager, and everyone else
+    to the registration form.
+    """
+    if request.user.is_staff:
+        return redirect('instance:index')
+    return redirect('registration:register')


### PR DESCRIPTION
Staff users are currently redirected to the beta registration page on login. This pull request redirects staff users to the instance manager instead.