### PR TITLE
Don't prefix IM angular routes with /instances/

### DIFF
--- a/instance/static/js/src/instance.js
+++ b/instance/static/js/src/instance.js
@@ -33,15 +33,15 @@ app.config(function($httpProvider) {
 });
 
 app.config(function($stateProvider, $urlRouterProvider, RestangularProvider) {
-    // For any unmatched url, send to /instances/
-    $urlRouterProvider.otherwise("/instances/");
+    // For any unmatched url, send to /
+    $urlRouterProvider.otherwise('/');
 
     // Required by Django
     RestangularProvider.setRequestSuffix('/');
 
     $stateProvider
         .state('instances', {
-            url: "/instances/",
+            url: "/",
             abstract: true, // By making this abstract, 'instances.empty' gets added to the homepage as well.
             templateUrl: "/static/html/instance/index.html",
             controller: "Index",

--- a/instance/static/js/src/instance.js
+++ b/instance/static/js/src/instance.js
@@ -32,9 +32,12 @@ app.config(function($httpProvider) {
     $httpProvider.defaults.xsrfHeaderName = 'X-CSRFToken';
 });
 
-app.config(function($stateProvider, $urlRouterProvider, RestangularProvider) {
+app.config(function($stateProvider, $urlRouterProvider, RestangularProvider, $locationProvider) {
     // For any unmatched url, send to /
     $urlRouterProvider.otherwise('/');
+
+    // Use History.pushState instead of hash/fragment URLs
+    $locationProvider.html5Mode(true);
 
     // Required by Django
     RestangularProvider.setRequestSuffix('/');

--- a/instance/templates/instance/index.html
+++ b/instance/templates/instance/index.html
@@ -5,6 +5,9 @@
 
 {% block title %}Instances{% endblock %}
 
+{# Needed for angular's pushState to work #}
+{% block base %}{% url 'instance:index' %}{% endblock base %}
+
 {% block css %}
 {% compress css %}
 <link href="{% static "scss/instance.scss" %}" type="text/x-scss" rel="stylesheet"/>

--- a/instance/urls.py
+++ b/instance/urls.py
@@ -31,5 +31,5 @@ from instance import views
 
 app_name = 'instance'
 urlpatterns = [
-    url(r'^$', views.index, name='index'),
+    url(r'^', views.index, name='index'),
 ]

--- a/templates/base.html
+++ b/templates/base.html
@@ -10,6 +10,9 @@
     <title>{% block title %}{% endblock title %} - OpenCraft -</title>
     {% endblock base_title %}
 
+    {# Base for relative urls #}
+    <base href="{% block base %}{% endblock base %}"/>
+
     {# Base Foundation CSS #}
     {% block foundation_css %}
     {% compress css %}


### PR DESCRIPTION
The instance manager django app now lives at `/instance/`, which means that we end up with routes like `/instance/#/instances/50`. This pull request removes the `/instances/` prefix from the angular routes and turns on the html5 pushState mode, turning that url into the less redundant `/instance/50`.