### PR TITLE
Correct case of Ansible setting for Celery worker timeout.

### DIFF
--- a/instance/templates/instance/ansible/vars.yml
+++ b/instance/templates/instance/ansible/vars.yml
@@ -77,4 +77,4 @@ COMMON_USER_INFO:{% for github_username in github_admin_username_list %}
     type: admin{% endfor %}{% endif %}
 
 # Workers
-edxapp_worker_default_stopwaitsecs: 1200
+EDXAPP_WORKER_DEFAULT_STOPWAITSECS: 1200


### PR DESCRIPTION
The setting was uppercased in edx/configuration#2993 after #65 was merged, and never corrected here.