### PR TITLE
Use js version of zxcvbn

### DIFF
--- a/registration/templates/registration/registration.html
+++ b/registration/templates/registration/registration.html
@@ -76,5 +76,6 @@
 {% block body_js %}
 <script src="{% static "djng/js/django-angular.min.js" %}"></script>
 <script src="{% static "external/js/icheck.min.js" %}"></script>
+<script src="{% static "external/js/zxcvbn.js" %}"></script>
 <script src="{% static "js/src/registration.js" %}"></script>
 {% endblock body_js %}

--- a/registration/templates/registration/registration_form.html
+++ b/registration/templates/registration/registration_form.html
@@ -35,6 +35,9 @@
             {% include row with field=form.accept_terms %}
             {% include row with field=form.subscribe_to_updates %}
         {% endwith %}
+        {% with field=form.password_strength %}
+            {{ field }}
+        {% endwith %}
         <div class="page-content__wrapper__stroke hidden-xs"></div>
     </div>
 

--- a/registration/tests/js/registration_app_spec.js
+++ b/registration/tests/js/registration_app_spec.js
@@ -22,7 +22,8 @@
 describe('RegistrationApp', function() {
     var $scope,
         httpBackend,
-        errors;
+        errors,
+        controller;
 
     beforeEach(function() {
         angular.mock.module('RegistrationApp');
@@ -35,7 +36,7 @@ describe('RegistrationApp', function() {
             $scope.registration = {};
             httpBackend = $httpBackend;
             errors = {};
-            $controller('Registration', {
+            controller = $controller('Registration as reg', {
                 $scope: $scope,
                 djangoForm: {
                     setErrors: function(form, err) {
@@ -74,7 +75,18 @@ describe('RegistrationApp', function() {
             }, 501);
         });
 
-        ['subdomain', 'username', 'email', 'password', 'password_confirmation'].forEach(function(field) {
+        it('triggers client-side validation when password field changes', function(done) {
+            spyOn($scope.reg, 'getValidationFeedback');
+            $scope.registration.password = 'changed';
+            $scope.form.password = {$dirty: true};
+            $scope.$digest();
+            setTimeout(function() {
+                expect($scope.reg.getValidationFeedback).toHaveBeenCalled();
+                done();
+            }, 501);
+        });
+
+        ['subdomain', 'username', 'email', 'password_confirmation'].forEach(function(field) {
             it('triggers server-side validation when ' + field + ' changes', function(done) {
                 spyOn($scope, 'validate');
                 $scope.registration[field] = 'changed';

--- a/registration/tests/test_views.py
+++ b/registration/tests/test_views.py
@@ -62,6 +62,7 @@ class BetaTestApplicationViewTestMixin:
             'email': 'albus.dumbledore@hogwarts.edu',
             'public_contact_email': 'support@hogwarts.edu',
             'password': 'gryffindor',
+            'password_strength': 3,
             'password_confirmation': 'gryffindor',
             'project_description': 'Online courses in Witchcraft and Wizardry',
             'accept_terms': True,
@@ -103,6 +104,7 @@ class BetaTestApplicationViewTestMixin:
         form_fields = {name: field
                        for name, field in self._get_form_fields(response).items()
                        if name not in {'password',
+                                       'password_strength',
                                        'password_confirmation',
                                        'csrfmiddlewaretoken'}}
         form_values = {name: field['value']
@@ -110,6 +112,7 @@ class BetaTestApplicationViewTestMixin:
         expected_values = {name: value
                            for name, value in self.form_data.items()
                            if name not in {'password',
+                                           'password_strength',
                                            'password_confirmation'}}
         self.assertEqual(form_values, expected_values)
         for name, field in form_fields.items():
@@ -317,9 +320,11 @@ class BetaTestApplicationViewTestMixin:
         """
         Password not strong enough.
         """
-        for password in ('password', 'qwerty', 'Hogwarts'):
+        passwords = {'password': 0, 'qwerty': 0, 'Hogwarts': 1}
+        for password, password_strength in passwords.items():
             self.form_data['password'] = password
             self.form_data['password_confirmation'] = password
+            self.form_data['password_strength'] = password_strength
             self._assert_registration_fails(self.form_data, expected_errors={
                 'password': ['Please use a stronger password: avoid common '
                              'patterns and make it long enough to be '
@@ -350,6 +355,7 @@ class BetaTestApplicationViewTestMixin:
         # The password fields do not appear on the form for logged in users
         form_data = self.form_data.copy()
         del form_data['password']
+        del form_data['password_strength']
         del form_data['password_confirmation']
         self._assert_registration_succeeds(form_data)
 

--- a/registration/tests/utils.py
+++ b/registration/tests/utils.py
@@ -73,7 +73,7 @@ class BrowserTestMixin:
             if element.get_attribute('type') == 'checkbox':
                 if bool(value) != element.is_selected():
                     element.click()
-            elif not element.get_attribute('readonly'):
+            elif not element.get_attribute('readonly') and not element.get_attribute('type') == 'hidden':
                 element.clear()
                 element.send_keys(value)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -126,4 +126,3 @@ unicodecsv==0.14.1
 virtualenv==15.0.1
 Werkzeug==0.11.1
 wrapt==1.10.8
-zxcvbn-py3==1.1

--- a/static/external/js/Makefile
+++ b/static/external/js/Makefile
@@ -25,7 +25,7 @@ CDNJS = https://cdnjs.cloudflare.com/ajax/libs
 
 all: angular.min.js angular.min.js.map angular-mocks.js angular-route.min.js angular-route.min.js.map \
 	 angular-ui-router.min.js django-angular.min.js icheck.min.js jquery.min.js jshint.js \
-	 restangular.min.js underscore-min.js underscore-min.map
+	 restangular.min.js underscore-min.js underscore-min.map zxcvbn.js
 
 angular.min.js:
 	$(GET) $@ $(CDNJS)/angular.js/1.4.6/angular.min.js
@@ -67,3 +67,6 @@ underscore-min.js:
 
 underscore-min.map:
 	$(GET) $@ $(CDNJS)/underscore.js/1.8.3/underscore-min.map
+
+zxcvbn.js:
+	$(GET) $@ $(CDNJS)/zxcvbn/4.3.0/zxcvbn.js


### PR DESCRIPTION
... to improve quality of user-visible feedback from password validation.

cf. [OC-1587](https://tasks.opencraft.com/browse/OC-1587)

The form now behaves like this w/r/t password validation: When user enters password it is validated on the client, and the form displays feedback (suggestions and warnings) from `zxcvbn`. If a user goes ahead and submits the form while password strength is still too low, the server rejects the submission based on the password strength computed on the client, and the form displays a generic error message: "Please use a stronger password: avoid common patterns and make it long enough to be difficult to crack.". At this point, the input field for "password" is empty (since `django-angular` clears contents of password fields by default), so it wouldn't make sense to display feedback that is specific to a given password. Then, when the user enters another password, client side validation kicks in again and displays password-specific feedback from `zxcvbn` (until the password is strong enough).