### PR TITLE
Introduce repository fork settings to be used for production instances.

### DIFF
--- a/instance/factories.py
+++ b/instance/factories.py
@@ -115,6 +115,8 @@ def production_instance_factory(**kwargs):
     extra_settings = ansible.yaml_merge(production_settings, configuration_extra_settings)
     instance_kwargs = dict(
         use_ephemeral_databases=False,
+        edx_platform_repository_url=settings.STABLE_EDX_PLATFORM_REPO_URL,
+        configuration_source_repo_url=settings.STABLE_CONFIGURATION_REPO_URL,
         configuration_version=settings.OPENEDX_RELEASE_STABLE_REF,
         openedx_release=settings.OPENEDX_RELEASE_STABLE_REF,
         configuration_extra_settings=extra_settings,

--- a/instance/tests/test_factories.py
+++ b/instance/tests/test_factories.py
@@ -140,8 +140,10 @@ class FactoriesTestCase(TestCase):
             patched_settings.INSTANCE_MYSQL_URL = None
             patched_settings.INSTANCE_MONGO_URL = None
 
-            # Ensure that validation passes for configuration_version:
+            # Copy required settings over to the mock settings
             patched_settings.OPENEDX_RELEASE_STABLE_REF = settings.OPENEDX_RELEASE_STABLE_REF
+            patched_settings.STABLE_EDX_PLATFORM_REPO_URL = settings.STABLE_EDX_PLATFORM_REPO_URL
+            patched_settings.STABLE_CONFIGURATION_REPO_URL = settings.STABLE_CONFIGURATION_REPO_URL
 
             production_instance_factory(sub_domain="production-instance-doomed")
 

--- a/opencraft/settings.py
+++ b/opencraft/settings.py
@@ -312,6 +312,16 @@ DEFAULT_CONFIGURATION_VERSION = env('DEFAULT_CONFIGURATION_VERSION', default=DEF
 # configuration, edx-platform, forum, notifier, xqueue, and certs when creating production instances.
 OPENEDX_RELEASE_STABLE_REF = env('OPENEDX_RELEASE_STABLE_REF', default='named-release/dogwood.rc')
 
+# The edx-platform repository used by default for production instances
+STABLE_EDX_PLATFORM_REPO_URL = env(
+    'STABLE_EDX_PLATFORM_REPO_URL', default='https://github.com/{}.git'.format(DEFAULT_FORK)
+)
+
+# The configuration repository used by default for production instances
+STABLE_CONFIGURATION_REPO_URL = env(
+    'STABLE_CONFIGURATION_REPO_URL', default=DEFAULT_CONFIGURATION_REPO_URL
+)
+
 # Ansible #####################################################################
 
 # Ansible requires a Python 2 interpreter


### PR DESCRIPTION
We want to be able to set different default forks for production instances than for sandboxes.  For the sandboxes, the upstream forks should be used by default, while we want to use the modified named release branches for production instances by default.

This PR introduces two new settings to allow this.