### PR TITLE
Fix intermittent errors affecting CircleCI builds

### DIFF
--- a/bin/run-circleci-tests
+++ b/bin/run-circleci-tests
@@ -4,6 +4,25 @@ set -e
 
 make install_system_dependencies
 
+# Try to get Redis up and running before launching tests.
+# In the past, individual tests from our unit test suite would sometimes fail with a "ConnectionRefusedError"
+# that was caused by Redis being unavailable in the container running the tests.
+# The solution below is based on suggestions from the following support thread:
+# https://discuss.circleci.com/t/redis-server-problems-unable-to-connect-localhost-6379/4040
+ATTEMPTS=0
+until bash -c "sudo service redis-server status"; do
+    if [ $ATTEMPTS -lt 300 ]
+    then
+        >&2 echo "Redis not running, trying to kick start it"
+        bash -c "sudo service redis-server start"
+        sleep 1
+        ATTEMPTS=$((ATTEMPTS+1))
+    else
+        >&2 echo "Redis is not running, so tests that depend on it will fail. Aborting."
+        exit 1
+    fi
+done
+
 case $CIRCLE_NODE_INDEX in
     0)
         make test

--- a/registration/tests/browser/browser_registration.py
+++ b/registration/tests/browser/browser_registration.py
@@ -51,12 +51,6 @@ class BetaTestBrowserTestCase(BrowserTestMixin,
             path=reverse('registration:register'),
         )
 
-    def form_valid(self):
-        """
-        Return True if the form is valid, False otherwise.
-        """
-        return 'ng-valid' in self.form.get_attribute('class').split()
-
     def _get_response_body(self, url):
         """
         Navigate to the given url and return the page body as a string.
@@ -66,8 +60,7 @@ class BetaTestBrowserTestCase(BrowserTestMixin,
 
     def _register(self, form_data):
         """
-        Fill in the registration form and click the submit button, if the form
-        is valid.
+        Fill in the registration form and click the submit button.
         """
         self.client.get(self.url)
         self.fill_form(form_data)
@@ -75,8 +68,7 @@ class BetaTestBrowserTestCase(BrowserTestMixin,
         # Wait for ajax validation to complete
         time.sleep(2)
 
-        if self.form_valid():
-            self.submit_form()
+        self.submit_form()
 
         return self.client.page_source
 

--- a/registration/tests/test_views.py
+++ b/registration/tests/test_views.py
@@ -27,6 +27,7 @@ import json
 import re
 
 from bs4 import BeautifulSoup
+from ddt import ddt, data, unpack
 from django.core import mail
 from django.core.urlresolvers import reverse
 from django.contrib.auth.models import User
@@ -43,6 +44,7 @@ from registration.tests.utils import UserMixin
 
 # Tests #######################################################################
 
+@ddt
 class BetaTestApplicationViewTestMixin:
     """
     Tests for beta test applications.
@@ -316,20 +318,24 @@ class BetaTestApplicationViewTestMixin:
             'public_contact_email': ['Enter a valid email address.'],
         })
 
-    def test_weak_password(self):
+    @data(
+        ('password', 0),
+        ('querty', 0),
+        ('Hogwarts', 1),
+    )
+    @unpack
+    def test_weak_password(self, password, password_strength):
         """
         Password not strong enough.
         """
-        passwords = {'password': 0, 'qwerty': 0, 'Hogwarts': 1}
-        for password, password_strength in passwords.items():
-            self.form_data['password'] = password
-            self.form_data['password_confirmation'] = password
-            self.form_data['password_strength'] = password_strength
-            self._assert_registration_fails(self.form_data, expected_errors={
-                'password': ['Please use a stronger password: avoid common '
-                             'patterns and make it long enough to be '
-                             'difficult to crack.'],
-            })
+        self.form_data['password'] = password
+        self.form_data['password_confirmation'] = password
+        self.form_data['password_strength'] = password_strength
+        self._assert_registration_fails(self.form_data, expected_errors={
+            'password': ['Please use a stronger password: avoid common '
+                         'patterns and make it long enough to be '
+                         'difficult to crack.'],
+        })
 
     def test_password_mismatch(self):
         """

--- a/registration/tests/utils.py
+++ b/registration/tests/utils.py
@@ -89,11 +89,15 @@ class BrowserTestMixin:
         Click the submit button on the form and wait for the next page to
         load.
         """
-        submit = self.form.find_element_by_tag_name('button')
         html = self.client.find_element_by_tag_name('html')
+        submit = self.form.find_element_by_tag_name('button')
         submit.click()
+        # Wait for page to start reloading.
         WebDriverWait(self.client, timeout=3) \
             .until(expected_conditions.staleness_of(html))
+        # Wait for page to finish reloading.
+        WebDriverWait(self.client, timeout=20) \
+            .until(lambda driver: driver.execute_script("return document.readyState;") == "complete")
 
     def _login(self, **kwargs):
         """

--- a/registration/tests/utils.py
+++ b/registration/tests/utils.py
@@ -28,6 +28,7 @@ from django.contrib.auth.models import User
 from django.core.urlresolvers import reverse
 from selenium import webdriver
 from selenium.common.exceptions import WebDriverException
+from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions
 from selenium.webdriver.support.ui import WebDriverWait
 
@@ -73,9 +74,15 @@ class BrowserTestMixin:
             if element.get_attribute('type') == 'checkbox':
                 if bool(value) != element.is_selected():
                     element.click()
+                    # Before moving on, make sure checkbox state (checked/unchecked) corresponds to desired value
+                    WebDriverWait(self.client, timeout=5) \
+                        .until(expected_conditions.element_selection_state_to_be(element, value))
             elif not element.get_attribute('readonly') and not element.get_attribute('type') == 'hidden':
                 element.clear()
                 element.send_keys(value)
+                # Before moving on, make sure input field contains desired text
+                WebDriverWait(self.client, timeout=5) \
+                    .until(expected_conditions.text_to_be_present_in_element_value((By.NAME, field), value))
 
     def submit_form(self):
         """


### PR DESCRIPTION
cf. [OC-1651](https://tasks.opencraft.com/browse/OC-1651)

Fixes the following issues affecting CircleCI builds:

* `ConnectionRefusedError` affecting unit tests (not possible to reproduce locally):

  ```
  ======================================================================
  ERROR: test_get_authenticated (instance.tests.api.test_instance.InstanceAPITestCase)
  ----------------------------------------------------------------------
  Traceback (most recent call last):
    File "/home/ubuntu/virtualenvs/venv-3.5.1/lib/python3.5/site-packages/redis/connection.py", line 439, in connect
      sock = self._connect()
    File "/home/ubuntu/virtualenvs/venv-3.5.1/lib/python3.5/site-packages/redis/connection.py", line 494, in _connect
      raise err
    File "/home/ubuntu/virtualenvs/venv-3.5.1/lib/python3.5/site-packages/redis/connection.py", line 482, in _connect
      sock.connect(socket_address)
  ConnectionRefusedError: [Errno 111] Connection refused
  ```

* `AssertionError` affecting browser tests (possible to reproduce locally):

  ```
  ======================================================================
  FAIL: test_invalid_email (registration.tests.browser.browser_registration.BetaTestBrowserTestCase)
  ----------------------------------------------------------------------
  Traceback (most recent call last):
    File "/home/ubuntu/opencraft/registration/tests/test_views.py", line 274, in test_invalid_email
      'email': ['Enter a valid email address.'],
    File "/home/ubuntu/opencraft/registration/tests/test_views.py", line 189, in assert_registration_fails
      expected_errors)
  AssertionError: defaultdict(<class 'list'>, {'email': ['This field is required.']}) != {'email': ['Enter a valid email address.']}
  ```

* Another type of `AssertionError` that's not listed on the ticket:

  ```
  ======================================================================
  FAIL: test_existing_user (registration.tests.browser.browser_registration.BetaTestBrowserTestCase)
  ----------------------------------------------------------------------
  Traceback (most recent call last):
    File "/home/ubuntu/opencraft/registration/tests/test_views.py", line 366, in test_existing_user
      self._assert_registration_succeeds(form_data)
    File "/home/ubuntu/virtualenvs/venv-3.5.1/lib/python3.5/site-packages/factory/django.py", line 339, in wrapper
      return callable_obj(*args, **kwargs)
    File "/home/ubuntu/opencraft/registration/tests/test_views.py", line 83, in _assert_registration_succeeds
      self._assert_success_response(response)
    File "/home/ubuntu/opencraft/registration/tests/test_views.py", line 104, in _assert_success_response
      response_body)
  AssertionError: 'Thank you for applying for the OpenCraft beta' not found in '<!DOCTYPE html> <html ...>...</html>'
