### PR TITLE
Fix footer spacing on smaller displays

### DIFF
--- a/static/scss/layout/_footer.scss
+++ b/static/scss/layout/_footer.scss
@@ -8,8 +8,6 @@
 
     &__container
     {
-        padding: 1.67rem;
-
         @include from('md')
         {
             display: table;
@@ -20,12 +18,6 @@
         {
             padding-left: 4.67rem;
             padding-right: 4.67rem;
-        }
-
-        @include from('lg')
-        {
-            padding-left: 0;
-            padding-right: 0;
         }
     }
 

--- a/static/scss/pages/_page.scss
+++ b/static/scss/pages/_page.scss
@@ -103,6 +103,7 @@
         &__inner
         {
             position: relative;
+            margin-bottom: 3rem;
             padding-top: 4rem;
             @extend %box-shadow;
 


### PR DESCRIPTION
@pomegranited noticed that there is no footer spacing on smaller displays:

![screen shot 2016-06-10 at 11 50 02 am](https://cloud.githubusercontent.com/assets/793379/15997685/2ea7759e-3161-11e6-81c2-5e46db828962.png)

This pull request fixes the spacing.