### PR TITLE
Set CMS_HOSTNAME Ansible variable to the Studio domain.

### DIFF
--- a/instance/models/openedx_instance.py
+++ b/instance/models/openedx_instance.py
@@ -19,6 +19,7 @@
 """
 Open edX Instance models
 """
+import re
 import string
 
 from django.conf import settings
@@ -144,6 +145,21 @@ class OpenEdXInstance(Instance, OpenEdXAppConfiguration, OpenEdXDatabaseMixin,
             return self.external_studio_domain
         else:
             return self.internal_studio_domain
+
+    @property
+    def studio_domain_nginx_regex(self):
+        """
+        Regex that matches either the internal or the external Studio URL.
+
+        This is exclusively meant for the Ansible variable CMS_HOSTNAME to configure the nginx
+        server_name regex to match the Studio domains.
+        """
+        if self.external_studio_domain:
+            domains = [self.external_studio_domain, self.internal_studio_domain]
+        else:
+            domains = [self.internal_studio_domain]
+        choices = '|'.join(map(re.escape, domains))  # pylint: disable=bad-builtin
+        return '~^({})$'.format(choices)
 
     @property
     def url(self):

--- a/instance/templates/instance/ansible/vars.yml
+++ b/instance/templates/instance/ansible/vars.yml
@@ -13,6 +13,7 @@ EDXAPP_PREVIEW_LMS_BASE: '{{ instance.lms_preview_domain }}'
 
 EDXAPP_CMS_SITE_NAME: '{{ instance.studio_domain }}'
 EDXAPP_CMS_BASE: '{{ instance.studio_domain }}'
+CMS_HOSTNAME: '{{ instance.studio_domain }}'
 
 # Enable OpenStack settings to be able to use Swift.  These three variables are ignored in versions
 # of the configuration repo that don't have the openstack role yet, so it's safe to include them.

--- a/instance/templates/instance/ansible/vars.yml
+++ b/instance/templates/instance/ansible/vars.yml
@@ -13,7 +13,7 @@ EDXAPP_PREVIEW_LMS_BASE: '{{ instance.lms_preview_domain }}'
 
 EDXAPP_CMS_SITE_NAME: '{{ instance.studio_domain }}'
 EDXAPP_CMS_BASE: '{{ instance.studio_domain }}'
-CMS_HOSTNAME: '{{ instance.studio_domain }}'
+CMS_HOSTNAME: '{{ instance.studio_domain_nginx_regex }}'
 
 # Enable OpenStack settings to be able to use Swift.  These three variables are ignored in versions
 # of the configuration repo that don't have the openstack role yet, so it's safe to include them.

--- a/instance/tests/models/test_openedx_instance.py
+++ b/instance/tests/models/test_openedx_instance.py
@@ -157,6 +157,7 @@ class OpenEdXInstanceTestCase(TestCase):
         self.assertEqual(instance.domain, internal_lms_domain)
         self.assertEqual(instance.lms_preview_domain, internal_lms_preview_domain)
         self.assertEqual(instance.studio_domain, internal_studio_domain)
+        self.assertEqual(instance.studio_domain_nginx_regex, r'~^(studio\-sample\.example\.org)$')
         self.assertEqual(instance.url, 'http://{}/'.format(internal_lms_domain))
         self.assertEqual(instance.lms_preview_url, 'http://{}/'.format(internal_lms_preview_domain))
         self.assertEqual(instance.studio_url, 'http://{}/'.format(internal_studio_domain))
@@ -176,6 +177,10 @@ class OpenEdXInstanceTestCase(TestCase):
         self.assertEqual(instance.domain, external_lms_domain)
         self.assertEqual(instance.lms_preview_domain, external_lms_preview_domain)
         self.assertEqual(instance.studio_domain, external_studio_domain)
+        self.assertEqual(
+            instance.studio_domain_nginx_regex,
+            r'~^(external\-studio\.domain\.com|studio\-sample\.example\.org)$'
+        )
         self.assertEqual(instance.url, 'http://{}/'.format(external_lms_domain))
         self.assertEqual(instance.lms_preview_url, 'http://{}/'.format(external_lms_preview_domain))
         self.assertEqual(instance.studio_url, 'http://{}/'.format(external_studio_domain))


### PR DESCRIPTION
This Ansible variable is used as the `server_name` for nginx, so it must match the Studio domain name.