### PR TITLE
Use production playbook

### DIFF
--- a/instance/models/mixins/ansible.py
+++ b/instance/models/mixins/ansible.py
@@ -51,6 +51,7 @@ class AnsibleAppServerMixin(models.Model):
     ansible_groups = (
         'rabbitmq',
         'elasticsearch',
+        'postfix_queue',
         'worker',
         'web',
         'forum',

--- a/instance/models/mixins/ansible.py
+++ b/instance/models/mixins/ansible.py
@@ -48,6 +48,17 @@ class AnsibleAppServerMixin(models.Model):
     """
     An AppServer that relies on Ansible to deploy its services
     """
+    ansible_groups = (
+        'rabbitmq',
+        'elasticsearch',
+        'worker',
+        'web',
+        'forum',
+        'notifier',
+        'xqueue',
+        'certs',
+    )
+
     class Meta:
         abstract = True
 
@@ -71,7 +82,8 @@ class AnsibleAppServerMixin(models.Model):
         public_ip = self.server.public_ip
         if public_ip is None:
             raise RuntimeError("Cannot prepare to run playbooks when server has no public IP.")
-        return '[app]\n{server_ip}'.format(server_ip=public_ip)
+        return '\n'.join('[{group}]\n{server_ip}'.format(group=group, server_ip=public_ip)
+                         for group in self.ansible_groups)
 
     def _run_playbook(self, working_dir, playbook):
         """

--- a/instance/models/openedx_appserver.py
+++ b/instance/models/openedx_appserver.py
@@ -126,7 +126,7 @@ class OpenEdXAppServer(AppServer, OpenEdXAppConfiguration, AnsibleAppServerMixin
     ))
     lms_user_settings = models.TextField(blank=True, help_text='YAML variables for LMS user creation.')
 
-    CONFIGURATION_PLAYBOOK = 'edx_sandbox'
+    CONFIGURATION_PLAYBOOK = 'edx_production'
     CONFIGURATION_VARS_TEMPLATE = 'instance/ansible/vars.yml'
     RUN_ROLE_PLAYBOOK = 'run_role'
     LMS_USER_VARS_TEMPLATE = 'instance/ansible/lms_users.yml'

--- a/instance/templates/instance/ansible/vars.yml
+++ b/instance/templates/instance/ansible/vars.yml
@@ -21,6 +21,15 @@ EDXAPP_CMS_SITE_NAME: '{{ instance.studio_domain }}'
 EDXAPP_CMS_BASE: '{{ instance.studio_domain }}'
 CMS_HOSTNAME: '{{ instance.studio_domain_nginx_regex }}'
 
+EDXAPP_CELERY_BROKER_HOSTNAME: ''
+EDXAPP_COMMENTS_SERVICE_URL: 'http://localhost:18080'
+EDXAPP_ECOMMERCE_API_URL: 'http://localhost:8002/api/v2'
+EDXAPP_ECOMMERCE_PUBLIC_URL_ROOT: 'http://localhost:8002'
+EDXAPP_ELASTIC_SEARCH_CONFIG:
+  - host: 'localhost'
+    port: 9200
+EDXAPP_XQUEUE_URL: 'http://localhost:18040'
+
 # Nginx
 {% if instance.protocol == 'https' %}
 NGINX_ENABLE_SSL: true

--- a/instance/templates/instance/ansible/vars.yml
+++ b/instance/templates/instance/ansible/vars.yml
@@ -48,6 +48,7 @@ COMMON_VHOST_ROLE_NAME: 'openstack'
 # Forum environment settings
 FORUM_RACK_ENV: 'production'
 FORUM_SINATRA_ENV: 'production'
+FORUM_ELASTICSEARCH_HOST: 'localhost'
 
 # Emails
 EDXAPP_CONTACT_EMAIL: '{{ appserver.email }}'

--- a/instance/tests/models/test_openedx_ansible_mixins.py
+++ b/instance/tests/models/test_openedx_ansible_mixins.py
@@ -23,6 +23,7 @@ OpenEdXAppServer Ansible Mixin - Tests
 # Imports #####################################################################
 
 import os
+from configparser import ConfigParser
 from unittest.mock import patch, call, Mock
 
 from instance.models.mixins.ansible import Playbook
@@ -48,7 +49,10 @@ class AnsibleAppServerTestCase(TestCase):
 
         appserver = make_test_appserver()
         appserver.provision()  # This is when the server gets created
-        self.assertEqual(appserver.inventory_str, '[app]\n192.168.100.200')
+        inventory = ConfigParser(allow_no_value=True)
+        inventory.read_string(appserver.inventory_str)
+        for group in appserver.ansible_groups:
+            self.assertEqual(inventory[group].keys(), {'192.168.100.200'})
 
     @patch_services
     def test_inventory_str_no_server(self, mocks):
@@ -79,7 +83,7 @@ class AnsibleAppServerTestCase(TestCase):
             inventory_str=mock_inventory,
             vars_str=appserver.configuration_settings,
             playbook_path='{}/playbooks'.format(working_dir),
-            playbook_name='edx_sandbox.yml',
+            playbook_name='edx_production.yml',
             username='ubuntu',
         ), mock_run_playbook.mock_calls)
 


### PR DESCRIPTION
https://github.com/edx/configuration/pull/3118 adds an `edx_production.yml` playbook specifically designed to deploy production instances. This pull request modifies the Instance Manager to use the new playbook.
