### PR TITLE
Make each child process log to its own file

### DIFF
--- a/opencraft/settings.py
+++ b/opencraft/settings.py
@@ -424,7 +424,7 @@ if 'file' in HANDLERS:
     LOGGING['handlers']['file'] = {
         'level': 'DEBUG',
         'class': 'logging.handlers.RotatingFileHandler',
-        'filename': 'log/main.log',
+        'filename': 'log/im.{}.log'.format(env('HONCHO_PROCESS_NAME', default='main')),
         'maxBytes': LOGGING_ROTATE_MAX_KBYTES * 1024,
         'backupCount': LOGGING_ROTATE_MAX_FILES,
         'formatter': 'verbose'

--- a/requirements.txt
+++ b/requirements.txt
@@ -40,8 +40,7 @@ glob2==0.4.1
 gunicorn==19.4.5
 # Using patched honcho that includes: https://github.com/nickstenning/honcho/pull/179
 git+https://github.com/open-craft/honcho.git@00c8f0d6c55ba1e9ec18470e942e47b07617099a#egg=honcho==0.7.2
-# Can be replaced with huey==1.1.2 when released to PyPI.
-git+https://github.com/coleifer/huey.git@7fb322880a16e87c659c38746e59d66c8e5f3db7#egg=huey==1.1.2
+huey==1.1.2
 ipdb==0.9.3
 ipython==4.2.0
 ipython-genutils==0.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -38,7 +38,8 @@ gitdb==0.6.4
 GitPython==2.0.0
 glob2==0.4.1
 gunicorn==19.4.5
-honcho==0.7.1
+# Using patched honcho that includes: https://github.com/nickstenning/honcho/pull/179
+git+https://github.com/open-craft/honcho.git@00c8f0d6c55ba1e9ec18470e942e47b07617099a#egg=honcho==0.7.2
 # Can be replaced with huey==1.1.2 when released to PyPI.
 git+https://github.com/coleifer/huey.git@7fb322880a16e87c659c38746e59d66c8e5f3db7#egg=huey==1.1.2
 ipdb==0.9.3


### PR DESCRIPTION
Child processes managed by honcho (web, websocket, worker, periodic) were all logging to the same (log/main.log) file using `logging.handlers.RotatingFileHandler`, which does not work correctly when shared by multiple processes.

We use the `HONCHO_PROCESS_NAME` environment variable exposed by honcho to subprocess environments to log output of each process to its own file:

    log/im.web.1.log
    log/im.web.2.log
    log/im.websocket.1.log
    ...

There is also `log/im.main.log` which is used to log output from the main (parent) honcho process.

*Testing*

1. Checkout this PR and do `pip install -r requirements.txt`.
2. Remove existing main.log files from the log folder: `rm log/main.log*`. The log folder should now be empty.
3. Start the IM: `make rundev`.
4. Look at the `log/` folder which should now contain `im.main.log`, `im.web.1.log`, `im.websocket.1.log`, and `im.worker.1.log`. Output is buffered so some of the files may be empty or not contain a lot of output.
5. Stop the IM, and run IM in production mode: `make run WORKERS=4`.
6. The log folder should now contain these additional files: `im.periodic1.log`, `im.worker.2.log`, `im.worker.3.log`, and `im.worker.4.log`.