### PR TITLE
Only install Django Debug Toolbar when in debugging mode.

### DIFF
--- a/opencraft/settings.py
+++ b/opencraft/settings.py
@@ -94,8 +94,10 @@ INSTALLED_APPS = (
     'huey.contrib.djhuey',
     'swampdragon',
     'simple_email_confirmation',
-    'debug_toolbar',
 ) + LOCAL_APPS
+
+if DEBUG:
+    INSTALLED_APPS += ('debug_toolbar',)
 
 MIDDLEWARE_CLASSES = (
     'django.contrib.sessions.middleware.SessionMiddleware',


### PR DESCRIPTION
The toolbar mostly disables itself when Django is not in debugging mode, but it still leaks some memory in that case.  In particular, the LoggingCollector collects all log messages in memory unconditionally, leading to a small but continuous memory leak.  The debug_toolbar app is also installed on all Huey workers, where it is essentially useless even when in debug mode.