### PR TITLE
Use new version of the user management playbook.

### DIFF
--- a/instance/models/openedx_appserver.py
+++ b/instance/models/openedx_appserver.py
@@ -126,9 +126,9 @@ class OpenEdXAppServer(AppServer, OpenEdXAppConfiguration, AnsibleAppServerMixin
     ))
     lms_user_settings = models.TextField(blank=True, help_text='YAML variables for LMS user creation.')
 
-    CONFIGURATION_PLAYBOOK = 'edx_sandbox'
+    CONFIGURATION_PLAYBOOK = 'playbooks/edx_sandbox.yml'
     CONFIGURATION_VARS_TEMPLATE = 'instance/ansible/vars.yml'
-    RUN_ROLE_PLAYBOOK = 'run_role'
+    MANAGE_USERS_PLAYBOOK = 'playbooks/edx-east/manage_edxapp_users_and_groups.yml'
     LMS_USER_VARS_TEMPLATE = 'instance/ansible/lms_users.yml'
     # Additional model fields/properties that contain yaml vars to add the the configuration vars:
     CONFIGURATION_EXTRA_FIELDS = [
@@ -166,7 +166,7 @@ class OpenEdXAppServer(AppServer, OpenEdXAppConfiguration, AnsibleAppServerMixin
         return Playbook(
             source_repo=self.configuration_source_repo_url,
             requirements_path='requirements.txt',
-            playbook_path='playbooks/{}.yml'.format(self.CONFIGURATION_PLAYBOOK),
+            playbook_path=self.CONFIGURATION_PLAYBOOK,
             version=self.configuration_version,
             variables=self.configuration_settings,
         )
@@ -178,7 +178,7 @@ class OpenEdXAppServer(AppServer, OpenEdXAppConfiguration, AnsibleAppServerMixin
         return Playbook(
             source_repo=self.configuration_source_repo_url,
             requirements_path='requirements.txt',
-            playbook_path='playbooks/{}.yml'.format(self.RUN_ROLE_PLAYBOOK),
+            playbook_path=self.MANAGE_USERS_PLAYBOOK,
             version=self.configuration_version,
             variables=self.lms_user_settings,
         )

--- a/instance/templates/instance/ansible/lms_users.yml
+++ b/instance/templates/instance/ansible/lms_users.yml
@@ -1,13 +1,12 @@
-role: create_lms_users
-
-CREATE_LMS_USERS:
+django_users:
 {% for user in lms_users %}
   - email: '{{ user.email }}'
-    name: '{{ user.profile.full_name }}'
     username: '{{ user.username }}'
-    password: '{{ user.password }}'
-    password_hash: true
-    is_staff: true
+    initial_password_hash: '{{ user.password }}'
+    staff: true
+    superuser: true
 {% empty %}
   []
 {% endfor %}
+
+django_groups: []

--- a/instance/tests/integration/base.py
+++ b/instance/tests/integration/base.py
@@ -45,7 +45,7 @@ class IntegrationTestCase(TestCase):
 
         # Use a reduced playbook for integration builds - it will run faster.
         # See https://github.com/open-craft/configuration/blob/integration/playbooks/opencraft_integration.yml
-        patcher = patch.object(OpenEdXAppServer, 'CONFIGURATION_PLAYBOOK', new='opencraft_integration')
+        patcher = patch.object(OpenEdXAppServer, 'CONFIGURATION_PLAYBOOK', new='playbooks/opencraft_integration.yml')
         self.addCleanup(patcher.stop)
         patcher.start()
 

--- a/instance/tests/integration/factories/instance.py
+++ b/instance/tests/integration/factories/instance.py
@@ -55,5 +55,5 @@ class OpenEdXInstanceFactory(DjangoModelFactory):
     configuration_source_repo_url = 'https://github.com/open-craft/configuration.git'
     configuration_version = 'integration'
     # The open-craft fork doesn't have the 'named-release/cypress' tag, so use upstream:
-    edx_platform_repository_url = 'https://github.com/edx/edx-platform.git'
+    edx_platform_repository_url = 'https://github.com/open-craft/edx-platform.git'
     use_ephemeral_databases = True

--- a/instance/tests/integration/integration_instance.py
+++ b/instance/tests/integration/integration_instance.py
@@ -111,7 +111,7 @@ class InstanceIntegrationTestCase(IntegrationTestCase):
         git_working_dir.return_value = os.path.join(os.path.dirname(__file__), "ansible")
 
         instance = OpenEdXInstanceFactory(name='Integration - test_ansible_failure')
-        with patch.object(OpenEdXAppServer, 'CONFIGURATION_PLAYBOOK', new="failure"):
+        with patch.object(OpenEdXAppServer, 'CONFIGURATION_PLAYBOOK', new="playbooks/failure.yml"):
             spawn_appserver(instance.ref.pk, mark_active_on_success=True, num_attempts=1)
         instance.refresh_from_db()
         self.assertIsNone(instance.active_appserver)
@@ -127,7 +127,7 @@ class InstanceIntegrationTestCase(IntegrationTestCase):
         git_working_dir.return_value = os.path.join(os.path.dirname(__file__), "ansible")
 
         instance = OpenEdXInstanceFactory(name='Integration - test_ansible_failignore')
-        with patch.object(OpenEdXAppServer, 'CONFIGURATION_PLAYBOOK', new="failignore"):
+        with patch.object(OpenEdXAppServer, 'CONFIGURATION_PLAYBOOK', new="playbooks/failignore.yml"):
             spawn_appserver(instance.ref.pk, mark_active_on_success=True, num_attempts=1)
         instance.refresh_from_db()
         self.assertIsNotNone(instance.active_appserver)

--- a/instance/tests/models/test_openedx_appserver.py
+++ b/instance/tests/models/test_openedx_appserver.py
@@ -195,9 +195,9 @@ class OpenEdXAppServerTestCase(TestCase):
         instance.lms_users.add(user)
         appserver = make_test_appserver(instance)
         ansible_settings = yaml.load(appserver.lms_user_settings)
-        self.assertEqual(ansible_settings['role'], 'create_lms_users')
-        self.assertEqual(len(ansible_settings['CREATE_LMS_USERS']), 1)
-        self.assertEqual(ansible_settings['CREATE_LMS_USERS'][0]['username'], user.username)
+        self.assertEqual(len(ansible_settings['django_users']), 1)
+        self.assertEqual(ansible_settings['django_users'][0]['username'], user.username)
+        self.assertEqual(ansible_settings['django_groups'], [])
 
     @override_settings(
         INSTANCE_SMTP_RELAY_HOST='smtp.myhost.com',


### PR DESCRIPTION
Make use of the user management playbook updated in edx/configuration#3274 and edx/edx-platform#13124.

#### Testing instructions

From the Django shell of an instance manager installation, run these commands (replacing the subdomain and the user name with appropriate values):
```
from instance.factories import production_instance_factory
instance = production_instance_factory(
    sub_domain='user-creation-test',
    edx_platform_repository_url='https://github.com/edx/edx-platform.git',
    configuration_source_repo_url='https://github.com/edx/configuration.git',
    configuration_version='master',
    openedx_release='master',
)
instance.lms_users.add(User.objects.get(username='some_existing_user'))
instance.spawn_appserver()
```
This will deploy a new instance and create a user on it.  Test that the user can log into the LMS and they have staff and superuser permissions.