### PR TITLE
Enable full Swift support for OpenCraft IM instances

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -10,8 +10,6 @@ machine:
     TEST_RUNNER: 'opencraft.tests.utils.CircleCIParallelTestRunner'
     WATCH_FORK: 'open-craft/edx-platform'
     WATCH_ORGANIZATION: 'open-craft'
-    # Integration configuration branch doesn't support Swift at present
-    SWIFT_ENABLE: false
 dependencies:
   pre:
     - pip install --upgrade pip

--- a/circle.yml
+++ b/circle.yml
@@ -10,6 +10,8 @@ machine:
     TEST_RUNNER: 'opencraft.tests.utils.CircleCIParallelTestRunner'
     WATCH_FORK: 'open-craft/edx-platform'
     WATCH_ORGANIZATION: 'open-craft'
+    # Integration configuration branch doesn't support Swift at present
+    SWIFT_ENABLE: false
 dependencies:
   pre:
     - pip install --upgrade pip

--- a/instance/models/mixins/openedx_storage.py
+++ b/instance/models/mixins/openedx_storage.py
@@ -84,21 +84,19 @@ class OpenEdXStorageMixin(SwiftContainerInstanceMixin):
             return ''
 
         new_settings = ''
-
-        # S3:
         if self.s3_access_key and self.s3_secret_access_key and self.s3_bucket_name:
+            # S3
             template = loader.get_template('instance/ansible/s3.yml')
             new_settings += template.render({'instance': self})
-
-        # SWIFT:
-        if settings.SWIFT_ENABLE:
+        elif settings.SWIFT_ENABLE:
+            # Only enable Swift if S3 isn't configured
             template = loader.get_template('instance/ansible/swift.yml')
             new_settings += template.render({
                 'user': self.swift_openstack_user,
                 'password': self.swift_openstack_password,
                 'tenant': self.swift_openstack_tenant,
                 'auth_url': self.swift_openstack_auth_url,
-                'region': self.swift_openstack_region
+                'region': self.swift_openstack_region,
+                'container_name': self.swift_container_name,
             })
-
         return new_settings

--- a/instance/templates/instance/ansible/swift.yml
+++ b/instance/templates/instance/ansible/swift.yml
@@ -1,6 +1,9 @@
 EDXAPP_SETTINGS: 'openstack'
 XQUEUE_SETTINGS: 'openstack_settings'
-COMMON_VHOST_ROLE_NAME: 'openstack'
+
+VHOST_NAME: 'openstack'
+# COMMON_VHOST_ROLE_NAME is deprecated; keeping it around for compatibility
+COMMON_VHOST_ROLE_NAME: '{{ VHOST_NAME }}'
 
 EDXAPP_DEFAULT_FILE_STORAGE: 'swift.storage.SwiftStorage'
 EDXAPP_FILE_UPLOAD_STORAGE_BUCKET_NAME: '{{ container_name }}'
@@ -15,12 +18,11 @@ EDXAPP_GRADE_STORAGE_CLASS: 'swift.storage.SwiftStorage'
 EDXAPP_GRADE_STORAGE_KWARGS:
   name_prefix: 'grades-download/'
 
-XQUEUE_SETTINGS: 'openstack_settings'
 XQUEUE_SWIFT_USERNAME: '{{ user }}'
 XQUEUE_SWIFT_KEY: '{{ password }}'
 XQUEUE_SWIFT_TENANT_NAME: '{{ tenant }}'
 XQUEUE_SWIFT_AUTH_URL: '{{ auth_url }}'
-XQUEUE_SWIFT_AUTH_VERSION: '2'
+XQUEUE_SWIFT_AUTH_VERSION: '{{ EDXAPP_SWIFT_AUTH_VERSION }}'
 XQUEUE_SWIFT_REGION_NAME: '{{ region }}'
 XQUEUE_UPLOAD_BUCKET: '{{ container_name }}'
 XQUEUE_UPLOAD_PATH_PREFIX: 'xqueue'

--- a/instance/templates/instance/ansible/swift.yml
+++ b/instance/templates/instance/ansible/swift.yml
@@ -14,3 +14,13 @@ EDXAPP_SWIFT_REGION_NAME: '{{ region }}'
 EDXAPP_GRADE_STORAGE_CLASS: 'swift.storage.SwiftStorage'
 EDXAPP_GRADE_STORAGE_KWARGS:
   name_prefix: 'grades-download/'
+
+XQUEUE_SETTINGS: 'openstack_settings'
+XQUEUE_SWIFT_USERNAME: '{{ user }}'
+XQUEUE_SWIFT_KEY: '{{ password }}'
+XQUEUE_SWIFT_TENANT_NAME: '{{ tenant }}'
+XQUEUE_SWIFT_AUTH_URL: '{{ auth_url }}'
+XQUEUE_SWIFT_AUTH_VERSION: '2'
+XQUEUE_SWIFT_REGION_NAME: '{{ region }}'
+XQUEUE_UPLOAD_BUCKET: '{{ container_name }}'
+XQUEUE_UPLOAD_PATH_PREFIX: 'xqueue'

--- a/instance/templates/instance/ansible/swift.yml
+++ b/instance/templates/instance/ansible/swift.yml
@@ -1,8 +1,16 @@
-# The following line is commented out until the openstack role has been merged upstream.
-# EDXAPP_DEFAULT_FILE_STORAGE: 'swift.storage.SwiftStorage'
+EDXAPP_SETTINGS: 'openstack'
+XQUEUE_SETTINGS: 'openstack_settings'
+COMMON_VHOST_ROLE_NAME: 'openstack'
+
+EDXAPP_DEFAULT_FILE_STORAGE: 'swift.storage.SwiftStorage'
+EDXAPP_FILE_UPLOAD_STORAGE_BUCKET_NAME: '{{ container_name }}'
 EDXAPP_SWIFT_AUTH_VERSION: '2'
 EDXAPP_SWIFT_USERNAME: '{{ user }}'
 EDXAPP_SWIFT_KEY: '{{ password }}'
 EDXAPP_SWIFT_TENANT_NAME: '{{ tenant }}'
 EDXAPP_SWIFT_AUTH_URL: '{{ auth_url }}'
 EDXAPP_SWIFT_REGION_NAME: '{{ region }}'
+
+EDXAPP_GRADE_STORAGE_CLASS: 'swift.storage.SwiftStorage'
+EDXAPP_GRADE_STORAGE_KWARGS:
+  name_prefix: 'grades-download/'

--- a/instance/templates/instance/ansible/vars.yml
+++ b/instance/templates/instance/ansible/vars.yml
@@ -30,12 +30,6 @@ NGINX_ENABLE_SSL: false
 NGINX_REDIRECT_TO_HTTPS: false
 {% endif %}
 
-# Enable OpenStack settings to be able to use Swift.  These three variables are ignored in versions
-# of the configuration repo that don't have the openstack role yet, so it's safe to include them.
-EDXAPP_SETTINGS: 'openstack'
-XQUEUE_SETTINGS: 'openstack_settings'
-COMMON_VHOST_ROLE_NAME: 'openstack'
-
 # Forum environment settings
 FORUM_RACK_ENV: 'production'
 FORUM_SINATRA_ENV: 'production'


### PR DESCRIPTION
_PR edits by @haikuginger_

We found that we weren't providing sufficient information to fully enable Swift support for OpenCraft IM instances. This PR updates our logic and playbooks to pass necessary information through appropriately. This code is deployed on our [staging instance manager.](https://stage.console.opencraft.com)

**Dependencies**: https://github.com/open-craft/configuration/commit/33a085b9d5fbcebc560e3ce5c4062f2f7a87b3e2

**Testing instructions**:

1. Deploy a new instance on Stage IM; be sure to provide necessary OpenStack settings during initialization.

2. Start a new appserver for that instance.

3. Test that instructor report CSVs can be created and downloaded on that appserver.

**Reviewers**
- [ ] @itsjeyd 