### PR TITLE
Enable Let's Encrypt automatic certificate deployment

### DIFF
--- a/instance/templates/instance/ansible/vars.yml
+++ b/instance/templates/instance/ansible/vars.yml
@@ -25,6 +25,13 @@ CMS_HOSTNAME: '{{ instance.studio_domain_nginx_regex }}'
 {% if instance.protocol == 'https' %}
 NGINX_ENABLE_SSL: true
 NGINX_REDIRECT_TO_HTTPS: true
+LETS_ENCRYPT_DOMAINS: 
+  - "{{ instance.internal_lms_domain }}"
+  - "{{ instance.external_lms_domain }}"
+  - "{{ instance.internal_lms_preview_domain }}"
+  - "{{ instance.external_lms_preview_domain }}"
+  - "{{ instance.internal_studio_domain }}"
+  - "{{ instance.external_studio_domain }}"
 {% else %}
 NGINX_ENABLE_SSL: false
 NGINX_REDIRECT_TO_HTTPS: false

--- a/instance/templates/instance/ansible/vars.yml
+++ b/instance/templates/instance/ansible/vars.yml
@@ -27,11 +27,11 @@ NGINX_ENABLE_SSL: true
 NGINX_REDIRECT_TO_HTTPS: true
 LETS_ENCRYPT_DOMAINS: 
   - "{{ instance.internal_lms_domain }}"
-  - "{{ instance.external_lms_domain }}"
   - "{{ instance.internal_lms_preview_domain }}"
-  - "{{ instance.external_lms_preview_domain }}"
   - "{{ instance.internal_studio_domain }}"
-  - "{{ instance.external_studio_domain }}"
+{% if instance.external_lms_domain %}  - "{{ instance.external_lms_domain }}"{% endif %}
+{% if instance.external_lms_preview_domain %}  - "{{ instance.external_lms_preview_domain }}"{% endif %}
+{% if instance.external_studio_domain %}  - "{{ instance.external_studio_domain }}"{% endif %}
 {% else %}
 NGINX_ENABLE_SSL: false
 NGINX_REDIRECT_TO_HTTPS: false


### PR DESCRIPTION
Updates `vars.yml` to set LETS_ENCRYPT_DOMAINS with:
- internal_lms_domain
- external_lms_domain
- internal_lms_preview_domain
- external_lms_preview_domain
- internal_studio_domain
- external_studio_domain

In combination with PR on openedx/configuration
( edx/configuration#3313 ) this should automatically
enable Let's Encrypt SSL certs on newly deployed hosts.
