### PR TITLE
Allow to set separate stable versions for edx-platform and configuration.

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,9 +272,17 @@ set the following configuration variables:
   not set, the value of `DEFAULT_OPENEDX_RELEASE` will be used.
 * `DEFAULT_FORK`: The fork of `edx-platform` to use by default. Defaults to the
   main repository, `edx/edx-platform`.
-* `OPENEDX_RELEASE_STABLE_REF`: Set this to a tag or branch for a stable
-  Open edX release. It is used as a default value for `configuration_version`
-  and `openedx_release` fields when creating production instances.
+* `OPENEDX_RELEASE_STABLE_REF`: Set this to a tag or branch for a stable Open
+  edX release. It is used as a default value for the `openedx_release` field
+  when creating production instances.
+* `STABLE_EDX_PLATFORM_REPO_URL`: The edx-platform repo used by default for
+  production instances.
+* `STABLE_EDX_PLATFORM_COMMIT`: The edx-platform commit ref used by default for
+  production instances.  Defaults to OPENEDX_RELEASE_STABLE_REF.
+* `STABLE_CONFIGURATION_REPO_URL`: The configuration repo used by default for
+  production instances.
+* `STABLE_CONFIGURATION_VERSION`: The configuration commit ref used by default
+  for production instances.  Defaults to OPENEDX_RELEASE_STABLE_REF.
 
 Migrations
 ----------

--- a/instance/factories.py
+++ b/instance/factories.py
@@ -116,8 +116,9 @@ def production_instance_factory(**kwargs):
     instance_kwargs = dict(
         use_ephemeral_databases=False,
         edx_platform_repository_url=settings.STABLE_EDX_PLATFORM_REPO_URL,
+        edx_platform_commit=settings.STABLE_EDX_PLATFORM_COMMIT,
         configuration_source_repo_url=settings.STABLE_CONFIGURATION_REPO_URL,
-        configuration_version=settings.OPENEDX_RELEASE_STABLE_REF,
+        configuration_version=settings.STABLE_CONFIGURATION_VERSION,
         openedx_release=settings.OPENEDX_RELEASE_STABLE_REF,
         configuration_extra_settings=extra_settings,
     )

--- a/instance/tests/test_factories.py
+++ b/instance/tests/test_factories.py
@@ -137,18 +137,13 @@ class FactoriesTestCase(TestCase):
             production_instance_factory()
 
         # Calling factory with settings that are problematic for production instances should produce warnings
-        with patch("instance.factories.settings") as patched_settings:
-            patched_settings.SWIFT_ENABLE = False
-            patched_settings.INSTANCE_MYSQL_URL = None
-            patched_settings.INSTANCE_MONGO_URL = None
-
-            # Copy required settings over to the mock settings
-            patched_settings.OPENEDX_RELEASE_STABLE_REF = settings.OPENEDX_RELEASE_STABLE_REF
-            patched_settings.STABLE_EDX_PLATFORM_REPO_URL = settings.STABLE_EDX_PLATFORM_REPO_URL
-            patched_settings.STABLE_CONFIGURATION_REPO_URL = settings.STABLE_CONFIGURATION_REPO_URL
-
+        with patch.multiple(
+            "instance.factories.settings",
+            SWIFT_ENABLE=False,
+            INSTANCE_MYSQL_URL=None,
+            INSTANCE_MONGO_URL=None,
+        ):
             production_instance_factory(sub_domain="production-instance-doomed")
-
             log_entries = LogEntry.objects.all()
             self.assertEqual(len(log_entries), 3)
             self.assertTrue(all(log_entry.level == "WARNING" for log_entry in log_entries))

--- a/opencraft/settings.py
+++ b/opencraft/settings.py
@@ -320,11 +320,13 @@ OPENEDX_RELEASE_STABLE_REF = env('OPENEDX_RELEASE_STABLE_REF', default='named-re
 STABLE_EDX_PLATFORM_REPO_URL = env(
     'STABLE_EDX_PLATFORM_REPO_URL', default='https://github.com/{}.git'.format(DEFAULT_FORK)
 )
+STABLE_EDX_PLATFORM_COMMIT = env('STABLE_EDX_PLATFORM_COMMIT', default=OPENEDX_RELEASE_STABLE_REF)
 
 # The configuration repository used by default for production instances
 STABLE_CONFIGURATION_REPO_URL = env(
     'STABLE_CONFIGURATION_REPO_URL', default=DEFAULT_CONFIGURATION_REPO_URL
 )
+STABLE_CONFIGURATION_VERSION = env('STABLE_CONFIGURATION_VERSION', default=OPENEDX_RELEASE_STABLE_REF)
 
 # Ansible #####################################################################
 


### PR DESCRIPTION
Currently, we only have one setting `OPENEDX_RELEASE_STABLE_REF` to set the stable release ref used by production instances.  This setting is used as `openedx_release` and `configuration_version` for production instances, which means it needs to be a valid ref for edx-platform, configuration, notifier, certs, forum, xqueue and possibly others, so usually only official release names will work.  However, we often want to commit custom changes to the edx-platform and configuration repos.  So far, we managed to do this by having a branch with the same name as an official release tag in the open-craft forks of configuration and edx-platform.  This solution is a confusing hack, so this PR introduces proper settings to set the stable versions of edx-platform and configuration explicitly.  The change is backwards-compatible since these settings default to `OPENEDX_RELEASE_STABLE_REF`.

**Testing instructions**

I'm not sure manual testing is strictly necessary, given how simple the change is.  In case you wish to test it, here is how.

Add the new settings `STABLE_EDX_PLATFORM_COMMIT` and `STABLE_CONFIGURATION_VERSION` to your `.env` file with some values.  In the Django shell, run

    from instance.factories import production_instance_factory
    instance = production_instance_factory(sub_domain="some_subdomain")
    vars(instance)

and verify that the fields `edx_platform_commit` and `configuration_version` have the desired values.