### PR TITLE
Pin the Insights and Analytics API versions for instances.

### DIFF
--- a/instance/templates/instance/ansible/vars.yml
+++ b/instance/templates/instance/ansible/vars.yml
@@ -64,6 +64,8 @@ forum_version: '{{ appserver.openedx_release }}'
 notifier_version: '{{ appserver.openedx_release }}'
 xqueue_version: '{{ appserver.openedx_release }}'
 certs_version: '{{ appserver.openedx_release }}'
+ANALYTICS_API_VERSION: '{{ appserver.openedx_release }}'
+INSIGHTS_VERSION: '{{ appserver.openedx_release }}'
 
 # Misc
 EDXAPP_LANG: 'en_US.UTF-8'


### PR DESCRIPTION
Set the Insights and Analytics API versions to `openedx_release`.  The default value for these versions is `master`, which means that these services won't get pinned to the selected release, but follow master instead.  This is clearly not intended (and probably won't work in many cases).