### PR TITLE
Compress application log files

### DIFF
--- a/opencraft/logging.py
+++ b/opencraft/logging.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+#
+# OpenCraft -- tools to aid developing and hosting free software projects
+# Copyright (C) 2015-2016 OpenCraft <contact@opencraft.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+"""
+OpenCraft - Logging
+"""
+
+# Imports #####################################################################
+
+import os
+import gzip
+from logging.handlers import RotatingFileHandler
+
+
+# Handlers ####################################################################
+
+class GzipRotatingFileHandler(RotatingFileHandler):
+    """
+    Uses gzip to compress the rotated log files.
+
+    https://docs.python.org/3/howto/logging-cookbook.html#using-a-rotator-and-namer-to-customize-log-rotation-processing
+    """
+
+    def __init__(self, *args, **kwargs):
+        super(GzipRotatingFileHandler, self).__init__(*args, **kwargs)
+        self.namer = self._namer
+        self.rotator = self._rotator
+
+    @staticmethod
+    def _namer(name):
+        """Append a .gz suffix to the rotated files."""
+        return name + '.gz'
+
+    @staticmethod
+    def _rotator(source, dest):
+        """Write compressed output when rotating files."""
+        with open(source, "rb") as sf:
+            with gzip.open(dest, "wb", compresslevel=9) as df:
+                for line in sf:
+                    df.write(line)
+            os.remove(source)

--- a/opencraft/settings.py
+++ b/opencraft/settings.py
@@ -427,7 +427,7 @@ LOGGING = {
 if 'file' in HANDLERS:
     LOGGING['handlers']['file'] = {
         'level': 'DEBUG',
-        'class': 'logging.handlers.RotatingFileHandler',
+        'class': 'opencraft.logging.GzipRotatingFileHandler',
         'filename': 'log/im.{}.log'.format(env('HONCHO_PROCESS_NAME', default='main')),
         'maxBytes': LOGGING_ROTATE_MAX_KBYTES * 1024,
         'backupCount': LOGGING_ROTATE_MAX_FILES,

--- a/opencraft/tests/test_logging.py
+++ b/opencraft/tests/test_logging.py
@@ -1,0 +1,97 @@
+# -*- coding: utf-8 -*-
+#
+# OpenCraft -- tools to aid developing and hosting free software projects
+# Copyright (C) 2015-2016 OpenCraft <contact@opencraft.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+"""
+OpenCraft - Logging - Tests
+"""
+
+# Imports #####################################################################
+
+import os
+import sys
+import gzip
+import logging
+import tempfile
+import shutil
+
+from instance.tests.base import TestCase
+from opencraft.logging import GzipRotatingFileHandler
+
+
+# Tests #######################################################################
+
+class GzipRotatingFileHandlerTest(TestCase):
+    """
+    Test cases for the compressing log file handler.
+    """
+
+    def setUp(self):
+        super(GzipRotatingFileHandlerTest, self).setUp()
+
+        # Create temp log dir, to be deleted on cleanup
+        self.log_dir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.log_dir)
+
+        # Configure log handler
+        self.log_file = os.path.join(self.log_dir, 'test.log')
+        self.num_logs = 3
+        self.test_string = 'a' * 1000
+        self.max_bytes = sys.getsizeof(self.test_string) + 1
+        self.rotated_log_files = [
+            '{log_file}.{idx}.{suffix}'.format(log_file=self.log_file, idx=idx + 1, suffix='gz')
+            for idx in range(self.num_logs)
+        ]
+
+        # Log to this handler only
+        self.logger = logging.getLogger('test')
+        for handler in list(self.logger.handlers):
+            self.logger.removeHandler(handler)
+        self.logger.addHandler(GzipRotatingFileHandler(backupCount=self.num_logs,
+                                                       filename=self.log_file,
+                                                       maxBytes=self.max_bytes))
+
+    def test_namer(self):
+        """
+        Ensure the rotated log files are named correctly.
+        """
+        # Initially, only the base log file exists
+        self.assertTrue(os.path.isfile(self.log_file))
+        for log_file in self.rotated_log_files:
+            self.assertFalse(os.path.isfile(log_file))
+
+        # As messages are logged, the rotated log files get created
+        for idx in range(self.num_logs + 1):
+            self.logger.error(self.test_string)
+            self.assertTrue(os.path.isfile(self.log_file))
+
+            for log_file in self.rotated_log_files[:idx]:
+                self.assertTrue(os.path.isfile(log_file))
+
+            for log_file in self.rotated_log_files[idx:]:
+                self.assertFalse(os.path.isfile(log_file))
+
+    def test_rotator(self):
+        """
+        Ensure the rotated log files are compressed.
+        """
+        self.logger.error(self.test_string)
+        for log_file in self.rotated_log_files:
+            self.logger.error(self.test_string)
+            with gzip.open(log_file, 'rt') as gz:
+                data = gz.read().strip()
+                self.assertEqual(self.test_string, data)


### PR DESCRIPTION
Adds `opencraft.logging.GzipRotatingFileHandler`, which gzips the instance manager's rotated log files.

*Testing Instructions*

1. Set `LOGGING_ROTATE_MAX_KBYTES=1` in your local OpenCraft IM .env file - this is to trigger log rotation without needing to generate huge logs.
1. Run `make rundev`, and refresh http://localhost:5000/ several times.
1. Ensure that `.gz` log files are created in under `logs/`
1. Ensure that you can `gunzip` and read them.