### PR TITLE
Make sure YouTube API key is unset by default.

### DIFF
--- a/instance/templates/instance/ansible/vars.yml
+++ b/instance/templates/instance/ansible/vars.yml
@@ -53,6 +53,10 @@ SECURITY_UPGRADE_ON_ANSIBLE: true
 # OAuth
 EDXAPP_OAUTH_ENFORCE_SECURE: '{{ NGINX_REDIRECT_TO_HTTPS }}'
 
+# Set YouTube API key to null to avoid YouTube XHR errors.
+# Can be overridden in extra settings with a valid API key.
+EDXAPP_YOUTUBE_API_KEY: !!null
+
 # Repositories URLs
 edx_ansible_source_repo: '{{ appserver.configuration_source_repo_url }}'
 edx_platform_repo: '{{ appserver.edx_platform_repository_url }}'

--- a/instance/tests/models/test_openedx_appserver.py
+++ b/instance/tests/models/test_openedx_appserver.py
@@ -250,6 +250,15 @@ class OpenEdXAppServerTestCase(TestCase):
         self.assertNotIn('POSTFIX_QUEUE_HEADER_CHECKS', configuration_vars)
         self.assertNotIn('POSTFIX_QUEUE_SENDER_CANONICAL_MAPS', configuration_vars)
 
+    def test_youtube_api_key_unset(self):
+        """
+        Check that EDXAPP_YOUTUBE_API_KEY is set to None by default.
+        """
+        instance = OpenEdXInstanceFactory(sub_domain='youtube.apikey', use_ephemeral_databases=True)
+        appserver = make_test_appserver(instance)
+        configuration_vars = yaml.load(appserver.configuration_settings)
+        self.assertIsNone(configuration_vars['EDXAPP_YOUTUBE_API_KEY'])
+
 
 @ddt
 class OpenEdXAppServerStatusTestCase(TestCase):


### PR DESCRIPTION
Default for the `EDXAPP_YOUTUBE_API_KEY` variable in edx/configuration repository is `"PUT_YOUR_API_KEY_HERE"` rather than empty/null.

Set it to null in default vars to prevent failing YouTube XHR requests when loading course units containing videos in the Studio or LMS.

A valid YouTube API key can still be set via extra settings.

**Testing Instructions**

1. Spawn a new VM.
2. SSH into the new VM.
3. Make sure `YOUTUBE_API_KEY` is set to null in `/edx/app/edxapp/lms.auth.json` and `/edx/app/edxapp/cms.auth.json`.
4. In the Studio, open a unit that contains at least one YouTube video.
5. Make sure no error is show.
6. Check the browser console to make sure there are no failed YouTube API XHR requests.

**Reviewers**:

- [ ] @itsjeyd