### PR TITLE
Add integration test post cleanup to run on CircleCI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,6 +115,17 @@ else
 	echo -e "\nIntegration tests skipped (create a '.env.integration' file to run them)"
 endif
 
+test_integration_cleanup: clean
+ifneq ($(wildcard .env.integration),)
+	echo -e "\nRunning integration test cleanup script with credentials from .env.integration file..."
+	honcho -e .env.integration run bin/integration-cleanup
+else ifdef OPENSTACK_USER
+	echo -e "\nRunning integration test cleanup script with credentials from environment variables..."
+	bin/integration-cleanup
+else
+	echo -e "\nIntegration test cleanup script skipped (create a '.env.integration' file to run them)"
+endif
+
 test_js: clean static_external
 	cd instance/tests/js && $(RUN_JS_TESTS)
 	cd registration/tests/js && $(RUN_JS_TESTS)

--- a/README.md
+++ b/README.md
@@ -422,6 +422,22 @@ your development environment is likely a good starting point:
     cp .env .env.integration
 
 
+There is also a cleanup routine intended for use by CI services to check for and
+clean up any dangling OpenStack VMs past a certain age threshold. While it isn't
+necessary in the usual case, old integration tests that were killed without cleanup
+can be cleaned up after four hours by running the make target:
+
+    make test_integration_cleanup
+
+The age threshold for the cleanup script defaults to four hours, but this can be
+adjusted by setting `INSTANCE_AGE_THRESHOLD` to a number (in seconds) in the
+`.env.integration` file.
+
+Note that, if executing locally and with the same environment as Circle CI, setting
+the `INSTANCE_AGE_THRESHOLD` to a number too low may result in interrupted
+integration test builds on Circle CI.
+
+
 Debug
 -----
 

--- a/bin/integration-cleanup
+++ b/bin/integration-cleanup
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+set -e
+
+
+# Age tolerance threshold for running instances (in seconds); defaults to 4 hours.
+#   Override in CircleCI by defining INSTANCE_AGE_THRESHOLD for .env.integration.
+AGE_THRESHOLD=${INSTANCE_AGE_THRESHOLD:-"14400"}
+
+# Export the OpenStack environment variables to be used by the Nova CLI.
+export OS_USERNAME=$OPENSTACK_USER
+export OS_PASSWORD=$OPENSTACK_PASSWORD
+export OS_TENANT_NAME=$OPENSTACK_TENANT
+export OS_AUTH_URL=$OPENSTACK_AUTH_URL
+
+echo "Querying Nova for list of running integration test instances..."
+
+# Get the list of potential instances to terminate.
+# Returns a table of instances with four columns:
+#   The instance ID, key pair, creation date, and name.
+INSTANCE_LIST=$(nova list --fields=key_name,created,name --status=ACTIVE | grep circleci | sed 's/|//g')
+
+# Use a string length check here. We can't use `wc -l` to check because INSTANCE_LIST will always have
+# at least one newline.
+if [ ${#INSTANCE_LIST} -eq 0 ]
+then
+    echo "No active instances returned, nothing to clean up. Quitting."
+    exit
+fi
+
+INSTANCE_LIST_SIZE=$(echo "$INSTANCE_LIST" | wc -l)
+
+echo "Number of active instances returned: $INSTANCE_LIST_SIZE"
+
+function parse_iso8601 {
+    # Converts an iso8601 date to Unix EPOCH time.
+    # http://unix.stackexchange.com/a/107755
+    date -d "$(echo $1 | sed 's/T/ /')" +%s
+}
+
+echo "$INSTANCE_LIST" | while read -r INSTANCE_ID INSTANCE_KEY INSTANCE_CREATED_DATE INSTANCE_NAME
+do
+    INSTANCE_CREATED=$(parse_iso8601 "$INSTANCE_CREATED_DATE")
+
+    echo "Checking instance $INSTANCE_NAME..."
+    echo "  > id=$INSTANCE_ID, key_name=$INSTANCE_KEY, created=$INSTANCE_CREATED_DATE ($INSTANCE_CREATED)"
+
+    # Double-check to make sure that the instance is using the circleci keypair.
+    if [ $INSTANCE_KEY != 'circleci' ]
+    then
+        echo "  > SKIPPING: Instance keypair name $INSTANCE_KEY != 'circleci'!"
+        continue
+    fi
+
+    INSTANCE_AGE=$(($(date +%s)-INSTANCE_CREATED))
+
+    # Don't terminate if the instance age is less than the time threshold.
+    if [ $INSTANCE_AGE -lt $AGE_THRESHOLD ]
+    then
+        echo "  > SKIPPING: Instance is only $INSTANCE_AGE seconds old (age threshold is $AGE_THRESHOLD seconds)."
+        continue
+    fi
+
+    echo "  > TERMINATING instance (age: $INSTANCE_AGE seconds, age threshold: $AGE_THRESHOLD seconds)..."
+
+    time nova delete "$INSTANCE_ID"
+done

--- a/circle.yml
+++ b/circle.yml
@@ -27,3 +27,5 @@ test:
     - bin/run-circleci-tests:
         timeout: 1800
         parallel: true
+  post:
+    - make test_integration_cleanup

--- a/instance/models/openedx_appserver.py
+++ b/instance/models/openedx_appserver.py
@@ -287,7 +287,7 @@ class OpenEdXAppServer(AppServer, OpenEdXAppConfiguration, AnsibleAppServerMixin
         # Start by requesting a new server/VM:
         self._status_to_waiting_for_server()
         assert self.server.vm_not_yet_requested
-        self.server.name_prefix = ('edxapp-' + slugify(self.instance.lms_preview_domain))[:20]
+        self.server.name_prefix = ('edxapp-' + slugify(self.instance.domain))[:20]
         self.server.save()
 
         def accepts_ssh_commands():

--- a/instance/tests/integration/integration_instance.py
+++ b/instance/tests/integration/integration_instance.py
@@ -27,7 +27,6 @@ from unittest.mock import patch
 
 import requests
 from django.conf import settings
-from django.test import override_settings
 
 from instance.models.appserver import Status as AppServerStatus
 from instance.models.openedx_appserver import OpenEdXAppServer
@@ -43,9 +42,6 @@ from opencraft.tests.utils import shard
 
 # Tests #######################################################################
 
-@override_settings(
-    DEFAULT_LMS_PREVIEW_DOMAIN_PREFIX='integ-',
-)
 class InstanceIntegrationTestCase(IntegrationTestCase):
     """
     Integration test cases for instance high-level tasks

--- a/instance/tests/integration/integration_instance.py
+++ b/instance/tests/integration/integration_instance.py
@@ -27,6 +27,7 @@ from unittest.mock import patch
 
 import requests
 from django.conf import settings
+from django.test import override_settings
 
 from instance.models.appserver import Status as AppServerStatus
 from instance.models.openedx_appserver import OpenEdXAppServer
@@ -42,6 +43,9 @@ from opencraft.tests.utils import shard
 
 # Tests #######################################################################
 
+@override_settings(
+    DEFAULT_LMS_PREVIEW_DOMAIN_PREFIX='integ-',
+)
 class InstanceIntegrationTestCase(IntegrationTestCase):
     """
     Integration test cases for instance high-level tasks


### PR DESCRIPTION
This PR implements [OC-1590](https://tasks.opencraft.com/browse/OC-1590).

A new make target `integration_test_cleanup` is added, which is called after tests (failure or not) run on CircleCI via the `post` test hook.

The script (`bin/integration-cleanup`) is fed the environment variables placed by CircleCI into `.env.integration` by `honcho`. It queries nova for the list of active instances and filters out anything instances not using the `circleci` keypair. From there, new instances are filtered out by a configurable time threshold.

The time threshold is in seconds and can be overridden by supplying a `INSTANCE_AGE_THRESHOLD` variable to the `.env.integration` environment through CircleCI if we choose to do so in the future.


**Testing instructions**:

1. Checkout this branch in an OpenCraft IM vagrant machine: `git remote update; git checkout bdero/integration-test-cleanup`
1. Create a `.env.integration` file at the root of the repository; fill it with the contents of the **"OpenCraft IM - Integration test settings"** entry from the keepass.

    **NOTE:** You may need to escape all of the double quotes in order to prevent `honcho` from removing them (resulting in JSON parse errors otherwise).
1. Create a few dangling integration test VMs:
   1. Run `make test_integration`.
   1. Wait until an instance spins up. You can tell that it has when you see a log message like:

      ```
Reached appropriate status (Booting). Proceeding.
      ```
   1. Cancel the tests by sending keyboard interrupts (e.g. Ctrl+C) until you arrive back in your terminal prompt.
   1. Repeat the previous three steps once or twice to produce 2-3 dangling VMs.

1. Launch the cleanup script: `make test_integration_cleanup`

   Example output (1 skipped and 7 terminated):
   ```sh
(opencraft) vagrant@vagrant:~/opencraft$ make test_integration_cleanup
find -name '*.pyc' -delete
find -name '*~' -delete
find -name '__pycache__' -type d -delete
rm -rf .coverage build
find static/external -type f -not -name 'Makefile' -not -name '.gitignore' -delete
find static/external -type d -empty -delete
echo -e "\nRunning integration test cleanup script with credentials from .env.integration file..."

Running integration test cleanup script with credentials from .env.integration file...
honcho -e .env.integration run bin/integration-cleanup
Querying Nova for list of running integration test instances...
Number of active instances returned: 8
Checking instance edxapp-integ-17f829d-1...
  > id=461a94e6-832e-4e1d-a939-4b8087b8eb67, key_name=circleci, created=1476304326
  > SKIPPING: Instance is only 937 seconds old (age threshold is 1200 seconds).
Checking instance edxapp-preview-b0482-1...
  > id=488dd1bf-e3d0-4246-b107-0574fb79480d, key_name=circleci, created=1476198640
  > TERMINATING instance (age: 106623 seconds, age threshold: 1200 seconds)...
Request to delete server 488dd1bf-e3d0-4246-b107-0574fb79480d has been accepted.

real	0m3.584s
user	0m0.392s
sys	0m0.076s
Checking instance edxapp-preview-07ee6-1...
  > id=59c9c0bf-2160-4129-8c00-aa3ff1370f89, key_name=circleci, created=1476114523
  > TERMINATING instance (age: 190744 seconds, age threshold: 1200 seconds)...
Request to delete server 59c9c0bf-2160-4129-8c00-aa3ff1370f89 has been accepted.

real	0m4.335s
user	0m0.384s
sys	0m0.064s
Checking instance edxapp-preview-df5f4-1...
  > id=8cbe7653-b059-4186-bbd3-7516fabdb00f, key_name=circleci, created=1476198651
  > TERMINATING instance (age: 106620 seconds, age threshold: 1200 seconds)...
Request to delete server 8cbe7653-b059-4186-bbd3-7516fabdb00f has been accepted.

real	0m3.645s
user	0m0.364s
sys	0m0.060s
Checking instance edxapp-integ-022d101-1...
  > id=ad80da00-ba22-46bd-b120-7429e4924263, key_name=circleci, created=1476291186
  > TERMINATING instance (age: 14089 seconds, age threshold: 1200 seconds)...
Request to delete server ad80da00-ba22-46bd-b120-7429e4924263 has been accepted.

real	0m3.096s
user	0m0.352s
sys	0m0.068s
Checking instance edxapp-integ-63f7583-1...
  > id=cda48769-c907-4b88-9776-66b65b2763ba, key_name=circleci, created=1476291249
  > TERMINATING instance (age: 14029 seconds, age threshold: 1200 seconds)...
Request to delete server cda48769-c907-4b88-9776-66b65b2763ba has been accepted.

real	0m3.074s
user	0m0.376s
sys	0m0.080s
Checking instance edxapp-preview-ac9dd-1...
  > id=da025d8f-30f8-41db-b83a-9f66ebcbfc39, key_name=circleci, created=1476136014
  > TERMINATING instance (age: 169267 seconds, age threshold: 1200 seconds)...
Request to delete server da025d8f-30f8-41db-b83a-9f66ebcbfc39 has been accepted.

real	0m4.556s
user	0m0.328s
sys	0m0.084s
Checking instance edxapp-preview-7eba5-1...
  > id=ed7d54fb-0520-437d-be3f-a160807088bd, key_name=circleci, created=1476114508
  > TERMINATING instance (age: 190777 seconds, age threshold: 1200 seconds)...
Request to delete server ed7d54fb-0520-437d-be3f-a160807088bd has been accepted.

real	0m3.185s
user	0m0.404s
sys	0m0.036s

   ```

**Reviewer**: @itsjeyd 