### PR TITLE
Upgrade Huey to the latest release.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -40,7 +40,8 @@ glob2==0.4.1
 gunicorn==19.4.5
 # Using patched honcho that includes: https://github.com/nickstenning/honcho/pull/179
 git+https://github.com/open-craft/honcho.git@00c8f0d6c55ba1e9ec18470e942e47b07617099a#egg=honcho==0.7.2
-huey==1.1.2
+# Using modified huey until https://github.com/coleifer/huey/pull/189 is merged.
+git+https://github.com/open-craft/huey.git@2a67490287864fbffb51598be9e79fb3b6b85756#egg=huey==1.2.1
 ipdb==0.9.3
 ipython==4.2.0
 ipython-genutils==0.1.0


### PR DESCRIPTION
This makes sure we get a fix for a race condition that caused the scheduler thread to silently die every now and then, resulting in no periodic tasks being scheduled anymore.

The new version of Huey is installed on stage, and everything looks fine.  For testing, take a look at the stage instance manager, in particular the log files of the periodic scheduler and the workers, to see if you notice any issues.

Huey releases don't include any release notes, so I went through all commits between the 1.1.2 and 1.2.1 releases to check for backwards-incompatible changes.  There were a few, but none that would affect us.