### PR TITLE
Add task for cleaning up VMs

### DIFF
--- a/instance/models/openedx_instance.py
+++ b/instance/models/openedx_instance.py
@@ -29,7 +29,8 @@ from tldextract import TLDExtract
 
 from instance.gandi import GandiAPI
 from instance.logging import log_exception
-from instance.models.appserver import Status
+from instance.models.appserver import Status as AppServerStatus
+from instance.models.server import Status as ServerStatus
 from instance.utils import sufficient_time_passed
 from .instance import Instance
 from .mixins.openedx_database import OpenEdXDatabaseMixin
@@ -214,7 +215,10 @@ class OpenEdXInstance(Instance, OpenEdXAppConfiguration, OpenEdXDatabaseMixin,
         if self.appserver_set.count() == 0:
             return False
         all_appservers_terminated = all(
-            appserver.status == Status.Terminated for appserver in self.appserver_set.all()
+            appserver.status == AppServerStatus.Terminated or
+            (appserver.status == AppServerStatus.ConfigurationFailed and
+             appserver.server.status == ServerStatus.Terminated)
+            for appserver in self.appserver_set.all()
         )
         monitoring_turned_off = self.new_relic_availability_monitors.count() == 0
         return all_appservers_terminated and monitoring_turned_off

--- a/instance/serializers/openedx_instance.py
+++ b/instance/serializers/openedx_instance.py
@@ -41,7 +41,7 @@ class OpenEdXInstanceBasicSerializer(serializers.ModelSerializer):
         model = OpenEdXInstance
         fields = (
             'domain',
-            'shut_down',
+            'shutdown',
         )
 
     def to_representation(self, obj):

--- a/instance/serializers/openedx_instance.py
+++ b/instance/serializers/openedx_instance.py
@@ -41,7 +41,7 @@ class OpenEdXInstanceBasicSerializer(serializers.ModelSerializer):
         model = OpenEdXInstance
         fields = (
             'domain',
-            'shutdown',
+            'is_shut_down',
         )
 
     def to_representation(self, obj):

--- a/instance/serializers/openedx_instance.py
+++ b/instance/serializers/openedx_instance.py
@@ -41,6 +41,7 @@ class OpenEdXInstanceBasicSerializer(serializers.ModelSerializer):
         model = OpenEdXInstance
         fields = (
             'domain',
+            'shut_down',
         )
 
     def to_representation(self, obj):

--- a/instance/static/html/instance/index.html
+++ b/instance/static/html/instance/index.html
@@ -10,7 +10,7 @@
   <!-- Instances List -->
   <div class="large-3 columns">
     <ul class="side-nav side-instance-list">
-      <li ng-repeat="instance in instanceList | filter: {shut_down: false}"
+      <li ng-repeat="instance in instanceList | filter: {shutdown: false}"
           ng-class="{active: instance.id == state.params.instanceId}"
           ng-init="
               active_appserver = instance.active_appserver;

--- a/instance/static/html/instance/index.html
+++ b/instance/static/html/instance/index.html
@@ -10,7 +10,7 @@
   <!-- Instances List -->
   <div class="large-3 columns">
     <ul class="side-nav side-instance-list">
-      <li ng-repeat="instance in instanceList"
+      <li ng-repeat="instance in instanceList | filter: {shut_down: false}"
           ng-class="{active: instance.id == state.params.instanceId}"
           ng-init="
               active_appserver = instance.active_appserver;

--- a/instance/static/html/instance/index.html
+++ b/instance/static/html/instance/index.html
@@ -10,7 +10,7 @@
   <!-- Instances List -->
   <div class="large-3 columns">
     <ul class="side-nav side-instance-list">
-      <li ng-repeat="instance in instanceList | filter: {shutdown: false}"
+      <li ng-repeat="instance in instanceList | filter: {is_shut_down: false}"
           ng-class="{active: instance.id == state.params.instanceId}"
           ng-init="
               active_appserver = instance.active_appserver;

--- a/instance/tasks.py
+++ b/instance/tasks.py
@@ -22,11 +22,14 @@ Worker tasks for instance hosting & management
 
 # Imports #####################################################################
 
+from datetime import datetime
 import logging
 
-from huey.contrib.djhuey import db_task
+from huey.contrib.djhuey import crontab, db_task, db_periodic_task
 
 from instance.models.openedx_instance import OpenEdXInstance
+from instance.utils import sufficient_time_passed
+from pr_watch import github
 
 
 # Logging #####################################################################
@@ -60,3 +63,51 @@ def spawn_appserver(instance_ref_id, mark_active_on_success=False, num_attempts=
                 # finish and replace the second as the active server. We are not really worried about that for now.
                 instance.set_appserver_active(appserver_id)
             break
+
+
+@db_task()
+def shut_down_instances():
+    """
+    Shut down instances whose PRs got merged (more than) one week ago.
+
+    Terminate all app servers belonging to these instances, and disable monitoring.
+    """
+    for instance in OpenEdXInstance.objects.filter(watchedpullrequest__isnull=False):
+        pr = github.get_pr_info_by_number(
+            instance.watchedpullrequest.target_fork_name,
+            instance.watchedpullrequest.github_pr_number
+        )
+        if pr['state'] == 'closed':
+            closed_at = github.parse_date(pr['closed_at'])
+            now = datetime.now()
+            if sufficient_time_passed(closed_at, now, 7):
+                instance.disable_monitoring()
+                for appserver in instance.appserver_set.all():
+                    appserver.terminate_vm()
+
+
+@db_task()
+def terminate_obsolete_appservers():
+    """
+    Terminate app servers that were created (more than) two days before the currently-active app server
+    of each individual instance.
+
+    Do nothing for instances that don't have an active app server.
+    """
+    for instance in OpenEdXInstance.objects.all():
+        active_appserver = instance.active_appserver
+        if active_appserver:
+            for appserver in instance.appserver_set.all():
+                if sufficient_time_passed(appserver.created, active_appserver.created, 2):
+                    appserver.terminate_vm()
+
+
+@db_periodic_task(crontab(day='*/1', hour='1', minute='0'))
+def clean_up():
+    """
+    Clean up obsolete VMs.
+
+    This task runs once per day.
+    """
+    shut_down_instances()
+    terminate_obsolete_appservers()

--- a/instance/tasks.py
+++ b/instance/tasks.py
@@ -66,7 +66,7 @@ def spawn_appserver(instance_ref_id, mark_active_on_success=False, num_attempts=
 
 
 @db_task()
-def shut_down_instances():
+def shut_down_obsolete_pr_sandboxes():
     """
     Shut down instances whose PRs got merged (more than) one week ago.
     """
@@ -98,5 +98,5 @@ def clean_up():
 
     This task runs once per day.
     """
-    shut_down_instances()
+    shut_down_obsolete_pr_sandboxes()
     terminate_obsolete_appservers_all_instances()

--- a/instance/tests/api/test_openedx_instance.py
+++ b/instance/tests/api/test_openedx_instance.py
@@ -51,6 +51,7 @@ class OpenEdXInstanceAPITestCase(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         instance_data = response.data[0].items()
         self.assertIn(('domain', 'domain.api.example.com'), instance_data)
+        self.assertIn(('shut_down', False), instance_data)
         self.assertIn(('appserver_count', 0), instance_data)
         self.assertIn(('active_appserver', None), instance_data)
         self.assertIn(('newest_appserver', None), instance_data)
@@ -70,6 +71,7 @@ class OpenEdXInstanceAPITestCase(APITestCase):
 
         instance_data = response.data.items()
         self.assertIn(('domain', 'domain.api.example.com'), instance_data)
+        self.assertIn(('shut_down', False), instance_data)
         self.assertIn(('name', instance.name), instance_data)
         self.assertIn(('url', 'http://domain.api.example.com/'), instance_data)
         self.assertIn(('studio_url', 'http://studio-domain.api.example.com/'), instance_data)

--- a/instance/tests/api/test_openedx_instance.py
+++ b/instance/tests/api/test_openedx_instance.py
@@ -51,7 +51,7 @@ class OpenEdXInstanceAPITestCase(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         instance_data = response.data[0].items()
         self.assertIn(('domain', 'domain.api.example.com'), instance_data)
-        self.assertIn(('shut_down', False), instance_data)
+        self.assertIn(('shutdown', False), instance_data)
         self.assertIn(('appserver_count', 0), instance_data)
         self.assertIn(('active_appserver', None), instance_data)
         self.assertIn(('newest_appserver', None), instance_data)
@@ -71,7 +71,7 @@ class OpenEdXInstanceAPITestCase(APITestCase):
 
         instance_data = response.data.items()
         self.assertIn(('domain', 'domain.api.example.com'), instance_data)
-        self.assertIn(('shut_down', False), instance_data)
+        self.assertIn(('shutdown', False), instance_data)
         self.assertIn(('name', instance.name), instance_data)
         self.assertIn(('url', 'http://domain.api.example.com/'), instance_data)
         self.assertIn(('studio_url', 'http://studio-domain.api.example.com/'), instance_data)

--- a/instance/tests/api/test_openedx_instance.py
+++ b/instance/tests/api/test_openedx_instance.py
@@ -51,7 +51,7 @@ class OpenEdXInstanceAPITestCase(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         instance_data = response.data[0].items()
         self.assertIn(('domain', 'domain.api.example.com'), instance_data)
-        self.assertIn(('shutdown', False), instance_data)
+        self.assertIn(('is_shut_down', False), instance_data)
         self.assertIn(('appserver_count', 0), instance_data)
         self.assertIn(('active_appserver', None), instance_data)
         self.assertIn(('newest_appserver', None), instance_data)
@@ -71,7 +71,7 @@ class OpenEdXInstanceAPITestCase(APITestCase):
 
         instance_data = response.data.items()
         self.assertIn(('domain', 'domain.api.example.com'), instance_data)
-        self.assertIn(('shutdown', False), instance_data)
+        self.assertIn(('is_shut_down', False), instance_data)
         self.assertIn(('name', instance.name), instance_data)
         self.assertIn(('url', 'http://domain.api.example.com/'), instance_data)
         self.assertIn(('studio_url', 'http://studio-domain.api.example.com/'), instance_data)

--- a/instance/tests/fixtures/api/instance_detail.json
+++ b/instance/tests/fixtures/api/instance_detail.json
@@ -6,6 +6,7 @@
     "modified": "2016-05-20T07:46:01.033134Z",
     "instance_type": "openedxinstance",
     "domain": "pr12338.sandbox.example.com",
+    "shut_down": false,
     "email": "contact@example.com",
     "protocol": "http",
     "use_ephemeral_databases": true,

--- a/instance/tests/fixtures/api/instance_detail.json
+++ b/instance/tests/fixtures/api/instance_detail.json
@@ -6,7 +6,7 @@
     "modified": "2016-05-20T07:46:01.033134Z",
     "instance_type": "openedxinstance",
     "domain": "pr12338.sandbox.example.com",
-    "shutdown": false,
+    "is_shut_down": false,
     "email": "contact@example.com",
     "protocol": "http",
     "use_ephemeral_databases": true,

--- a/instance/tests/fixtures/api/instance_detail.json
+++ b/instance/tests/fixtures/api/instance_detail.json
@@ -6,7 +6,7 @@
     "modified": "2016-05-20T07:46:01.033134Z",
     "instance_type": "openedxinstance",
     "domain": "pr12338.sandbox.example.com",
-    "shut_down": false,
+    "shutdown": false,
     "email": "contact@example.com",
     "protocol": "http",
     "use_ephemeral_databases": true,

--- a/instance/tests/fixtures/api/instances_list.json
+++ b/instance/tests/fixtures/api/instances_list.json
@@ -7,7 +7,7 @@
         "modified": "2016-05-20T07:46:01.033134Z",
         "instance_type": "openedxinstance",
         "domain": "pr12338.sandbox.example.com",
-        "shutdown": false,
+        "is_shut_down": false,
         "appserver_count": 2,
         "active_appserver": {
             "id": 8,
@@ -42,7 +42,7 @@
         "modified": "2016-05-20T07:46:00.524334Z",
         "instance_type": "openedxinstance",
         "domain": "pr12340.sandbox.example.com",
-        "shutdown": false,
+        "is_shut_down": false,
         "appserver_count": 1,
         "active_appserver": null,
         "newest_appserver": {

--- a/instance/tests/fixtures/api/instances_list.json
+++ b/instance/tests/fixtures/api/instances_list.json
@@ -7,6 +7,7 @@
         "modified": "2016-05-20T07:46:01.033134Z",
         "instance_type": "openedxinstance",
         "domain": "pr12338.sandbox.example.com",
+        "shut_down": false,
         "appserver_count": 2,
         "active_appserver": {
             "id": 8,
@@ -41,6 +42,7 @@
         "modified": "2016-05-20T07:46:00.524334Z",
         "instance_type": "openedxinstance",
         "domain": "pr12340.sandbox.example.com",
+        "shut_down": false,
         "appserver_count": 1,
         "active_appserver": null,
         "newest_appserver": {

--- a/instance/tests/fixtures/api/instances_list.json
+++ b/instance/tests/fixtures/api/instances_list.json
@@ -7,7 +7,7 @@
         "modified": "2016-05-20T07:46:01.033134Z",
         "instance_type": "openedxinstance",
         "domain": "pr12338.sandbox.example.com",
-        "shut_down": false,
+        "shutdown": false,
         "appserver_count": 2,
         "active_appserver": {
             "id": 8,
@@ -42,7 +42,7 @@
         "modified": "2016-05-20T07:46:00.524334Z",
         "instance_type": "openedxinstance",
         "domain": "pr12340.sandbox.example.com",
-        "shut_down": false,
+        "shutdown": false,
         "appserver_count": 1,
         "active_appserver": null,
         "newest_appserver": {

--- a/instance/tests/models/test_openedx_instance.py
+++ b/instance/tests/models/test_openedx_instance.py
@@ -618,7 +618,7 @@ class OpenEdXInstanceTestCase(TestCase):
     )
     @ddt.unpack
     @patch('instance.models.mixins.openedx_monitoring.newrelic')
-    def test_shutdown(
+    def test_is_shut_down(
             self,
             num_running_appservers,
             num_terminated_appservers,
@@ -628,10 +628,14 @@ class OpenEdXInstanceTestCase(TestCase):
             mock_newrelic
     ):
         """
-        Test that `shutdown` property correctly reports whether an instance has been shut down.
+        Test that `is_shut_down` property correctly reports whether an instance has been shut down.
 
-        An instance has been shut down if all of its app servers have been terminated,
-        and monitoring has been turned off.
+        An instance has been shut down if monitoring has been turned off
+        and each of its app servers has either been terminated
+        or failed to provision and the corresponding VM has since been terminated.
+
+        If an instance has no app servers, we assume that it has *not* been shut down.
+        This ensures that the GUI lists newly created instances without app servers.
         """
         instance = OpenEdXInstanceFactory()
 
@@ -656,7 +660,7 @@ class OpenEdXInstanceTestCase(TestCase):
             monitor_id = str(uuid4())
             instance.new_relic_availability_monitors.create(pk=monitor_id)
 
-        self.assertEqual(instance.shutdown, expected_result)
+        self.assertEqual(instance.is_shut_down, expected_result)
 
     @patch('instance.models.openedx_instance.OpenEdXMonitoringMixin.disable_monitoring')
     def test_shut_down(self, mock_disable_monitoring):

--- a/instance/tests/test_tasks.py
+++ b/instance/tests/test_tasks.py
@@ -126,10 +126,10 @@ class CleanUpTestCase(TestCase):
         self.assertEqual(mock_terminate_appservers.call_count, 5)
 
     @ddt.data(
-        {'pr_state': 'closed', 'pr_days_since_closed': 4, 'instance_shutdown': False},
-        {'pr_state': 'closed', 'pr_days_since_closed': 7, 'instance_shutdown': True},
-        {'pr_state': 'closed', 'pr_days_since_closed': 10, 'instance_shutdown': True},
-        {'pr_state': 'open', 'pr_days_since_closed': None, 'instance_shutdown': False},
+        {'pr_state': 'closed', 'pr_days_since_closed': 4, 'instance_is_shut_down': False},
+        {'pr_state': 'closed', 'pr_days_since_closed': 7, 'instance_is_shut_down': True},
+        {'pr_state': 'closed', 'pr_days_since_closed': 10, 'instance_is_shut_down': True},
+        {'pr_state': 'open', 'pr_days_since_closed': None, 'instance_is_shut_down': False},
     )
     @patch('instance.models.openedx_instance.OpenEdXInstance.shut_down')
     def test_shut_down_instances(self, data, mock_shut_down):
@@ -159,7 +159,7 @@ class CleanUpTestCase(TestCase):
             tasks.shut_down_instances()
 
             # Check if task tried to shut down instances
-            if data['instance_shutdown']:
+            if data['instance_is_shut_down']:
                 self.assertEqual(mock_shut_down.call_count, 5)
             else:
                 self.assertEqual(mock_shut_down.call_count, 0)

--- a/instance/tests/test_tasks.py
+++ b/instance/tests/test_tasks.py
@@ -22,13 +22,19 @@ Worker tasks - Tests
 
 # Imports #####################################################################
 
+from datetime import timedelta
 from unittest.mock import patch
 
 import ddt
+from django.utils import timezone
 
 from instance import tasks
+from instance.models.appserver import Status as AppServerStatus
+from instance.models.server import OpenStackServer, Status as ServerStatus
 from instance.tests.base import TestCase
+from instance.tests.models.factories.openedx_appserver import make_test_appserver
 from instance.tests.models.factories.openedx_instance import OpenEdXInstanceFactory
+from pr_watch.tests.factories import make_watched_pr_and_instance
 
 
 # Tests #######################################################################
@@ -101,3 +107,246 @@ class SpawnAppServerTestCase(TestCase):
         tasks.spawn_appserver(instance.ref.pk)
         self.assertEqual(self.mock_spawn_appserver.call_count, 1)
         self.assertTrue(any("Spawning new AppServer, attempt 1 of 1" in log.text for log in instance.log_entries))
+
+
+@ddt.ddt
+class CleanUpTestCase(TestCase):
+    """
+    Test cases for clean up tasks
+    """
+
+    @staticmethod
+    def _set_appserver_configuration_failed(appserver):
+        """
+        Transition `appserver` to Status.ConfigurationFailed.
+        """
+        appserver._status_to_waiting_for_server()
+        appserver._status_to_configuring_server()
+        appserver._status_to_configuration_failed()
+
+    @staticmethod
+    def _set_appserver_running(appserver):
+        """
+        Transition `appserver` to Status.Running.
+        """
+        appserver._status_to_waiting_for_server()
+        appserver._status_to_configuring_server()
+        appserver._status_to_running()
+
+    def _create_appserver(self, instance, created, status):
+        """
+        Return appserver for `instance` that was `created` on a specific date, and has `status`.
+
+        Note that there is no need to set the status of the VM (OpenStackServer)
+        that is associated with the app server to something other than ServerStatus.Pending:
+
+        Servers are allowed to transition to ServerStatus.Terminated from any state,
+        and this class does not test functionality for terminating servers itself.
+        """
+        appserver = make_test_appserver(instance)
+        appserver.created = created
+        appserver.save()
+        if status == AppServerStatus.Running:
+            self._set_appserver_running(appserver)
+        elif status == AppServerStatus.ConfigurationFailed:
+            self._set_appserver_configuration_failed(appserver)
+        return appserver
+
+    def _create_running_appserver(self, instance, created):
+        """
+        Return running app server for `instance` that was `created` on a specific date,
+        and has `status` AppServerStatus.Running.
+        """
+        return self._create_appserver(instance, created, AppServerStatus.Running)
+
+    def _create_failed_appserver(self, instance, created):
+        """
+        Return running app server for `instance` that was `created` on a specific date,
+        and has `status` AppServerStatus.ConfigurationFailed.
+        """
+        return self._create_appserver(instance, created, AppServerStatus.ConfigurationFailed)
+
+    def _assert_status(self, appservers):
+        """
+        Assert that status of app servers in `appservers` matches expected status.
+
+        Assumes that `appservers` is an iterable of tuples of the following form:
+
+            (<appserver>, <expected status>, <expected server status>)
+
+        where <expected status> is the expected AppServerStatus of <appserver>,
+        and <expected server status> is the expected ServerStatus of the OpenStackServer associated with <appserver>.
+        """
+        for appserver, expected_status, expected_server_status in appservers:
+            appserver.refresh_from_db()
+            self.assertEqual(appserver.status, expected_status)
+            # Status of appserver.server is still stale after refresh_from_db, so reload server manually:
+            server = OpenStackServer.objects.get(id=appserver.server.pk)
+            self.assertEqual(server.status, expected_server_status)
+
+    def test_terminate_obsolete_appservers(self):
+        """
+        Test that `terminate_obsolete_appservers` correctly identifies and terminates app servers
+        that were created (more than) two days before the currently-active app server of individual instances.
+        """
+        instance = OpenEdXInstanceFactory()
+        reference_date = timezone.now()
+
+        # Create app servers
+        obsolete_appserver = self._create_running_appserver(instance, reference_date - timedelta(days=5))
+        obsolete_appserver_failed = self._create_failed_appserver(instance, reference_date - timedelta(days=5))
+
+        recent_appserver = self._create_running_appserver(instance, reference_date - timedelta(days=1))
+        recent_appserver_failed = self._create_failed_appserver(instance, reference_date - timedelta(days=1))
+
+        active_appserver = self._create_running_appserver(instance, reference_date)
+
+        newer_appserver = self._create_running_appserver(instance, reference_date + timedelta(days=3))
+        newer_appserver_failed = self._create_failed_appserver(instance, reference_date + timedelta(days=3))
+
+        # Set single app server active
+        instance.active_appserver = active_appserver
+        instance.save()
+
+        # Run task
+        tasks.terminate_obsolete_appservers()
+
+        # Check status of running app servers
+        self._assert_status([
+            (obsolete_appserver, AppServerStatus.Terminated, ServerStatus.Terminated),
+            (recent_appserver, AppServerStatus.Running, ServerStatus.Pending),
+            (active_appserver, AppServerStatus.Running, ServerStatus.Pending),
+            (newer_appserver, AppServerStatus.Running, ServerStatus.Pending),
+        ])
+
+        # Check status of failed app servers:
+        # AppServerStatus.Terminated is reserved for instances that were running successfully at some point,
+        # so app servers with AppServerStatus.ConfigurationFailed will still have that status
+        # after `terminate_obsolete_appservers` calls `terminate_vm` on them.
+        # However, the VM (OpenStackServer) that an app server is associated with *should* have ServerStatus.Terminated
+        # if the app server was old enough to be terminated.
+        self._assert_status([
+            (obsolete_appserver_failed, AppServerStatus.ConfigurationFailed, ServerStatus.Terminated),
+            (recent_appserver_failed, AppServerStatus.ConfigurationFailed, ServerStatus.Pending),
+            (newer_appserver_failed, AppServerStatus.ConfigurationFailed, ServerStatus.Pending),
+        ])
+
+    def test_terminate_obsolete_appservers_no_active(self):
+        """
+        Test that `terminate_obsolete_appservers` does not terminate any app servers
+        if an instance does not have an active app server.
+        """
+        instance = OpenEdXInstanceFactory()
+        reference_date = timezone.now()
+
+        # Create app servers
+        obsolete_appserver = self._create_running_appserver(instance, reference_date - timedelta(days=5))
+        obsolete_appserver_failed = self._create_failed_appserver(instance, reference_date - timedelta(days=5))
+
+        recent_appserver = self._create_running_appserver(instance, reference_date - timedelta(days=1))
+        recent_appserver_failed = self._create_failed_appserver(instance, reference_date - timedelta(days=1))
+
+        appserver = self._create_running_appserver(instance, reference_date)
+        appserver_failed = self._create_failed_appserver(instance, reference_date)
+
+        newer_appserver = self._create_running_appserver(instance, reference_date + timedelta(days=3))
+        newer_appserver_failed = self._create_failed_appserver(instance, reference_date + timedelta(days=3))
+
+        # Run task
+        tasks.terminate_obsolete_appservers()
+
+        # Check status of app servers (should be unchanged)
+        self._assert_status([
+            (obsolete_appserver, AppServerStatus.Running, ServerStatus.Pending),
+            (obsolete_appserver_failed, AppServerStatus.ConfigurationFailed, ServerStatus.Pending),
+            (recent_appserver, AppServerStatus.Running, ServerStatus.Pending),
+            (recent_appserver_failed, AppServerStatus.ConfigurationFailed, ServerStatus.Pending),
+            (appserver, AppServerStatus.Running, ServerStatus.Pending),
+            (appserver_failed, AppServerStatus.ConfigurationFailed, ServerStatus.Pending),
+            (newer_appserver, AppServerStatus.Running, ServerStatus.Pending),
+            (newer_appserver_failed, AppServerStatus.ConfigurationFailed, ServerStatus.Pending),
+        ])
+
+    @ddt.data(
+        {'pr_state': 'closed', 'pr_days_since_closed': 4, 'instance_shut_down': False},
+        {'pr_state': 'closed', 'pr_days_since_closed': 7, 'instance_shut_down': True},
+        {'pr_state': 'closed', 'pr_days_since_closed': 10, 'instance_shut_down': True},
+        {'pr_state': 'open', 'pr_days_since_closed': None, 'instance_shut_down': False},
+    )
+    @patch('instance.models.openedx_instance.OpenEdXMonitoringMixin.disable_monitoring')
+    def test_shut_down_instances(self, data, mock_disable_monitoring):
+        """
+        Test that `shut_down_instances` correctly identifies and shuts down instances
+        whose PRs got merged (more than) one week ago.
+        """
+        reference_date = timezone.now()
+
+        # Create PR and instance
+        pr = make_watched_pr_and_instance()
+        instance = pr.instance
+
+        appserver = self._create_running_appserver(instance, reference_date - timedelta(days=14))
+        appserver_failed = self._create_failed_appserver(instance, reference_date - timedelta(days=12))
+
+        newer_appserver = self._create_running_appserver(instance, reference_date - timedelta(days=5))
+        newer_appserver_failed = self._create_failed_appserver(instance, reference_date - timedelta(days=3))
+
+        # Calculate date when PR was closed
+        pr_state = data['pr_state']
+        if pr_state == 'closed':
+            pr_closed_date = reference_date - timedelta(days=data['pr_days_since_closed'])
+            closed_at = pr_closed_date.strftime('%Y-%m-%dT%H:%M:%SZ')
+        else:
+            closed_at = None
+
+        with patch(
+            'pr_watch.github.get_pr_info_by_number',
+            return_value={'state': pr_state, 'closed_at': closed_at},
+        ):
+            # Run task
+            tasks.shut_down_instances()
+
+            # Check status of app servers
+            if data['instance_shut_down']:
+                self._assert_status([
+                    (appserver, AppServerStatus.Terminated, ServerStatus.Terminated),
+                    (appserver_failed, AppServerStatus.ConfigurationFailed, ServerStatus.Terminated),
+                    (newer_appserver, AppServerStatus.Terminated, ServerStatus.Terminated),
+                    (newer_appserver_failed, AppServerStatus.ConfigurationFailed, ServerStatus.Terminated),
+                ])
+                self.assertEqual(mock_disable_monitoring.call_count, 1)
+            else:
+                self._assert_status([
+                    (appserver, AppServerStatus.Running, ServerStatus.Pending),
+                    (appserver_failed, AppServerStatus.ConfigurationFailed, ServerStatus.Pending),
+                    (newer_appserver, AppServerStatus.Running, ServerStatus.Pending),
+                    (newer_appserver_failed, AppServerStatus.ConfigurationFailed, ServerStatus.Pending),
+                ])
+                self.assertEqual(mock_disable_monitoring.call_count, 0)
+
+    @patch('instance.models.openedx_instance.OpenEdXAppServer.terminate_vm')
+    @patch('instance.models.openedx_instance.OpenEdXMonitoringMixin.disable_monitoring')
+    def test_shut_down_instances_no_pr(self, mock_disable_monitoring, mock_terminate_vm):
+        """
+        Test that `shut_down_instances` does not shut down instances
+        that are not associated with a PR.
+        """
+        instance = OpenEdXInstanceFactory()
+        date = timezone.now()
+
+        self._create_running_appserver(instance, date)
+
+        tasks.shut_down_instances()
+
+        for mocked_method in (mock_disable_monitoring, mock_terminate_vm):
+            self.assertEqual(mocked_method.call_count, 0)
+
+    @patch('instance.tasks.terminate_obsolete_appservers')
+    @patch('instance.tasks.shut_down_instances')
+    def test_clean_up_task(self, mock_shut_down_instances, mock_terminate_obsolete_appservers):
+        """
+        Test that `clean_up` task spawns `shut_down_instances` and `terminate_obsolete_appservers` tasks.
+        """
+        tasks.clean_up()
+        mock_shut_down_instances.assert_called_once_with()
+        mock_terminate_obsolete_appservers.assert_called_once_with()

--- a/instance/tests/test_utils.py
+++ b/instance/tests/test_utils.py
@@ -22,12 +22,13 @@ Utils module - Tests
 
 # Imports #####################################################################
 
+from datetime import datetime
 import itertools
 import subprocess
 from unittest.mock import patch
 
 from instance.tests.base import TestCase
-from instance.utils import poll_streams, _line_timeout_generator
+from instance.utils import sufficient_time_passed, poll_streams, _line_timeout_generator
 
 
 # Tests #######################################################################
@@ -79,3 +80,26 @@ class UtilsTestCase(TestCase):
         for actual, expected in zip(timeout, [3, 3, 3, 3, 3, 3]):
             self.assertEqual(actual, expected)
         self.assertFalse(mock_time.called)
+
+    def test_sufficient_time_passed(self):
+        """
+        Test helper function for checking if sufficient time passed between two dates.
+        """
+        date = datetime(2016, 9, 25, 8, 20, 5)
+        reference_date = datetime(2016, 10, 11, 15, 10, 30)
+
+        # Delta between dates greater than expected delta (actual delta: 16 days)
+        result = sufficient_time_passed(date, reference_date, 5)
+        self.assertTrue(result)
+        # Delta between dates equal to expected delta
+        result = sufficient_time_passed(date, reference_date, 16)
+        self.assertTrue(result)
+        # Delta between dates less than expected delta (actual delta: 16 days)
+        result = sufficient_time_passed(date, reference_date, 20)
+        self.assertFalse(result)
+        # Negative delta (reference date follows date), delta between dates greater than expected delta
+        result = sufficient_time_passed(reference_date, date, 5)
+        self.assertFalse(result)
+        # Negative delta (reference date follows date), delta between dates less than expected delta
+        result = sufficient_time_passed(reference_date, date, 20)
+        self.assertFalse(result)

--- a/instance/utils.py
+++ b/instance/utils.py
@@ -124,3 +124,11 @@ def poll_streams(*files, line_timeout=None, global_timeout=None):
                 yield (key.fileobj, line)
             else:
                 selector.unregister(key.fileobj)
+
+
+def sufficient_time_passed(date, reference_date, expected_days_since):
+    """
+    Check if delta between `date` and `reference_date` is greater than or equal to `expected_days_since`.
+    """
+    days_since = (reference_date - date).days
+    return days_since >= expected_days_since

--- a/pr_watch/github.py
+++ b/pr_watch/github.py
@@ -22,6 +22,7 @@ GitHub Service API - Helper functions
 
 # Imports #####################################################################
 
+from datetime import datetime
 import functools
 import logging
 import operator
@@ -107,14 +108,21 @@ def is_pr_body_requesting_ephemeral_databases(pr_body, domain):
     return None
 
 
+def get_pr_info_by_number(pr_target_fork_name, pr_number):
+    """
+    Return dict containing all available information about PR identified by `pr_target_fork_name` and `pr_number`.
+    """
+    return get_object_from_url('https://api.github.com/repos/{pr_target_fork_name}/pulls/{pr_number}'.format(
+        pr_target_fork_name=pr_target_fork_name,
+        pr_number=pr_number,
+    ))
+
+
 def get_pr_by_number(pr_target_fork_name, pr_number):
     """
     Returns a PR object based on the reponse
     """
-    r_pr = get_object_from_url('https://api.github.com/repos/{pr_target_fork_name}/pulls/{pr_number}'.format(
-        pr_target_fork_name=pr_target_fork_name,
-        pr_number=pr_number,
-    ))
+    r_pr = get_pr_info_by_number(pr_target_fork_name, pr_number)
     pr_fork_name = r_pr['head']['repo']['full_name']
     pr_branch_name = r_pr['head']['ref']
     pr = PR(
@@ -162,6 +170,15 @@ def get_username_list_from_team(organization_name, team_name='Owners'):
     team = get_team_from_organization(organization_name, team_name)
     url = 'https://api.github.com/teams/{team_id}/members'.format(team_id=team['id'])
     return [user_dict['login'] for user_dict in get_object_from_url(url)]
+
+
+def parse_date(date):
+    """
+    Create datetime object from `date`.
+
+    GitHub API returns dates in ISO 8601 format.
+    """
+    return datetime.strptime(date, '%Y-%m-%dT%H:%M:%SZ')
 
 
 # Classes #####################################################################


### PR DESCRIPTION
This PR adds a task to the scheduler which runs every day and (1) shuts down instances whose PRs were merged (more than) 7 days ago and (2) terminates app servers that were created (more than) two days prior to the active app server of the parent instance. It also makes sure that shut-down instances are hidden from the GUI.

cf. [OC-1998](https://tasks.opencraft.com/browse/OC-1998)

**Test instructions**

1. Create an instance that is not associated with a PR:

    * Run `make shell`.

    * Create instance via:

        ```python
        from instance.factories import instance_factory
        regular_instance = instance_factory(name="Regular instance, no PR", sub_domain="regular-instance-zohoRek6")
        ```
    * Spawn four app servers for the instance (to speed this up you can use separate terminal windows):

        ```python
        first_appserver_id = regular_instance.spawn_appserver()
        second_appserver_id = regular_instance.spawn_appserver()
        third_appserver_id = regular_instance.spawn_appserver()
        fourth_appserver_id = regular_instance.spawn_appserver()
        ```

    * Update the `created` field of the app servers to fake their age:

        ```python
        from datetime import timedelta
        from django.utils import timezone

        reference_date = timezone.now()
        
        # Obsolete app server:
        first_appserver = regular_instance.appserver_set.get(pk=first_appserver_id)
        first_appserver.created = reference_date - timedelta(days=5)
        first_appserver.save()
        # Recent app server:
        second_appserver = regular_instance.appserver_set.get(pk=second_appserver_id)
        second_appserver.created = reference_date - timedelta(days=4)
        second_appserver.save()
        # Active app server:
        third_appserver = regular_instance.appserver_set.get(pk=third_appserver_id)
        third_appserver.created = reference_date - timedelta(days=3)
        third_appserver.save()
        # Newest app server:
        fourth_appserver = regular_instance.appserver_set.get(pk=fourth_appserver_id)
        fourth_appserver.created = reference_date - timedelta(days=2)
        fourth_appserver.save()
        ```

    * Run the new `clean_up` task:

        ```python
        from instance.tasks import clean_up
        clean_up()
        ```

    * Verify that `regular_instance` is unchanged (i.e., none of its app servers have been terminated). You can use the GUI or do it directly in the shell via something like:

        ```python
        for appserver in regular_instance.appserver_set.all():
            print(appserver)
            print("Status: ", appserver.status)
            print("Status (server): ", appserver.server.status)
        ```

        This should produce the following output:

        ```
        AppServer 1
        Status:  Running [running]
        Status (server):  Ready [ready]
        AppServer 2
        Status:  Running [running]
        Status (server):  Ready [ready]
        AppServer 3
        Status:  Running [running]
        Status (server):  Ready [ready]
        AppServer 4
        Status:  Running [running]
        Status (server):  Ready [ready]
        ```

    * Activate the third app server:

        ```python
        regular_instance.set_appserver_active(third_appserver_id)
        ```

2. Create an instance that is associated with a PR that was merged *more than 7 days ago*:

    * Create instance:

        ```python
        from pr_watch.github import get_pr_by_number
        merged_pr = get_pr_by_number('edx/edx-platform', 13443)
        merged_pr_instance, created = WatchedPullRequest.objects.get_or_create_from_pr(merged_pr)
        ```

    * Spawn app server:

        ```python
        appserver_id = merged_pr_instance.spawn_appserver()
        ```

    * Set app server active:

        ```python
        merged_pr_instance.set_appserver_active(appserver_id)
        ```

3. Create an instance that is associated with a PR that was merged *less than 7 days ago*:

    * Create instance:

        ```python
        from pr_watch.github import get_pr_by_number
        recently_merged_pr = get_pr_by_number('edx/edx-platform', 13611)
        recently_merged_pr_instance, created = WatchedPullRequest.objects.get_or_create_from_pr(recently_merged_pr)
        ```

    * Spawn app server:

        ```python
        appserver_id = recently_merged_pr_instance.spawn_appserver()
        ```

    * Set app server active:

        ```python
        recently_merged_pr_instance.set_appserver_active(appserver_id)
        ```

4. Create an instance that is associated with an open PR (if the PR referenced below is no longer open, you'll need to select a different one):

    * Create instance:

        ```python
        from pr_watch.github import get_pr_by_number
        open_pr = get_pr_by_number('edx/edx-platform', 13771)
        open_pr_instance, created = WatchedPullRequest.objects.get_or_create_from_pr(open_pr)
        ```

    * Spawn app server:

        ```python
        appserver_id = open_pr_instance.spawn_appserver()
        ```

    * Set app server active:

        ```python
        open_pr_instance.set_appserver_active(appserver_id)
        ```

5. Run the `clean_up` task again:

    ```python
    from instance.tasks import clean_up
    clean_up()
    ```

6. Make sure that: 

    * Instance not associated with PR has had it's oldest app server terminated, is unchanged otherwise, and visible in the GUI.
    * Instance associated with PR merged more than 7 days ago has been shut down, and is no longer visible in the GUI.
    * Instance associated with PR merged less than 7 days ago is unchanged, and visible in the GUI.
    * Instance associated with open PR is unchanged, and visible in the GUI.

7. Double-check "OVH - OpenStack - Horizon - OpenCraft IM - Dev" account to see if correct set of app servers left.

**Reviewers**

- [ ] @haikuginger 