### PR TITLE
Integration test improvements

### DIFF
--- a/registration/provision.py
+++ b/registration/provision.py
@@ -41,6 +41,15 @@ logger = logging.getLogger(__name__)
 
 @receiver(email_confirmed)
 def provision_instance(sender, **kwargs):
+    """
+    Provision a new instance once all email addresses of a user are confirmed.
+    This method wraps _provision_instance so that we can mock it out more easily
+    for testing purposes.
+    """
+    _provision_instance(sender, **kwargs)
+
+
+def _provision_instance(sender, **kwargs):
     """Provision a new instance once all email addresses of a user are confirmed."""
     user = sender
     if not all(email.is_confirmed for email in user.email_address_set.iterator()):

--- a/registration/tests/browser/browser_login.py
+++ b/registration/tests/browser/browser_login.py
@@ -23,6 +23,7 @@ Login browser tests
 # Imports #####################################################################
 
 from django.contrib.staticfiles.testing import StaticLiveServerTestCase
+from django.core.urlresolvers import reverse
 
 from registration.tests.utils import BrowserTestMixin, UserMixin
 
@@ -48,3 +49,21 @@ class LoginBrowserTestCase(BrowserTestMixin, UserMixin,
         self.fill_form({'username': self.username})
         self.assertIn('Please enter a correct username and password',
                       self.form.text)
+
+    def test_valid_credentials(self):
+        """
+        Check that we're logged in successfully when entering correct credentials.
+        """
+        self._login(
+            username=self.username,
+            password=self.password
+        )
+        # Check that after logging in, we're directed to the registration URL (shared
+        # between registration and updating details)
+        self.assertEqual(
+            self.client.current_url,
+            '{host}{path}'.format(
+                host=self.live_server_url,
+                path=reverse('registration:register'),
+            ),
+        )


### PR DESCRIPTION
This pull request adds tests to verify that, when provisioning an instance with non-ephemeral databases, the expected MySQL and Mongo databases are correctly created. 

**Dependencies**: None

**Testing instructions**:
1. Read code.
2. Run tests.

**Author notes and concerns**:
1. We were hoping to do more than this for this particular task, but I ran into some confusing Mongo behavior that took some time to figure out, and didn't have time to research what other tests might be useful in the context of this task.

**Reviewers**
- [ ] @bradenmacdonald 
