### PR TITLE
Add domain/name to CSV and use betatest user email

### DIFF
--- a/instance/tests/integration/integration_instance.py
+++ b/instance/tests/integration/integration_instance.py
@@ -151,7 +151,11 @@ class InstanceIntegrationTestCase(IntegrationTestCase):
         #   Appserver IP,Owner Emails,Unique Hits,Total Users,Total Courses,Age (Days)
         #   149.202.188.116,"['brandon@opencraft.com', 'x@bdero.me']",4,7,1,0
 
-        self.assertEqual('Appserver IP,Owner Emails,Unique Hits,Total Users,Total Courses,Age (Days)', out_lines[0])
+        self.assertEqual(
+            '"Appserver IP","Internal LMS Domain","Name","Contact Email","Unique Hits","Total Users","Total Courses",'
+            '"Age (Days)"',
+            out_lines[0]
+        )
         # stdout should contain 3 lines (as opposed to 2) to account for the last newline.
         self.assertEqual(len(out_lines), 3)
 

--- a/instance/tests/integration/integration_instance.py
+++ b/instance/tests/integration/integration_instance.py
@@ -27,6 +27,7 @@ from unittest.mock import patch
 
 import requests
 from django.conf import settings
+from django.contrib.auth.models import User
 from django.core.management import call_command
 from django.utils.six import StringIO
 
@@ -41,6 +42,7 @@ from instance.tests.integration.factories.instance import OpenEdXInstanceFactory
 from instance.tasks import spawn_appserver
 from instance.models.mixins.secret_keys import SecretKeyProvider
 from opencraft.tests.utils import shard
+from registration.models import BetaTestApplication
 
 
 # Tests #######################################################################
@@ -141,6 +143,19 @@ class InstanceIntegrationTestCase(IntegrationTestCase):
         self.assertTrue(instance.successfully_provisioned)
         self.assertTrue(instance.require_user_creation_success())
 
+        user = User.objects.create_user('betatestuser', 'betatest@example.com')
+
+        BetaTestApplication.objects.create(
+            user=user,
+            subdomain='betatestdomain',
+            instance_name='betatestinstance',
+            public_contact_email='publicemail@example.com',
+            project_description='I want to beta test OpenCraft IM',
+            status=BetaTestApplication.ACCEPTED,
+            instance=instance,
+        )
+
+        # Run the management command and collect the CSV from stdout.
         out = StringIO()
         call_command('activity_csv', stdout=out)
 
@@ -148,14 +163,19 @@ class InstanceIntegrationTestCase(IntegrationTestCase):
 
         # The output should look similar to this when one instance is launched:
         #
-        #   Appserver IP,Owner Emails,Unique Hits,Total Users,Total Courses,Age (Days)
-        #   149.202.188.116,"['brandon@opencraft.com', 'x@bdero.me']",4,7,1,0
+        #   "Appserver IP","Internal LMS Domain","Name","Contact Email","Unique Hits","Total Users","Total Courses",
+        #     "Age (Days)"
+        #   "213.32.77.49","test.example.com","Instance","betatest@example.com","87","6","1",1
 
         self.assertEqual(
             '"Appserver IP","Internal LMS Domain","Name","Contact Email","Unique Hits","Total Users","Total Courses",'
             '"Age (Days)"',
             out_lines[0]
         )
+        self.assertIn('"Integration - test_spawn_appserver"', out_lines[1])
+        self.assertIn('"betatest@example.com"', out_lines[1])
+        self.assertNotIn('N/A', out_lines[1])
+
         # stdout should contain 3 lines (as opposed to 2) to account for the last newline.
         self.assertEqual(len(out_lines), 3)
 


### PR DESCRIPTION
The output of the command now looks like this:

```
"Appserver IP","Internal LMS Domain","Name","Contact Email","Unique Hits","Total Users","Total Courses","Age (Days)"
"213.32.77.49","test.example.com","This, name, ""is, crazy""","x@bdero.me","9","6","1",0
```

Note that it lists the "Internal DNS Domain" and the "Name" of the instance reference. The email is taken from the beta test user's OCIM account email. If there is no "Beta test application" associated with the instance, "N/A" is placed in the email field instead.

FYI @antoviaque, can you take a look to see if this is the appropriate behavior for the email?

**JIRA tickets**: Improves output of [OC-1999](https://tasks.opencraft.com/browse/OC-1999).

**Testing instructions**:

Get OCIM setup to manage at least one instance ***with a betatest application***.

1. Setup an OpenCraft IM vagrant box.
1. Configure the OpenCraft IM dev to either use the "Dev" or "Integration" account on OVH.
1. Create a new instance.
1. Provision a new app server for the previously created instance.
1. Set the new app server as the active app server for the instance (can be done from the Instance admin panel).
1. From the admin panel create a new "Beta test application" - set the Instance to be the instance created in the previous steps.

Test this improvement:

1. Checkout this branch:
   
   ```
   git remote update && git checkout origin/bdero/activity_csv
   ```
1. Ensure everything is up-to-date:
   
   ```
   make clean && make migration_check && make static_external
   ```
1. Run the new management command:
   
   ```
   make manage activity_csv --out out.csv
   ```
   
   **NOTE:** You will likely see build failures building "cryptography" during the virtualenv setup. This is expected and not an issue.
   
   Example successful output of playbook:
   
   ```
   PLAY [all] *********************************************************************
   
   TASK [setup] *******************************************************************
   ok: [149.202.188.116]
   
   TASK [Copy stats script] *******************************************************
   ok: [149.202.188.116]
   
   TASK [Run stats script] ********************************************************
   changed: [149.202.188.116]
   
   TASK [debug] *******************************************************************
   ok: [149.202.188.116] => {
   "stats_results": {
       "changed": true,
       "cmd": [
           "/edx/bin/python.edxapp",
           "/tmp/collect_activity.py",
           "149.202.188.116",
           "/tmp/activity_report"
       ],
       "delta": "0:00:03.881274",
       "end": "2016-10-20 15:41:23.425372",
       "rc": 0,
       "start": "2016-10-20 15:41:19.544098",
       "stderr": "2016-10-20 15:41:21,163 WARNING 5561 [py.warnings] base.py:116 - /edx/app/edxapp/edx-platform/openedx/core/djangoapps/site_configuration/models.py:19: RemovedInDjango19Warning: Model class openedx.core.djangoapps.site_configuration.models.SiteConfiguration doesn't declare an explicit app_label and either isn't in an application in INSTALLED_APPS or else was imported before its application was loaded. This will no longer be supported in Django 1.9.\n  class SiteConfiguration(models.Model):\n\n2016-10-20 15:41:21,164 WARNING 5561 [py.warnings] base.py:116 - /edx/app/edxapp/edx-platform/openedx/core/djangoapps/site_configuration/models.py:113: RemovedInDjango19Warning: Model class openedx.core.djangoapps.site_configuration.models.SiteConfigurationHistory doesn't declare an explicit app_label and either isn't in an application in INSTALLED_APPS or else was imported before its application was loaded. This will no longer be supported in Django 1.9.\n  class SiteConfigurationHistory(TimeStampedModel):\n\n2016-10-20 15:41:21,196 WARNING 5561 [py.warnings] importlib.py:9 - /edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/require/helpers.py:4: RemovedInDjango19Warning: django.utils.importlib will be removed in Django 1.9.\n  from django.utils.importlib import import_module\n\n2016-10-20 15:41:21,208 WARNING 5561 [py.warnings] base.py:116 - /edx/app/edxapp/edx-platform/openedx/core/djangoapps/self_paced/models.py:11: RemovedInDjango19Warning: Model class openedx.core.djangoapps.self_paced.models.SelfPacedConfiguration doesn't declare an explicit app_label and either isn't in an application in INSTALLED_APPS or else was imported before its application was loaded. This will no longer be supported in Django 1.9.\n  class SelfPacedConfiguration(ConfigurationModel):\n\n2016-10-20 15:41:21,338 WARNING 5561 [py.warnings] base.py:116 - /edx/app/edxapp/edx-platform/openedx/core/djangoapps/content/course_overviews/models.py:618: RemovedInDjango19Warning: Model class openedx.core.djangoapps.content.course_overviews.models.CourseOverviewTab doesn't declare an explicit app_label and either isn't in an application in INSTALLED_APPS or else was imported before its application was loaded. This will no longer be supported in Django 1.9.\n  class CourseOverviewTab(models.Model):\n\n2016-10-20 15:41:21,339 WARNING 5561 [py.warnings] base.py:116 - /edx/app/edxapp/edx-platform/openedx/core/djangoapps/content/course_overviews/models.py:626: RemovedInDjango19Warning: Model class openedx.core.djangoapps.content.course_overviews.models.CourseOverviewImageSet doesn't declare an explicit app_label and either isn't in an application in INSTALLED_APPS or else was imported before its application was loaded. This will no longer be supported in Django 1.9.\n  class CourseOverviewImageSet(TimeStampedModel):\n\n2016-10-20 15:41:21,340 WARNING 5561 [py.warnings] base.py:116 - /edx/app/edxapp/edx-platform/openedx/core/djangoapps/content/course_overviews/models.py:764: RemovedInDjango19Warning: Model class openedx.core.djangoapps.content.course_overviews.models.CourseOverviewImageConfig doesn't declare an explicit app_label and either isn't in an application in INSTALLED_APPS or else was imported before its application was loaded. This will no longer be supported in Django 1.9.\n  class CourseOverviewImageConfig(ConfigurationModel):\n\n2016-10-20 15:41:21,344 WARNING 5561 [py.warnings] base.py:116 - /edx/app/edxapp/edx-platform/common/djangoapps/course_modes/models.py:29: RemovedInDjango19Warning: Model class course_modes.models.CourseMode doesn't declare an explicit app_label and either isn't in an application in INSTALLED_APPS or else was imported before its application was loaded. This will no longer be supported in Django 1.9.\n  class CourseMode(models.Model):\n\nParsing log file: access.log\nWriting to file passed via parameter: /tmp/activity_report",
       "stdout": "[149.202.188.116]\ncourses = 1\nhits = 4\nusers = 7",
       "stdout_lines": [
           "[149.202.188.116]",
           "courses = 1",
           "hits = 4",
           "users = 7"
       ],
       "warnings": []
   }
   }
   
   TASK [Fetch stats] *************************************************************
   changed: [149.202.188.116]
   
   TASK [debug] *******************************************************************
   ok: [149.202.188.116] => {
   "fetch_results": {
       "changed": true,
       "checksum": "932360475ce5553997c0c5848587113df8d66fae",
       "dest": "/tmp/tmp5mdcxrap/149.202.188.116",
       "md5sum": "22bee0d1341ccfe358eab3a86424b936",
       "remote_checksum": "932360475ce5553997c0c5848587113df8d66fae",
       "remote_md5sum": null
   }
   }
   
   PLAY RECAP *********************************************************************
   149.202.188.116            : ok=6    changed=2    unreachable=0    failed=0
   
   Appserver IP,Owner Emails,Unique Hits,Total Users,Total Courses,Age (Days)
   149.202.188.116,"['brandon@opencraft.com', 'x@bdero.me']",4,7,1,0
   Done generating CSV output.
   ```
   
   Note that the actual CSV output is written to stdout, while everything else is written to stderr. This makes the command directly machine readable.

1. Check the contents of `out.csv` to verify that the **"Internal LMS Domain"** and **"Name"** are listed. Also note that the email of the beta test user on OCIM is used for the email field. (**If there is no betatest application associated with the instance, "N/A" is used for the email instead**):
   
   ```
   $ cat out.csv 
   "Appserver IP","Internal LMS Domain","Name","Contact Email","Unique Hits","Total Users","Total Courses","Age (Days)"
   "213.32.77.49","test.example.com","This, name, ""is, crazy""","x@bdero.me","9","6","1",0
   ```

**Reviewers**
- [ ] @pomegranited 
