### PR TITLE
Fixes for load balancer issues

### DIFF
--- a/instance/api/openedx_appserver.py
+++ b/instance/api/openedx_appserver.py
@@ -33,7 +33,7 @@ from instance.models.openedx_appserver import OpenEdXAppServer
 from instance.models.openedx_instance import OpenEdXInstance
 from instance.serializers.appserver import AppServerBasicSerializer
 from instance.serializers.openedx_appserver import OpenEdXAppServerSerializer, SpawnAppServerSerializer
-from instance.tasks import spawn_appserver
+from instance.tasks import set_appserver_active, spawn_appserver
 
 
 # Views - API #################################################################
@@ -98,5 +98,5 @@ class OpenEdXAppServerViewSet(viewsets.ReadOnlyModelViewSet):
             return Response(
                 {"error": "Cannot make an unhealthy app server active."}, status=status.HTTP_400_BAD_REQUEST
             )
-        app_server.instance.set_appserver_active(app_server.pk)
-        return Response({'status': 'App server updated.'})
+        set_appserver_active(app_server.pk)
+        return Response({'status': 'App server activation initiated.'})

--- a/instance/models/load_balancer.py
+++ b/instance/models/load_balancer.py
@@ -149,7 +149,7 @@ class LoadBalancingServer(ValidateModelMixin, TimeStampedModel):
         for instance in self.get_instances():
             map_entries, conf_entries = instance.get_load_balancer_configuration()
             backend_map.extend(
-                " ".join([domain, backend + self.fragment_name_postfix])
+                " ".join([domain.lower(), backend + self.fragment_name_postfix])
                 for domain, backend in map_entries
             )
             backend_conf.extend(

--- a/instance/models/openedx_instance.py
+++ b/instance/models/openedx_instance.py
@@ -274,9 +274,14 @@ class OpenEdXInstance(LoadBalancedInstance, OpenEdXAppConfiguration, OpenEdXData
         """
         if not self.active_appserver:
             return self.get_preliminary_page_config(self.ref.pk)
+        ip_address = self.active_appserver.server.public_ip
+        if not ip_address:
+            # The active appserver doesn't have a public IP address.  This means that the server
+            # has been terminated, so we don't show the preliminary page in this case, and simply
+            # deconfigure the backend instead.
+            return [], []
         backend_name = "be-{}".format(self.active_appserver.server.name)
         server_name = "appserver-{}".format(self.active_appserver.pk)
-        ip_address = self.active_appserver.server.public_ip
         template = loader.get_template("instance/haproxy/openedx.conf")
         config = template.render(dict(
             domain=self.domain,

--- a/instance/tasks.py
+++ b/instance/tasks.py
@@ -27,6 +27,7 @@ import logging
 
 from huey.contrib.djhuey import crontab, db_task, db_periodic_task
 
+from instance.models.openedx_appserver import OpenEdXAppServer
 from instance.models.openedx_instance import OpenEdXInstance
 from instance.utils import sufficient_time_passed
 from pr_watch import github
@@ -63,6 +64,16 @@ def spawn_appserver(instance_ref_id, mark_active_on_success=False, num_attempts=
                 # finish and replace the second as the active server. We are not really worried about that for now.
                 instance.set_appserver_active(appserver_id)
             break
+
+
+@db_task()
+def set_appserver_active(appserver_id):
+    """
+    Mark an AppServer as active.
+    """
+    logger.info('Retrieving AppServer: ID=%s', appserver_id)
+    appserver = OpenEdXAppServer.objects.get(pk=appserver_id)
+    appserver.instance.set_appserver_active(appserver_id)
 
 
 @db_task()

--- a/instance/tests/api/test_openedx_appserver.py
+++ b/instance/tests/api/test_openedx_appserver.py
@@ -209,7 +209,7 @@ class OpenEdXAppServerAPITestCase(APITestCase):
 
         response = self.api_client.post('/api/v1/openedx_appserver/{pk}/make_active/'.format(pk=app_server.pk))
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.data, {'status': 'App server updated.'})
+        self.assertEqual(response.data, {'status': 'App server activation initiated.'})
         self.assertEqual(mock_run_playbook.call_count, 1)
 
         instance.refresh_from_db()


### PR DESCRIPTION
This PR includes three fixes:

1. Don't include appservers that have been turned down in the LB configuration.  This has caused `None` appearing as an IP address in the configuration, resulting in haproxy refusing to reload the config.

2. Convert all domain names to lower case for the LB configuration.  I've already manually patched this up on the LB server, but we should do it in the IM as well.  Actually, all domain names should be converted to lower case when entered, and only stored in lower case, but this fix makes sure we at least never send upper-case names to the load balancer.

3. Add a new Huey task for activating an appserver.  This takes much longer than it used to, since it now has to run a playbook to reconfigure the LB server, so we can't do it as part of a normal request response anymore.