### PR TITLE
Add explicit Swift enable flag

### DIFF
--- a/instance/templates/instance/ansible/swift.yml
+++ b/instance/templates/instance/ansible/swift.yml
@@ -5,6 +5,7 @@ VHOST_NAME: 'openstack'
 # COMMON_VHOST_ROLE_NAME is deprecated; keeping it around for compatibility
 COMMON_VHOST_ROLE_NAME: '{{ VHOST_NAME }}'
 
+EDXAPP_USE_SWIFT_STORAGE: true
 EDXAPP_DEFAULT_FILE_STORAGE: 'swift.storage.SwiftStorage'
 EDXAPP_FILE_UPLOAD_STORAGE_BUCKET_NAME: '{{ container_name }}'
 EDXAPP_SWIFT_AUTH_VERSION: '2'


### PR DESCRIPTION
This change adds support for versions of configuration at or newer than https://github.com/edx/configuration/commit/5754b49810d8195975368a8167e53ac7b5cb1bb3. That commit does a meta-include of the Openstack role in edxapp when this explicit flag is set.

**Dependencies**: None

**Testing instructions**:

1. Create an instance using version 5754b49  or newer of configuration.
2. Ensure that the instance does not use ephemeral databases.
3. Spawn an appserver, noting that it spawns successfully with Swift storage enabled.

**Reviewers**
- [x] @smarnach