### PR TITLE
Some further load balancer fixes.

### DIFF
--- a/debian_packages.lst
+++ b/debian_packages.lst
@@ -1,4 +1,5 @@
 git
+libffi-dev
 libmysqlclient-dev
 libpq-dev
 make

--- a/instance/admin.py
+++ b/instance/admin.py
@@ -26,9 +26,10 @@ from django.contrib import admin
 
 from instance.models.database_server import MySQLServer, MongoDBServer
 from instance.models.instance import InstanceReference
-from instance.models.openedx_instance import OpenEdXInstance
-from instance.models.openedx_appserver import OpenEdXAppServer
+from instance.models.load_balancer import LoadBalancingServer
 from instance.models.log_entry import LogEntry
+from instance.models.openedx_appserver import OpenEdXAppServer
+from instance.models.openedx_instance import OpenEdXInstance
 from instance.models.server import OpenStackServer
 
 
@@ -66,6 +67,10 @@ class MongoDBServerAdmin(admin.ModelAdmin): # pylint: disable=missing-docstring
     list_display = ('name', 'description', 'hostname', 'port', 'username', 'password')
 
 
+class LoadBalancingServerAdmin(admin.ModelAdmin): # pylint: disable=missing-docstring
+    list_display = ('domain', 'ssh_username')
+
+
 admin.site.register(LogEntry, LogEntryAdmin)
 admin.site.register(OpenStackServer, OpenStackServerAdmin)
 admin.site.register(InstanceReference, InstanceReferenceAdmin)
@@ -73,3 +78,4 @@ admin.site.register(OpenEdXInstance, OpenEdXInstanceAdmin)
 admin.site.register(OpenEdXAppServer, OpenEdXAppServerAdmin)
 admin.site.register(MySQLServer, MySQLServerAdmin)
 admin.site.register(MongoDBServer, MongoDBServerAdmin)
+admin.site.register(LoadBalancingServer, LoadBalancingServerAdmin)

--- a/instance/models/load_balancer.py
+++ b/instance/models/load_balancer.py
@@ -193,7 +193,7 @@ class LoadBalancingServer(ValidateModelMixin, TimeStampedModel):
         This is factored out into a separate method so it can be mocked out in the tests.
         """
         playbook_path = pathlib.Path(settings.SITE_ROOT) / "playbooks/load_balancer_conf/load_balancer_conf.yml"
-        with cache.lock(self.domain):
+        with cache.lock("load_balancer_reconfigure:{}".format(self.domain), timeout=900):
             returncode = ansible.capture_playbook_output(
                 requirements_path=str(playbook_path.parent / "requirements.txt"),
                 inventory_str=self.domain,

--- a/instance/models/openedx_instance.py
+++ b/instance/models/openedx_instance.py
@@ -268,7 +268,7 @@ class OpenEdXInstance(LoadBalancedInstance, OpenEdXAppConfiguration, OpenEdXData
             self.use_ephemeral_databases = settings.INSTANCE_EPHEMERAL_DATABASES
         super().save(**kwargs)
 
-    def get_load_balancer_configuration(self):
+    def get_load_balancer_configuration(self, triggered_by_instance=False):
         """
         Return the haproxy configuration fragment and backend map for this instance.
         """
@@ -279,6 +279,11 @@ class OpenEdXInstance(LoadBalancedInstance, OpenEdXAppConfiguration, OpenEdXData
             # The active appserver doesn't have a public IP address.  This means that the server
             # has been terminated, so we don't show the preliminary page in this case, and simply
             # deconfigure the backend instead.
+            if triggered_by_instance:
+                self.logger.info(
+                    "Active appserver does not have a public IP address. "
+                    "Deconfiguring the load balancer backend."
+                )
             return [], []
         backend_name = "be-{}".format(self.active_appserver.server.name)
         server_name = "appserver-{}".format(self.active_appserver.pk)
@@ -289,7 +294,14 @@ class OpenEdXInstance(LoadBalancedInstance, OpenEdXAppConfiguration, OpenEdXData
             ip_address=ip_address,
         ))
         backend_map = [(domain, backend_name) for domain in self.get_load_balanced_domains()]
-        return backend_map, [(backend_name, config)]
+        backend_conf = [(backend_name, config)]
+        if triggered_by_instance:
+            self.logger.info(
+                "New load-balancer configuration:\n    backend map: %s\n   configuration: %s",
+                backend_map,
+                backend_conf,
+            )
+        return backend_map, backend_conf
 
     @property
     def appserver_set(self):
@@ -306,7 +318,7 @@ class OpenEdXInstance(LoadBalancedInstance, OpenEdXAppConfiguration, OpenEdXData
         self.logger.info('Making %s active for instance %s...', app_server.name, self.name)
         self.active_appserver = app_server
         self.save()
-        self.load_balancing_server.reconfigure()
+        self.reconfigure_load_balancer()
         self.enable_monitoring()
 
     def set_appserver_inactive(self):
@@ -316,8 +328,7 @@ class OpenEdXInstance(LoadBalancedInstance, OpenEdXAppConfiguration, OpenEdXData
         self.disable_monitoring()
         self.active_appserver = None
         self.save()
-        if self.load_balancing_server is not None:
-            self.load_balancing_server.reconfigure()
+        self.reconfigure_load_balancer()
 
     @log_exception
     def spawn_appserver(self):
@@ -329,7 +340,7 @@ class OpenEdXInstance(LoadBalancedInstance, OpenEdXAppConfiguration, OpenEdXData
         if not self.load_balancing_server:
             self.load_balancing_server = LoadBalancingServer.objects.select_random()
             self.save()
-            self.load_balancing_server.reconfigure()
+            self.reconfigure_load_balancer()
 
         # We unconditionally set the DNS records here, though this would only be strictly needed
         # when the first AppServer is spawned.  However, there is no easy way to tell whether the
@@ -418,7 +429,7 @@ class OpenEdXInstance(LoadBalancedInstance, OpenEdXAppConfiguration, OpenEdXData
             if self.active_appserver is None:
                 # If an appserver is active, reconfiguring the load_balancer happens
                 # implicitly when terminate_vm() is called further down.
-                load_balancer.reconfigure()
+                self.reconfigure_load_balancer(load_balancer)
         for appserver in self.appserver_set.iterator():
             appserver.terminate_vm()
 

--- a/instance/tests/models/test_load_balancer.py
+++ b/instance/tests/models/test_load_balancer.py
@@ -47,7 +47,9 @@ def mock_instances():
     """
     instances = [
         _make_mock_instance(
-            ["test1.lb.opencraft.hosting", "test2.lb.opencraft.hosting"],
+            # We include an upper-case domain name here to be able to test it gets properly
+            # converted to lower-case when the configuration is sent to the load balancer.
+            ["test1.lb.opencraft.hosting", "TEST2.lb.opencraft.hosting"],
             "1.2.3.4",
             "first-backend",
         ),

--- a/instance/tests/models/test_openedx_instance.py
+++ b/instance/tests/models/test_openedx_instance.py
@@ -467,8 +467,12 @@ class OpenEdXInstanceTestCase(TestCase):
             backend_map, config, domain_names, instance.active_appserver.server.public_ip
         )
 
-        # Test configuration after terminating appserver
-        with patch('instance.openstack.get_server_public_address', return_value=None):
+        # Test configuration in case an active appserver doesn't have a public IP address anymore.
+        # This might happen if the OpenStack server dies or gets modified from the outside, but it
+        # is not expected to happen under normal circumstances.  We deconfigure the backend and log
+        # an error in this case.
+        with patch('instance.openstack.get_server_public_address', return_value=None), \
+                self.assertLogs("instance.models.instance", "ERROR"):
             self.assertEqual(instance.get_load_balancer_configuration(), ([], []))
 
     def test_get_load_balancer_config_ext_domains(self):

--- a/instance/tests/models/test_openedx_instance.py
+++ b/instance/tests/models/test_openedx_instance.py
@@ -467,6 +467,10 @@ class OpenEdXInstanceTestCase(TestCase):
             backend_map, config, domain_names, instance.active_appserver.server.public_ip
         )
 
+        # Test configuration after terminating appserver
+        with patch('instance.openstack.get_server_public_address', return_value=None):
+            self.assertEqual(instance.get_load_balancer_configuration(), ([], []))
+
     def test_get_load_balancer_config_ext_domains(self):
         """
         Test the load balancer configuration when external domains are set.


### PR DESCRIPTION
This PR addresses the open comments in #154.  See that PR for discussions.

The PR also contains a further fix:

* Install the libffi-dev library, which for some reason is needed to install Ansible version 2.1.2.0 as of today.  (Yesterday it was still possible to install it without that lib being available.)  This lib has already been installed on stage and prod.  See also the mail from Matjaz.
