### PR TITLE
Added human readable description and name fields for DBs

### DIFF
--- a/instance/admin.py
+++ b/instance/admin.py
@@ -59,11 +59,11 @@ class OpenEdXAppServerAdmin(admin.ModelAdmin): # pylint: disable=missing-docstri
 
 
 class MySQLServerAdmin(admin.ModelAdmin): # pylint: disable=missing-docstring
-    list_display = ('hostname', 'port', 'username', 'password')
+    list_display = ('name', 'description', 'hostname', 'port', 'username', 'password')
 
 
 class MongoDBServerAdmin(admin.ModelAdmin): # pylint: disable=missing-docstring
-    list_display = ('hostname', 'port', 'username', 'password')
+    list_display = ('name', 'description', 'hostname', 'port', 'username', 'password')
 
 
 admin.site.register(LogEntry, LogEntryAdmin)

--- a/instance/migrations/0065_create_description.py
+++ b/instance/migrations/0065_create_description.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('instance', '0064_merge'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='mongodbserver',
+            name='description',
+            field=models.CharField(blank=True, max_length=250),
+        ),
+        migrations.AddField(
+            model_name='mongodbserver',
+            name='name',
+            field=models.CharField(max_length=250, blank=True),
+        ),
+        migrations.AddField(
+            model_name='mysqlserver',
+            name='description',
+            field=models.CharField(blank=True, max_length=250),
+        ),
+        migrations.AddField(
+            model_name='mysqlserver',
+            name='name',
+            field=models.CharField(max_length=250, blank=True),
+        ),
+    ]

--- a/instance/migrations/0066_populate_name.py
+++ b/instance/migrations/0066_populate_name.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+def populate_name(apps, schema_editor):
+    dbs = (
+        apps.get_model('instance', model)
+        for model in ['MySQLServer', 'MongoDBServer']
+    )
+    for model in dbs:
+        for row in model.objects.all():
+            row.name = row.hostname
+            row.save()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('instance', '0065_create_description'),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            populate_name,
+            reverse_code=migrations.RunPython.noop
+        ),
+    ]

--- a/instance/migrations/0067_remove_blank_name.py
+++ b/instance/migrations/0067_remove_blank_name.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('instance', '0066_populate_name'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='mongodbserver',
+            name='name',
+            field=models.CharField(max_length=250, blank=False),
+        ),
+        migrations.AlterField(
+            model_name='mysqlserver',
+            name='name',
+            field=models.CharField(max_length=250, blank=False),
+        ),
+    ]

--- a/instance/models/database_server.py
+++ b/instance/models/database_server.py
@@ -73,6 +73,7 @@ class DatabaseServerManager(models.Manager):
                 )
             logger.info("Creating DatabaseServer %s", hostname)
             database_server, created = self.get_or_create(  # pylint: disable=no-member
+                name=hostname,
                 hostname=hostname,
                 defaults=dict(
                     username=username,
@@ -120,6 +121,10 @@ class DatabaseServer(ValidateModelMixin, TimeStampedModel):
     class Meta:
         abstract = True
 
+    # Human readable identifier for database instances
+    name = models.CharField(max_length=250, blank=False)
+    description = models.CharField(max_length=250, blank=True)
+
     # Host name or IP address of this database server
     hostname = models.CharField(max_length=128, unique=True)
 
@@ -166,7 +171,13 @@ class DatabaseServer(ValidateModelMixin, TimeStampedModel):
         return url
 
     def __str__(self):
-        return self.hostname
+        description = ''
+        if self.description:
+            description = ' ({description})'.format(description=self.description)
+        return '{name}{description}'.format(
+            name=self.name,
+            description=description
+        )
 
     def settings_match(self, username, password, port):
         """

--- a/instance/tests/models/factories/database_server.py
+++ b/instance/tests/models/factories/database_server.py
@@ -37,6 +37,7 @@ class MySQLServerFactory(DjangoModelFactory):
     class Meta:
         model = MySQLServer
 
+    name = factory.Sequence('mysql-server-{}'.format)
     hostname = factory.Sequence('mysql-server-{}'.format)
 
 
@@ -47,4 +48,5 @@ class MongoDBServerFactory(DjangoModelFactory):
     class Meta:
         model = MongoDBServer
 
+    name = factory.Sequence('mysql-server-{}'.format)
     hostname = factory.Sequence('mongodb-server-{}'.format)


### PR DESCRIPTION
This PR adds a human readable name and description field to database entries. The name fields are bootstrapped with the hostname field values by the migrations.

**Testing instructions:**

1. Checkout master on a local OCIM vagrant instance.
1. Login to the admin panel and create a new MySQL and MongoDB database entry. Fill in whatever hostnames you want, it doesn't have to be real for the purpose of testing this change.
1. Navigate to the [Open edX instance "add" page](https://console.opencraft.com/admin/instance/openedxinstance/add/).
1. Check the `Mysql server` and `Mongodb server` dropdowns and confirm that the `hostname` is used as the display for both.
1. Checkout this PR's branch and run `make migrate`.
1. Navigate to the [Open edX instance "add" page](https://console.opencraft.com/admin/instance/openedxinstance/add/) again.
1. Confirm that the dropdowns still show the same content as before (the hostname).
1. Navigate to the MySQL and MongoDB DB entries in OCIM and edit them - fill out new names and descriptions.
1. Navigate to the [Open edX instance "add" page](https://console.opencraft.com/admin/instance/openedxinstance/add/) again.
1. Verify that the MySQL and MongoDB server names are listed in the format **"Name (Description)"**. Note that if the description field is left blank, then the format will just be **"Name"**.