### PR TITLE
Use multiple gunicorn workers in production

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,4 +1,4 @@
-web: gunicorn opencraft.wsgi --log-file -
+web: gunicorn opencraft.wsgi --timeout 60 --workers 4 --log-file -
 websocket: python3 websocket.py
 worker: python3 manage.py run_huey --no-periodic
 periodic: python3 manage.py run_huey --workers=0


### PR DESCRIPTION
This PR configures gunicorn to spawn 4 workers in production mode.