### PR TITLE
Fix bug occurring when shutting down instance with no active appserver.

### DIFF
--- a/instance/models/mixins/load_balanced.py
+++ b/instance/models/mixins/load_balanced.py
@@ -93,7 +93,7 @@ class LoadBalancedInstance(models.Model):
             if load_balancing_server is None:
                 return
         self.logger.info("Triggering reconfiguration of the load balancing server...")
-        self.load_balancing_server.reconfigure(self.ref.pk)
+        load_balancing_server.reconfigure(self.ref.pk)
 
     def get_preliminary_page_config(self, primary_key):
         """

--- a/instance/models/openedx_instance.py
+++ b/instance/models/openedx_instance.py
@@ -425,10 +425,7 @@ class OpenEdXInstance(LoadBalancedInstance, OpenEdXAppConfiguration, OpenEdXData
             load_balancer = self.load_balancing_server
             self.load_balancing_server = None
             self.save()
-            if self.active_appserver is None:
-                # If an appserver is active, reconfiguring the load_balancer happens
-                # implicitly when terminate_vm() is called further down.
-                self.reconfigure_load_balancer(load_balancer)
+            self.reconfigure_load_balancer(load_balancer)
         for appserver in self.appserver_set.iterator():
             appserver.terminate_vm()
 


### PR DESCRIPTION
This bug was encountered by @bdero when shutting down unused beta test instances.

The bug occurs when an instance without any active appserver is shut down.  This case triggered a special code path, which was not covered by the tests.  I added a test to cover it.

I also removed the `if` clause that triggered that special code path, since it's not needed anymore in the current version.  (It was needed at some point.)  I leave the test in anyway.

For testing, create an instance, spawn an appserver, and shut the instance down without activating the appserver.