### PR TITLE
Use the Gandi API to determine the registered domain.

### DIFF
--- a/instance/tests/fake_gandi_client.py
+++ b/instance/tests/fake_gandi_client.py
@@ -1,0 +1,216 @@
+# -*- coding: utf-8 -*-
+#
+# OpenCraft -- tools to aid developing and hosting free software projects
+# Copyright (C) 2015-2016 OpenCraft <contact@opencraft.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+"""
+Fake implementation of the XML RPC client for the Gandi API.
+"""
+from unittest import mock
+import xmlrpc.client
+
+
+class FakeZone:
+    """
+    A fake implementation of a Gandi DNS zone.
+
+    The fake implementation keeps track of version numbers and DNS records.
+    """
+    def __init__(self):
+        self.active_version = 0
+        self.next_version = 1
+        self.records = {0: []}
+
+    def filter_records(self, version_id, query_record, inverse_match=False):
+        """
+        Return DNS records matching the query record.
+
+        If inverse_match is True, return non-matching records instead.
+        """
+        for record in self.records[version_id]:
+            match = True
+            for key, value in query_record.items():
+                if not isinstance(value, list):
+                    value = [value]
+                if record.get(key) not in value:
+                    match = False
+                    break
+            if match != inverse_match:
+                yield record
+
+    def add_record(self, version_id, record):
+        """
+        Add a DNS record.
+        """
+        if version_id == self.active_version:
+            raise xmlrpc.client.Fault(581030, "Cannot modify the active version.")
+        if version_id not in range(self.next_version):
+            raise xmlrpc.client.Fault(581042, "No such version.")
+        if {"name", "type", "value"} - record.keys():
+            raise xmlrpc.client.Fault(581137, "Required parameter missing.")
+        if "ttl" not in record:
+            record["ttl"] = 10800
+        self.records[version_id].append(record)
+        return record
+
+    def delete_record(self, version_id, record):
+        """
+        Delete a DNS record.
+        """
+        if version_id == self.active_version:
+            raise xmlrpc.client.Fault(581030, "Cannot modify the active version.")
+        if version_id not in range(self.next_version):
+            raise xmlrpc.client.Fault(581042, "No such version.")
+        if "name" not in record:
+            # The actual API does not enforce this - you can delete all records by specifying an
+            # empty record.  In the context of OpenCraft IM, we always want the name to be included.
+            raise xmlrpc.client.Fault(581137, "Required parameter missing.")
+        new_records = list(self.filter_records(version_id, record, inverse_match=True))
+        deleted = len(self.records[version_id]) - len(new_records)
+        self.records[version_id] = new_records
+        return deleted
+
+    def list_records(self, version_id, record=None):
+        """
+        List DNS records.
+        """
+        if version_id not in range(self.next_version):
+            raise xmlrpc.client.Fault(581042, "No such version.")
+        if not record:
+            return self.records[version_id]
+        return list(self.filter_records(version_id, record))
+
+    def new_version(self):
+        """
+        Create a new version of a DNS zone.
+        """
+        version = self.next_version
+        self.records[version] = self.records[self.active_version].copy()
+        self.next_version += 1
+        return version
+
+    def set_version(self, version_id):
+        """
+        Make the given DNS zone version active.
+        """
+        if version_id not in range(self.next_version):
+            raise xmlrpc.client.Fault(581042, "No such version.")
+        self.active_version = version_id
+        return True
+
+
+class FakeGandiClient:
+    """
+    Fake implementation of the XML RPC client for the Gandi API.
+
+    The behaviour should reflect how the behaviour of the actual Gandi client.  The fake responses
+    are reduced to the fields we need.
+    """
+
+    _DOMAINS_BY_ZONE_ID = {
+        9900: "test.com",
+        1234: "example.com",
+        4711: "opencraft.co.uk",
+    }
+
+    def __init__(self):
+        self.domain = mock.Mock(spec=["list", "info", "zone"])
+        self.domain.list.side_effect = self._domain_list
+        self.domain.info.side_effect = self._domain_info
+        self.domain.zone.record.add.side_effect = self._domain_zone_record_add
+        self.domain.zone.record.delete.side_effect = self._domain_zone_record_delete
+        self.domain.zone.record.list.side_effect = self._domain_zone_record_list
+        self.domain.zone.version.new.side_effect = self._domain_zone_version_new
+        self.domain.zone.version.set.side_effect = self._domain_zone_version_set
+        self._registry = {zone_id: FakeZone() for zone_id in self._DOMAINS_BY_ZONE_ID}
+        self._version_creation_failures = 0
+
+    def make_version_creation_fail(self, times):
+        """
+        Make the call to domain.zone.version.new fail for the next `times` attempts.
+        """
+        self._version_creation_failures = times
+
+    def list_records(self, domain):
+        """
+        Convenience method to make listing the records for a domain easier.
+        """
+        zone_id = self._domain_info(None, domain)["zone_id"]
+        zone = self._registry[zone_id]
+        return zone.list_records(zone.active_version)
+
+    def _domain_list(self, api_key):
+        """
+        List domains managed by the account.
+        """
+        return [{"fqdn": domain} for domain in self._DOMAINS_BY_ZONE_ID.values()]
+
+    def _domain_info(self, api_key, domain):
+        """
+        Return details for the given domain.
+        """
+        domain = domain.lower()
+        for zone_id, other_domain in self._DOMAINS_BY_ZONE_ID.items():
+            if domain == other_domain:
+                return {"fqdn": domain, "zone_id": zone_id}
+        raise xmlrpc.client.Fault(510042, "Domain '{}' doesn't exist.".format(domain))
+
+    def _get_zone(self, zone_id):
+        """
+        Retrieve a fake zone from the registry.
+        """
+        try:
+            return self._registry[zone_id]
+        except KeyError:
+            raise xmlrpc.client.Fault(581042, "No such zone.") from None
+
+    def _domain_zone_record_add(self, api_key, zone_id, zone_version_id, record):
+        """
+        Add a DNS record.
+        """
+        zone = self._get_zone(zone_id)
+        return zone.add_record(zone_version_id, record)
+
+    def _domain_zone_record_delete(self, api_key, zone_id, zone_version_id, record):
+        """
+        Delete a DNS record.
+        """
+        zone = self._get_zone(zone_id)
+        return zone.delete_record(zone_version_id, record)
+
+    def _domain_zone_record_list(self, api_key, zone_id, zone_version_id, record=None):
+        """
+        List DNS records.
+        """
+        zone = self._get_zone(zone_id)
+        return zone.list_records(zone_version_id, record)
+
+    def _domain_zone_version_new(self, api_key, zone_id):
+        """
+        Create a new version of a DNS zone.
+        """
+        if self._version_creation_failures:
+            self._version_creation_failures -= 1
+            raise xmlrpc.client.Fault(581091, "Error")
+        zone = self._get_zone(zone_id)
+        return zone.new_version()
+
+    def _domain_zone_version_set(self, api_key, zone_id, zone_version_id):
+        """
+        Make the given DNS zone version active.
+        """
+        zone = self._get_zone(zone_id)
+        return zone.set_version(zone_version_id)

--- a/instance/tests/test_gandi.py
+++ b/instance/tests/test_gandi.py
@@ -27,6 +27,7 @@ import xmlrpc.client
 
 from instance import gandi
 from instance.tests.base import TestCase
+from instance.tests.fake_gandi_client import FakeGandiClient
 
 
 # Tests #######################################################################
@@ -37,57 +38,76 @@ class GandiTestCase(TestCase):
     """
     def setUp(self):
         super().setUp()
+        self.api = gandi.GandiAPI(client=FakeGandiClient())
 
-        with patch('xmlrpc.client.ServerProxy'):
-            self.api = gandi.GandiAPI()
-            self.api.client.domain.info.return_value = {
-                'fqdn': 'test.com',
-                'zone_id': 9900,
-                # .... full API response contains more fields, but we don't need them in this test.
-            }
+    def populate_cache(self):
+        """
+        Populate the zone ID cache of the Gandi API and reset the mocks.
+        """
+        self.api._populate_zone_id_cache()
+        self.api.client.domain.reset_mock()
 
     def assert_set_dns_record_calls(self, attempts=1):
         """
         Verify Gandi API calls for setting a DNS record value.
         """
-        domain_info_call = call.domain.info('TEST_GANDI_API_KEY', 'test.com')
-        create_new_zone_version_call = call.domain.zone.version.new('TEST_GANDI_API_KEY', 9900)
-        delete_old_record_call = call.domain.zone.record.delete(
-            'TEST_GANDI_API_KEY', 9900, 'new_zone_version',
+        create_new_zone_version_call = call.zone.version.new('TEST_GANDI_API_KEY', 9900)
+        delete_old_record_call = call.zone.record.delete(
+            'TEST_GANDI_API_KEY', 9900, 1,
             {'type': ['A', 'CNAME'], 'name': 'sub.domain'}
         )
-        create_new_record_call = call.domain.zone.record.add(
-            'TEST_GANDI_API_KEY', 9900, 'new_zone_version',
+        create_new_record_call = call.zone.record.add(
+            'TEST_GANDI_API_KEY', 9900, 1,
             {'value': '192.168.99.99', 'ttl': 1200, 'type': 'A', 'name': 'sub.domain'}
         )
-        set_new_zone_version_call = call.domain.zone.version.set('TEST_GANDI_API_KEY', 9900, 'new_zone_version')
+        set_new_zone_version_call = call.zone.version.set('TEST_GANDI_API_KEY', 9900, 1)
 
         self.assertEqual(
-            self.api.client.mock_calls,
-            [domain_info_call] +
+            self.api.client.domain.mock_calls,
             [create_new_zone_version_call] * attempts +
             [delete_old_record_call, create_new_record_call, set_new_zone_version_call]
         )
+
+    def test_populate_zone_id_cache(self):
+        """
+        Test that populating the zone ID cache results in the expected API calls.
+        """
+        self.api.get_zone_id('test.com')  # Implicitly calls _populate_zone_id_cache()
+        self.assertEqual(len(self.api.client.domain.mock_calls), 4)
+        self.api.client.domain.assert_has_calls([
+            call.list('TEST_GANDI_API_KEY'),
+            call.info('TEST_GANDI_API_KEY', 'test.com'),
+            call.info('TEST_GANDI_API_KEY', 'example.com'),
+            call.info('TEST_GANDI_API_KEY', 'opencraft.co.uk'),
+        ], any_order=True)
+
+    def test_split_domain_name(self):
+        """
+        Test that splitting domain names in subdomain and registered domain works correctly.
+        """
+        self.assertEqual(self.api.split_domain_name('sub.domain.test.com'), ('sub.domain', 'test.com'))
+        self.assertEqual(self.api.split_domain_name('sub.domain.opencraft.co.uk'), ('sub.domain', 'opencraft.co.uk'))
+        self.assertEqual(self.api.split_domain_name('example.com'), ('@', 'example.com'))
+        with self.assertRaises(ValueError):
+            self.api.split_domain_name('sub.domain.unknown.com')
 
     def test_get_zone_id(self):
         """
         Gets zone_id for the requested FQDN.
         The zone_id is cached in memory after retreived for the first time.
         """
+        self.populate_cache()
         zone_id = self.api.get_zone_id('test.com')
         self.assertEqual(zone_id, 9900)
-        self.assertEqual(self.api.client.domain.info.call_count, 1)
-        zone_id = self.api.get_zone_id('test.com')
-        self.assertEqual(zone_id, 9900)
-        # Cached zone_id value was used; no additional call to the API was made.
-        self.assertEqual(self.api.client.domain.info.call_count, 1)
+        # There shouldn't be any API calls because the IDs are retrieved from the cache.
+        self.assertEqual(len(self.api.client.domain.mock_calls), 0)
 
     def test_set_dns_record(self):
         """
         Set a DNS record value.
         """
-        self.api.client.domain.zone.version.new.return_value = 'new_zone_version'
-        self.api.set_dns_record('test.com', type='A', name='sub.domain', value='192.168.99.99')
+        self.populate_cache()
+        self.api.set_dns_record('sub.domain.test.com', type='A', value='192.168.99.99')
         self.assert_set_dns_record_calls()
 
     @patch('time.sleep')
@@ -95,11 +115,11 @@ class GandiTestCase(TestCase):
         """
         Test retry behaviour when setting a DNS record.  Succeed in the third attempt.
         """
-        fault = xmlrpc.client.Fault(581091, 'Error')
-        self.api.client.domain.zone.version.new.side_effect = [fault, fault, 'new_zone_version']
+        self.populate_cache()
+        self.api.client.make_version_creation_fail(2)
         self.api.set_dns_record(
-            'test.com',
-            type='A', name='sub.domain', value='192.168.99.99'
+            'sub.domain.test.com',
+            type='A', value='192.168.99.99'
         )
         self.assert_set_dns_record_calls(attempts=3)
         self.assertEqual(sleep.mock_calls, [call(1), call(2)])
@@ -109,11 +129,11 @@ class GandiTestCase(TestCase):
         """
         Test retry behaviour when setting a DNS record.  Fail all attempts.
         """
-        self.api.client.domain.zone.version.new.side_effect = xmlrpc.client.Fault(581091, 'Error')
+        self.api.client.make_version_creation_fail(10)
         with self.assertRaises(xmlrpc.client.Fault):
             self.api.set_dns_record(
-                'test.com',
-                type='A', name='sub.domain', value='192.168.99.99'
+                'sub.domain.test.com',
+                type='A', value='192.168.99.99'
             )
         self.assertEqual(sleep.mock_calls, [call(1), call(2), call(4)])
 
@@ -121,14 +141,13 @@ class GandiTestCase(TestCase):
         """
         Test remove_dns_record().
         """
-        self.api.client.domain.zone.version.new.return_value = 'new_zone_version'
-        self.api.remove_dns_record('test.com', 'sub.domain')
-        self.assertEqual(self.api.client.mock_calls, [
-            call.domain.info('TEST_GANDI_API_KEY', 'test.com'),
-            call.domain.zone.version.new('TEST_GANDI_API_KEY', 9900),
-            call.domain.zone.record.delete(
-                'TEST_GANDI_API_KEY', 9900, 'new_zone_version',
+        self.populate_cache()
+        self.api.remove_dns_record('sub.domain.test.com')
+        self.assertEqual(self.api.client.domain.mock_calls, [
+            call.zone.version.new('TEST_GANDI_API_KEY', 9900),
+            call.zone.record.delete(
+                'TEST_GANDI_API_KEY', 9900, 1,
                 {'type': ['A', 'CNAME'], 'name': 'sub.domain'}
             ),
-            call.domain.zone.version.set('TEST_GANDI_API_KEY', 9900, 'new_zone_version'),
+            call.zone.version.set('TEST_GANDI_API_KEY', 9900, 1),
         ])

--- a/requirements.txt
+++ b/requirements.txt
@@ -129,7 +129,6 @@ sqlparse==0.2.2
 static3==0.7.0
 stevedore==1.18.0
 -e git+https://github.com/jonashagstedt/swampdragon.git@ef8dedd191b7b3a7a11d49f5190699ed0b00bcb2#egg=SwampDragon
-tldextract==2.0.2
 tlslite==0.4.9
 tornado==4.4.2
 tornado-redis==2.4.18


### PR DESCRIPTION
This PR removes the dependency on the `tldextract` library and uses information from the Gandi API instead to determine the registered domain name.  This is necessary since `tldextract` depends on the Public Suffix List, so it will return incorrect results for `opencraft.hosting`, which is now on the Public Suffix List.

The new version requests the list of all domains registered with the Gandi account when first needed, and builds a dictionary of all zone IDs.  For setting a DNS record, we now pass in the fully qualified domain name and search the dictionary for a matching suffix.  If none is found, we raise an exception, since this means the domain name can't be set using the configured Gandi account.

This PR also introduces a fake implementation of the Gandi API which behaves similar to the actual Gandi API (at least similar enough).  It provides stricter tests that can concentrate more on desired outcomes at the same time.  (I actually didn't expect this to become as complex as it did.)

This is tested by the integration tests.  For manual testing, you can try this on stage, which uses the domain `stage.opencraft.hosting`, so it's a good test candidate.  You only need to _start_ provisioning an instance, since DNS records are set early in the process.