### PR TITLE
Fix database server creation logic

### DIFF
--- a/instance/models/database_server.py
+++ b/instance/models/database_server.py
@@ -73,9 +73,9 @@ class DatabaseServerManager(models.Manager):
                 )
             logger.info("Creating DatabaseServer %s", hostname)
             database_server, created = self.get_or_create(  # pylint: disable=no-member
-                name=hostname,
                 hostname=hostname,
                 defaults=dict(
+                    name=hostname,
                     username=username,
                     password=password,
                     port=port,


### PR DESCRIPTION
cf. [OC-2175](https://tasks.opencraft.com/browse/OC-2175)

**Test instructions**

1. If you don't have default MySQL and MongoDB database server objects in your local installation of OC IM, create them via:

    ```python
    MySQLServer.objects._create_default()
    MongoDBServer.objects._create_default()
    ```

2. Change the `name` field of the default MySQL and MongoDB database servers:

    ```python
    default_mysql_server = MySQLServer.objects.get()
    default_mongodb_server = MongoDBServer.objects.get()
    default_mysql_server.name = "Default MySQL server"
    default_mongodb_server.name = "Default MongoDB server"
    default_mysql_server.save()
    default_mongodb_server.save()
    ```

3. Try creating new (sandbox and production) instances on `master`:

    ```
    from instance.factories import instance_factory, production_instance_factory
    will_fail = instance_factory(sub_domain="will-fail")
    will_also_fail = production_instance_factory(sub_domain="will-also-fail")
    ```

    Observe that both attempts fail with:

    ```
    ValidationError: {'hostname': ['MySQL server with this Hostname already exists.']}
    ```

4. Check out this branch (`fix-database-server-creation`) and repeat the previous step:

    ```
    from instance.factories import instance_factory, production_instance_factory
    will_not_fail = instance_factory(sub_domain="will-not-fail")
    will_also_not_fail = production_instance_factory(sub_domain="will-also-not-fail")
    ```

    Observe that no `ValidationError` is raised, and instance creation finishes successfully.

**Reviewers**

- [x] @bdero 
