### PR TITLE
Deprovision NewRelic monitoring on instance.shut_down, and improve logging

### DIFF
--- a/instance/models/openedx_instance.py
+++ b/instance/models/openedx_instance.py
@@ -324,7 +324,6 @@ class OpenEdXInstance(LoadBalancedInstance, OpenEdXAppConfiguration, OpenEdXData
         """
         Reset the active AppServer to None.  Called when the active appserver is terminated.
         """
-        self.disable_monitoring()
         self.active_appserver = None
         self.save()
         self.reconfigure_load_balancer()
@@ -420,6 +419,7 @@ class OpenEdXInstance(LoadBalancedInstance, OpenEdXAppConfiguration, OpenEdXData
         """
         Shut down this instance.
         """
+        self.disable_monitoring()
         self.remove_dns_records()
         if self.load_balancing_server is not None:
             load_balancer = self.load_balancing_server

--- a/instance/models/server.py
+++ b/instance/models/server.py
@@ -192,7 +192,7 @@ class Server(ValidateModelMixin, TimeStampedModel):
         """
         Format a log line annotation for this server.
         """
-        return 'server={!s:.20}'.format(self.name)
+        return 'server={} ({!s:.20})'.format(self.pk, self.name)
 
     def sleep_until(self, condition, timeout=3600):
         """

--- a/instance/models/utils.py
+++ b/instance/models/utils.py
@@ -319,6 +319,8 @@ class ResourceStateDescriptor:
                 raise WrongStateException("This transition cannot be used to move from {} to {}".format(
                     current_state.name, to_state.name  # pylint: disable=no-member
                 ))
+            if (hasattr(resource, 'logger')):
+                resource.logger.info('Transition from "%s" to "%s"', current_state.name, to_state.name)
             self._set_state(resource, to_state)
         do_transition.from_states = from_states  # Convenient way for other code to inspect this transition
         do_transition.to_state = to_state  # Convenient way for other code to inspect this transition

--- a/instance/tasks.py
+++ b/instance/tasks.py
@@ -71,7 +71,7 @@ def set_appserver_active(appserver_id):
     """
     Mark an AppServer as active.
     """
-    logger.info('Retrieving AppServer: ID=%s', appserver_id)
+    logger.info('Activating AppServer: ID=%s', appserver_id)
     appserver = OpenEdXAppServer.objects.get(pk=appserver_id)
     appserver.instance.set_appserver_active(appserver_id)
 
@@ -90,6 +90,7 @@ def shut_down_obsolete_pr_sandboxes():
             closed_at = github.parse_date(pr['closed_at'])
             now = datetime.now()
             if sufficient_time_passed(closed_at, now, 7):
+                instance.logger.info("Shutting down obsolete sandbox instance")
                 instance.shut_down()
 
 
@@ -99,6 +100,7 @@ def terminate_obsolete_appservers_all_instances():
     Terminate obsolete app servers for all instances.
     """
     for instance in OpenEdXInstance.objects.all():
+        instance.logger.info("Terminating obsolete appservers for instance")
         instance.terminate_obsolete_appservers()
 
 

--- a/instance/tests/api/test_openedx_appserver.py
+++ b/instance/tests/api/test_openedx_appserver.py
@@ -236,26 +236,31 @@ class OpenEdXAppServerAPITestCase(APITestCase):
             },
             {
                 'level': 'INFO',
-                'text': 'instance.models.server    | server={server_name} | info',
+                'text': 'instance.models.server    | server={server_id} ({server_name}) | info',
             },
             {
                 'level': 'ERROR',
-                'text': 'instance.models.server    | server={server_name} | error',
+                'text': 'instance.models.server    | server={server_id} ({server_name}) | error',
             },
             {
                 'level': 'INFO',
-                'text': 'instance.models.server    | server={server_name} |'
+                'text': 'instance.models.server    | server={server_id} ({server_name}) |'
                         ' Starting server (status=Pending [pending])...'
             },
             {
                 'level': 'ERROR',
-                'text': 'instance.models.server    | server={server_name} |'
+                'text': 'instance.models.server    | server={server_id} ({server_name}) |'
                         ' Failed to start server: Not found (HTTP 404)'
+            },
+            {
+                'level': 'INFO',
+                'text': 'instance.models.server    | server={server_id} ({server_name}) |'
+                        ' Transition from "Pending" to "Failed"'
             },
         ]
         self.check_log_list(
             expected_list, response.data['log_entries'],
-            inst_id=instance.ref.id, as_id=app_server.pk, server_name=server.name,
+            inst_id=instance.ref.id, as_id=app_server.pk, server_id=server.pk, server_name=server.name,
         )
 
     def check_log_list(self, expected_list, log_list, **kwargs):
@@ -297,15 +302,17 @@ class OpenEdXAppServerAPITestCase(APITestCase):
             },
             {
                 'level': 'ERROR',
-                'text': 'instance.models.server    | server={server_name} | error',
-            },
-            {
-                'level': 'ERROR',
-                'text': 'instance.models.server    | server={server_name} |'
+                'text': 'instance.models.server    | server={server_id} ({server_name}) |'
                         ' Failed to start server: Not found (HTTP 404)'
             },
+            {
+                'level': 'INFO',
+                'text': 'instance.models.server    | server={server_id} ({server_name}) |'
+                        ' Transition from "Pending" to "Failed"'
+            },
         ]
+
         self.check_log_list(
             expected_list, response.data['log_error_entries'],
-            inst_id=instance.ref.id, as_id=app_server.pk, server_name=server.name,
+            inst_id=instance.ref.id, as_id=app_server.pk, server_id=server.pk, server_name=server.name,
         )

--- a/instance/tests/api/test_openedx_appserver.py
+++ b/instance/tests/api/test_openedx_appserver.py
@@ -26,11 +26,12 @@ from unittest.mock import patch
 
 import ddt
 from rest_framework import status
+from django.conf import settings
 
 from instance.tests.api.base import APITestCase
 from instance.tests.models.factories.openedx_appserver import make_test_appserver
 from instance.tests.models.factories.openedx_instance import OpenEdXInstanceFactory
-from instance.tests.utils import patch_gandi
+from instance.tests.utils import patch_gandi, patch_url
 
 
 # Tests #######################################################################
@@ -111,6 +112,7 @@ class OpenEdXAppServerAPITestCase(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
         self.assertEqual(response.data, {'detail': message})
 
+    @patch_url(settings.OPENSTACK_AUTH_URL)
     def test_get_details(self):
         """
         GET - Detailed attributes - instance manager allowed access
@@ -200,6 +202,7 @@ class OpenEdXAppServerAPITestCase(APITestCase):
         instance.refresh_from_db()
         self.assertEqual(instance.active_appserver, app_server)
 
+    @patch_url(settings.OPENSTACK_AUTH_URL)
     def test_get_log_entries(self):
         """
         GET - Log entries
@@ -267,6 +270,7 @@ class OpenEdXAppServerAPITestCase(APITestCase):
             text = expected_entry['text'].format(**kwargs)
             self.assertEqual(text, log_entry['text'])
 
+    @patch_url(settings.OPENSTACK_AUTH_URL)
     def test_get_log_error_entries(self):
         """
         GET - Log error entries

--- a/instance/tests/models/test_log_entry.py
+++ b/instance/tests/models/test_log_entry.py
@@ -65,7 +65,7 @@ class LoggingTestCase(TestCase):
                 self.instance.ref.pk, self.app_server.pk
             )
         )
-        self.server_prefix = 'instance.models.server    | server=test-vm-name | '
+        self.server_prefix = 'instance.models.server    | server={} (test-vm-name) | '.format(self.app_server.server.pk)
 
     def check_log_entries(self, entries, expected):
         """
@@ -150,8 +150,8 @@ class LoggingTestCase(TestCase):
             'log_entry': {
                 'created': '2015-09-21T21:07:01Z',
                 'level': 'INFO',
-                'text': ('instance.models.server    | server=test-vm-name | Text the client '
-                         'should also see, with unicode «ταБЬℓσ»'),
+                'text': ('instance.models.server    | server={} (test-vm-name) | Text the client '
+                         'should also see, with unicode «ταБЬℓσ»'.format(self.server.pk)),
             },
             'type': 'object_log_line',
             'server_id': self.server.pk,
@@ -224,7 +224,8 @@ class LoggingTestCase(TestCase):
         log_entry = LogEntry.objects.order_by('-pk')[0]
         self.assertEqual(
             str(log_entry),
-            '2015-10-20 20:10:15 |     INFO | instance.models.server    | server=test-vm-name | ' + msg,
+            '2015-10-20 20:10:15 |     INFO | instance.models.server    | server={} ({}) | {}'.format(
+                self.server.pk, self.server.name, msg)
         )
 
     def test_invalid_content_type_object_id_combo(self):

--- a/instance/tests/utils.py
+++ b/instance/tests/utils.py
@@ -24,6 +24,8 @@ Test utils
 
 from contextlib import ExitStack
 from unittest.mock import Mock, patch
+import requests
+import responses
 
 from instance import gandi
 from instance.tests.fake_gandi_client import FakeGandiClient
@@ -40,6 +42,39 @@ def patch_gandi(func=None):
     if func:
         return patcher(func)
     return patcher
+
+
+def patch_url(url, method=responses.GET, status=requests.codes.ok):
+    """
+    Decorator which mocks responses from the given url.
+
+    Arguments:
+
+    * `url`: http url to mock
+    * `method`: http method used in request (default responses.GET)
+    * `status`: http status returned by response (default requests.codes.ok)
+
+    Usage:
+
+    E.g., to mock POST requests to the OpenStack authentication URL:
+
+        import responses
+        from django.conf import settings
+        from instance.tests.utils import patch_url
+
+        @patch_url(settings.OPENSTACK_AUTH_URL, method=responses.POST)
+        def test_that_calls_nova(...):
+            ...
+    """
+    def function_wrapper(func):
+        def responses_wrapper(*args, **kwargs):
+            responses.add(
+                method=method,
+                url=url,
+                status=status,
+            )
+        return responses_wrapper(func)
+    return function_wrapper
 
 
 def patch_services(func):

--- a/instance/tests/utils.py
+++ b/instance/tests/utils.py
@@ -131,6 +131,12 @@ def patch_services(func):
                 mock_load_balancer_run_playbook=stack_patch(
                     'instance.models.load_balancer.LoadBalancingServer.run_playbook'
                 ),
+                mock_enable_monitoring=stack_patch(
+                    'instance.models.mixins.openedx_monitoring.OpenEdXMonitoringMixin.enable_monitoring'
+                ),
+                mock_disable_monitoring=stack_patch(
+                    'instance.models.mixins.openedx_monitoring.OpenEdXMonitoringMixin.disable_monitoring'
+                ),
             )
             stack.enter_context(patch_gandi())
             return func(self, mocks, *args, **kwargs)


### PR DESCRIPTION
Adds `instance.auto_deprovision_monitoring`, and uses it to decide whether to disable New Relic monitoring when terminating an active appserver.

Also improves logging to help diagnose major server events:
* Adds the server ID to all server log messages
* Logs all state transitions
* Logs automated task events `terminate_obsolete_appservers_all_instances` and `shut_down_obsolete_pr_sandboxes`.

**Testing instructions**:

1. Run migrations for this branch in your devstack.
1. Create a new instance.  Ensure that the instance's `auto_deprovision_monitoring` flag is set to True by default.
1. Provision a new appserver for that instance.  
1. Ensure that one of the following messages is logged:
    * "Skipping monitoring setup," if you don't have a valid `NEWRELIC_ADMIN_USER_API_KEY` key configured.
    * "Setting up New Relic Synthetics monitors," otherwise.
1. Activate the new appserver, and then then terminate it.  Ensure that the following message is logged on termination: "Removing New Relic Synthetics monitors".
1. Unset the `auto_deprovision_monitoring` flag, and provision a new appserver for that instance.
1. Activate the new appserver, and then terminate it.  Ensure that you do _not_ see the following message logged during termination: "Removing New Relic Synthetics monitors".  Note that if you have a valid `NEWRELIC_ADMIN_USER_API_KEY` key set, your configured monitors will be failing, and sending messages to ops@opencraft.com.

**Author notes and concerns**:

1. Log message changes are tested in unit tests.
1. We wanted to also log the currently logged-in user for important events, like terminating an appserver.  However, currently, we can only terminate an appserver from the shell or via a Huey task, when there's no username available to log.

**Reviewers**
- [ ] @bradenmacdonald 