### PR TITLE
Adds the programs database and ansible template vars

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -32,4 +32,5 @@ test:
         timeout: 1800
         parallel: true
   post:
-    - make test_integration_cleanup
+    - make test_integration_cleanup:
+        timeout: 1200

--- a/instance/models/mixins/openedx_database.py
+++ b/instance/models/mixins/openedx_database.py
@@ -99,6 +99,10 @@ class OpenEdXDatabaseMixin(MySQLInstanceMixin, MongoDBInstanceMixin, RabbitMQIns
                     }
                 ],
             },
+            {
+                "name": self._get_mysql_database_name("programs"),
+                "user": self._get_mysql_user_name("program"),
+            },
         ]
 
     @property

--- a/instance/models/mixins/storage.py
+++ b/instance/models/mixins/storage.py
@@ -56,7 +56,7 @@ class SwiftContainerInstanceMixin(models.Model):
         """
         Create the Swift containers if necessary.
         """
-        if settings.SWIFT_ENABLE and not self.swift_provisioned:
+        if settings.SWIFT_ENABLE:
             for container_name in self.swift_container_names:
                 openstack_utils.create_swift_container(
                     container_name,

--- a/instance/templates/instance/ansible/mysql.yml
+++ b/instance/templates/instance/ansible/mysql.yml
@@ -49,6 +49,19 @@ EDX_NOTES_API_MYSQL_DB_USER: '{{ edx_notes_api_user }}'
 EDX_NOTES_API_MYSQL_DB_PASS: '{{ edx_notes_api_pass }}'
 EDX_NOTES_API_MYSQL_HOST: '{{ host }}'
 
+# programs
+PROGRAMS_DEFAULT_DB_NAME: '{{ programs_database }}'
+PROGRAMS_DATABASES:
+  default:
+    ENGINE: 'django.db.backends.mysql'
+    NAME: '{{ programs_database }}'
+    USER: '{{ programs_user }}'
+    PASSWORD: '{{ programs_pass }}'
+    HOST: '{{ host }}'
+    PORT: {{ port }}
+    ATOMIC_REQUESTS: true
+    CONN_MAX_AGE: 60
+
 # analytics_api
 ANALYTICS_API_DEFAULT_DB_NAME: '{{ analytics_api_database }}'
 ANALYTICS_API_REPORTS_DB_NAME: '{{ reports_database }}'

--- a/instance/tests/models/test_openedx_database_mixins.py
+++ b/instance/tests/models/test_openedx_database_mixins.py
@@ -337,6 +337,13 @@ class MySQLInstanceTestCase(TestCase):
                     "CONN_MAX_AGE": 60,
                 }}]
             ),
+            "PROGRAMS_": make_nested_group_info(
+                ["DEFAULT_DB_NAME", "DATABASES"],
+                [{"name": "programs", "user": "program", "additional_settings": {
+                    "ATOMIC_REQUESTS": True,
+                    "CONN_MAX_AGE": 60,
+                }}]
+            ),
             "INSIGHTS_": make_nested_group_info(
                 ["DATABASE_NAME", "DATABASES"],
                 [{"name": "dashboard", "user": "dashboard"}]

--- a/instance/tests/models/test_openedx_storage_mixins.py
+++ b/instance/tests/models/test_openedx_storage_mixins.py
@@ -128,8 +128,8 @@ class SwiftContainerInstanceTestCase(TestCase):
         instance.provision_swift()
         self.check_swift(instance, create_swift_container)
 
-        # Provision again without resetting the mock.  The assertCountEqual assertion will verify
-        # that the container isn't provisioned again.
+        # Reset the mock, and provision again.  The container is technically reprovisioned, but this is a no-op.
+        create_swift_container.reset_mock()
         instance.provision_swift()
         self.check_swift(instance, create_swift_container)
 


### PR DESCRIPTION
The `programs` app has been added to `open-release/ficus.master`'s [`edx_sandbox.yml`](https://github.com/edx/configuration/blob/open-release/ficus.master/playbooks/edx_sandbox.yml#L49).  To support this role, we need to add the programs database and user, and set the corresponding ansible variables.

**Testing instructions**:

1. Create a new instance with settings similar to [ficus-xenial AppServer 7](https://console.opencraft.com/instance/2420/edx-appserver/782/):

    ```
    configuration_source_repo_url:	https://github.com/open-craft/configuration 
    configuration_version:	jill/ficus.master
    edx_platform_repository_url:	https://github.com/open-craft/edx-platform
    edx_platform_commit:	jill/ficus.master
    openedx_release:	open-release/ficus.master

    configuration_extra_settings: |	
      # configuration PR ##3522 changes openstack role variables
      COMMON_ENABLE_OPENSTACK_INTEGRATION: true
      COMMON_SWIFT_LOG_SYNC: true

      # Have to specify settings as openstack, not aws
      COMMON_EDXAPP_SETTINGS: 'openstack'
    ```
    Note that AppServer 7 failed to provision due to an error in `TASK [programs : migrate]`.
1. Spawn an appserver.  Provisioning should succeed beyond the `[programs]` role.
1. Spawn a second appserver, and ensure that the 3 "Provisioning" steps runs (again) without error.

**Author notes and concerns**:

1. The `programs` role has not yet been added to [`edx-stateless.yml`](https://github.com/edx/configuration/blob/open-release/ficus.master/playbooks/edx-stateless.yml), but since our clients might want the role, it's worth adding support for it into OCIM.

**Reviewers**
- [ ] @mtyaka