### PR TITLE
Make prospector play well with pylint again

### DIFF
--- a/.prospector/opencraft.yml
+++ b/.prospector/opencraft.yml
@@ -1,4 +1,4 @@
-autodetect: true
+autodetect: false
 doc-warnings: false
 dodgy:
   disable: []

--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ upgrade_dependencies:
 # Tests #######################################################################
 
 test_prospector: clean
-	prospector --profile opencraft
+	prospector --profile opencraft --uses django
 
 test_unit: clean static_external
 	honcho -e .env.test run coverage run --source='.' --omit='*/tests/*' ./manage.py test --noinput

--- a/email_verification/tests/test_views.py
+++ b/email_verification/tests/test_views.py
@@ -38,7 +38,7 @@ class VerifyEmailTestCase(TestCase):
     Tests for the verify_email view.
     """
     def setUp(self):
-        self.user = User.objects.create(username='ThePurpleOne') #pylint: disable=no-member
+        self.user = User.objects.create(username='ThePurpleOne')
         self.email = EmailAddress.objects.create_unconfirmed(
             email='raspberryberet@example.com',
             user=self.user,

--- a/instance/factories.py
+++ b/instance/factories.py
@@ -46,13 +46,13 @@ def _check_environment():
     if not settings.SWIFT_ENABLE:
         logger.warning("Swift support is currently disabled. Adjust SWIFT_ENABLE setting.")
         return
-    if not MySQLServer.objects.exists() and settings.DEFAULT_INSTANCE_MYSQL_URL is None:  # pylint: disable=no-member
+    if not MySQLServer.objects.exists() and settings.DEFAULT_INSTANCE_MYSQL_URL is None:
         logger.warning(
             "No MySQL servers configured, and default URL for external MySQL database is missing."
             "Create at least one MySQLServer, or set DEFAULT_INSTANCE_MYSQL_URL in your .env."
         )
         return
-    if not MongoDBServer.objects.exists() and settings.DEFAULT_INSTANCE_MONGO_URL is None:  # pylint: disable=no-member
+    if not MongoDBServer.objects.exists() and settings.DEFAULT_INSTANCE_MONGO_URL is None:
         logger.warning(
             "No MongoDB servers configured, and default URL for external MongoDB database is missing."
             "Create at least one MongoDBServer, or set DEFAULT_INSTANCE_MONGO_URL in your .env."

--- a/instance/management/commands/activity_csv.py
+++ b/instance/management/commands/activity_csv.py
@@ -63,7 +63,7 @@ class Command(BaseCommand):
             try:
                 out = open(options['out'], 'w')
             except PermissionError:
-                self.stderr.write(self.style.ERROR(  # pylint: disable=no-member
+                self.stderr.write(self.style.ERROR(
                     'Permission denied while attempting to write file: {outfile}'.format(outfile=options['out'])
                 ))
                 sys.exit(1)
@@ -79,11 +79,11 @@ class Command(BaseCommand):
 
         if not active_appservers:
             self.stderr.write(
-                self.style.SUCCESS('There are no active app servers! Nothing to do.')  # pylint: disable=no-member
+                self.style.SUCCESS('There are no active app servers! Nothing to do.')
             )
             sys.exit(0)
 
-        self.stderr.write(self.style.SUCCESS('Running playbook...'))  # pylint: disable=no-member
+        self.stderr.write(self.style.SUCCESS('Running playbook...'))
 
         with ansible.create_temp_dir() as playbook_output_dir:
             inventory = '[apps]\n{servers}'.format(servers='\n'.join(active_appservers.keys()))
@@ -91,7 +91,7 @@ class Command(BaseCommand):
 
             def log_line(line):
                 """Helper to pass to capture_playbook_output()."""
-                self.stderr.write(self.style.SUCCESS(line))  # pylint: disable=no-member
+                self.stderr.write(self.style.SUCCESS(line))
             log_line.info = log_line
             log_line.error = log_line
 
@@ -140,4 +140,4 @@ class Command(BaseCommand):
                     instance_age.days
                 ])
 
-            self.stderr.write(self.style.SUCCESS('Done generating CSV output.'))  # pylint: disable=no-member
+            self.stderr.write(self.style.SUCCESS('Done generating CSV output.'))

--- a/instance/models/database_server.py
+++ b/instance/models/database_server.py
@@ -56,7 +56,7 @@ class DatabaseServerManager(models.Manager):
         """
         Create the default database server configured in the Django settings, if any.
         """
-        database_server_url = getattr(settings, self.model.DEFAULT_SETTINGS_NAME, None)  # pylint: disable=no-member
+        database_server_url = getattr(settings, self.model.DEFAULT_SETTINGS_NAME, None)
         if database_server_url:
             database_server_url_obj = urlparse(database_server_url)
             hostname, username, password, port = (
@@ -68,11 +68,11 @@ class DatabaseServerManager(models.Manager):
             if not hostname:
                 raise ImproperlyConfigured(
                     "{setting_name} must specify at least host name of database server.".format(
-                        setting_name=self.model.DEFAULT_SETTINGS_NAME  # pylint: disable=no-member
+                        setting_name=self.model.DEFAULT_SETTINGS_NAME
                     )
                 )
             logger.info("Creating DatabaseServer %s", hostname)
-            database_server, created = self.get_or_create(  # pylint: disable=no-member
+            database_server, created = self.get_or_create(
                 hostname=hostname,
                 defaults=dict(
                     name=hostname,
@@ -103,10 +103,10 @@ class DatabaseServerManager(models.Manager):
         # The set of servers might change between retrieving the server count and retrieving the random server,
         # so we make this atomic.
         with transaction.atomic():
-            servers = self.filter(accepts_new_clients=True)  # pylint: disable=no-member
+            servers = self.filter(accepts_new_clients=True)
             count = servers.count()
             if not count:
-                raise self.model.DoesNotExist(  # pylint: disable=no-member
+                raise self.model.DoesNotExist(
                     "No configured DatabaseServer accepts new clients."
                 )
             return servers[random.randrange(count)]

--- a/instance/models/instance.py
+++ b/instance/models/instance.py
@@ -132,7 +132,7 @@ class Instance(ValidateModelMixin, models.Model):
     def ref(self):
         """ Get the InstanceReference for this Instance """
         try:
-            return self.ref_set.get()  # pylint: disable=no-member
+            return self.ref_set.get()
         except ObjectDoesNotExist:
             return InstanceReference(instance=self)
 

--- a/instance/models/instance.py
+++ b/instance/models/instance.py
@@ -77,7 +77,7 @@ class InstanceReference(TimeStampedModel):
         """
         if not kwargs.pop('instance_already_deleted', False):
             self.instance.delete(ref_already_deleted=True)
-        super().delete(*args, **kwargs)  # pylint: disable=no-member
+        super().delete(*args, **kwargs)
 
     def save(self, *args, **kwargs):
         """
@@ -164,7 +164,6 @@ class Instance(ValidateModelMixin, models.Model):
             self.ref.instance_id = self.pk  # <- Fix needed when self.ref is accessed before the first self.save()
         self.ref.save()
 
-    # pylint: disable=no-member
     def refresh_from_db(self, using=None, fields=None, **kwargs):
         """
         Reload from DB, or load related field.

--- a/instance/models/load_balancer.py
+++ b/instance/models/load_balancer.py
@@ -53,7 +53,7 @@ class LoadBalancingServerManager(models.Manager):
                     "DEFAULT_LOAD_BALANCING_SERVER must have the form ssh_username@domain.name."
                 )
             logger.info("Creating LoadBalancingServer %s", domain)
-            server, created = self.get_or_create(  # pylint: disable=no-member
+            server, created = self.get_or_create(
                 domain=domain,
                 defaults=dict(ssh_username=ssh_username),
             )
@@ -77,10 +77,10 @@ class LoadBalancingServerManager(models.Manager):
         # The set of servers might change between retrieving the server count and retrieving the random
         # server, so we make this atomic.
         with transaction.atomic():
-            servers = self.filter(accepts_new_backends=True)  # pylint: disable=no-member
+            servers = self.filter(accepts_new_backends=True)
             count = servers.count()
             if not count:
-                raise self.model.DoesNotExist(  # pylint: disable=no-member
+                raise self.model.DoesNotExist(
                     "No configured LoadBalancingServer accepts new backends."
                 )
             return servers[random.randrange(count)]
@@ -230,4 +230,4 @@ class LoadBalancingServer(ValidateModelMixin, TimeStampedModel):
         Delete the LoadBalancingServer from the database.
         """
         self.deconfigure()
-        super().delete(*args, **kwargs)  # pylint: disable=no-member
+        super().delete(*args, **kwargs)

--- a/instance/models/mixins/database.py
+++ b/instance/models/mixins/database.py
@@ -23,11 +23,11 @@ Instance app model mixins - Database
 # Imports #####################################################################
 
 import inspect
+import warnings
 
 from django.db import models
 import MySQLdb as mysql
 import pymongo
-import warnings
 
 from instance.models.database_server import MySQLServer, MongoDBServer
 

--- a/instance/models/mixins/openedx_database.py
+++ b/instance/models/mixins/openedx_database.py
@@ -36,6 +36,7 @@ from instance.models.rabbitmq import RabbitMQUser
 
 # Classes #####################################################################
 
+# pylint: disable=too-many-instance-attributes
 class OpenEdXDatabaseMixin(MySQLInstanceMixin, MongoDBInstanceMixin, RabbitMQInstanceMixin):
     """
     Mixin that provides functionality required for the database backends that an

--- a/instance/models/mixins/openedx_monitoring.py
+++ b/instance/models/mixins/openedx_monitoring.py
@@ -85,7 +85,7 @@ class NewRelicAvailabilityMonitor(models.Model):
     """
     A New Relic Synthetics availability monitor for an instance.
     """
-    id = models.CharField(max_length=256, primary_key=True)
+    id = models.CharField(max_length=256, primary_key=True)  # pylint: disable=invalid-name
     instance = models.ForeignKey(
         'OpenEdXInstance', related_name='new_relic_availability_monitors', on_delete=models.CASCADE
     )
@@ -98,4 +98,4 @@ class NewRelicAvailabilityMonitor(models.Model):
         Disable this availability monitor on delete.
         """
         newrelic.delete_synthetics_monitor(self.pk)
-        super().delete(*args, **kwargs)  # pylint: disable=no-member
+        super().delete(*args, **kwargs)

--- a/instance/models/mixins/rabbitmq.py
+++ b/instance/models/mixins/rabbitmq.py
@@ -23,8 +23,8 @@ Instance app model mixins - RabbitMQ
 # Imports #####################################################################
 
 import json
-import requests
 import urllib.parse
+import requests
 
 from django.conf import settings
 from django.db import models

--- a/instance/models/mixins/secret_keys.py
+++ b/instance/models/mixins/secret_keys.py
@@ -28,7 +28,6 @@ import hmac
 from base64 import b64encode, b64decode
 
 from django.db import models
-from django.template import loader
 import yaml
 
 # Functions ###################################################################

--- a/instance/models/openedx_appserver.py
+++ b/instance/models/openedx_appserver.py
@@ -190,7 +190,7 @@ class OpenEdXAppServer(AppServer, OpenEdXAppConfiguration, AnsibleAppServerMixin
         """
         Add local Django users to the list of LMS users to be created on the instance.
         """
-        self.lms_users.add(*lms_users)  # pylint: disable=no-member
+        self.lms_users.add(*lms_users)
         self.lms_user_settings = self.create_lms_user_settings()
         self.save()
 
@@ -318,7 +318,7 @@ class OpenEdXAppServer(AppServer, OpenEdXAppConfiguration, AnsibleAppServerMixin
         by this code.
         """
         self.logger.info('Checking security groups (OpenStack firewall settings)')
-        network = get_openstack_connection().network  # pylint: disable=no-member
+        network = get_openstack_connection().network
         main_security_group = network.find_security_group(settings.OPENEDX_APPSERVER_SECURITY_GROUP_NAME)
         if not main_security_group:
             # We need to create this security group:

--- a/instance/models/openedx_appserver.py
+++ b/instance/models/openedx_appserver.py
@@ -318,7 +318,7 @@ class OpenEdXAppServer(AppServer, OpenEdXAppConfiguration, AnsibleAppServerMixin
         by this code.
         """
         self.logger.info('Checking security groups (OpenStack firewall settings)')
-        network = get_openstack_connection().network
+        network = get_openstack_connection().network  # pylint: disable=no-member
         main_security_group = network.find_security_group(settings.OPENEDX_APPSERVER_SECURITY_GROUP_NAME)
         if not main_security_group:
             # We need to create this security group:

--- a/instance/models/utils.py
+++ b/instance/models/utils.py
@@ -319,8 +319,12 @@ class ResourceStateDescriptor:
                 raise WrongStateException("This transition cannot be used to move from {} to {}".format(
                     current_state.name, to_state.name  # pylint: disable=no-member
                 ))
-            if (hasattr(resource, 'logger')):
-                resource.logger.info('Transition from "%s" to "%s"', current_state.name, to_state.name)
+            if hasattr(resource, 'logger'):
+                resource.logger.info(
+                    'Transition from "%s" to "%s"',
+                    current_state.name,  # pylint: disable=no-member
+                    to_state.name
+                )
             self._set_state(resource, to_state)
         do_transition.from_states = from_states  # Convenient way for other code to inspect this transition
         do_transition.to_state = to_state  # Convenient way for other code to inspect this transition

--- a/instance/models/utils.py
+++ b/instance/models/utils.py
@@ -101,7 +101,7 @@ class ClassProperty(property):
     def __get__(self, cls, owner):
         # TODO: Requires astroid 2.0+ to pass pylint
         # https://bitbucket.org/logilab/pylint/issues/439/confused-by-descriptors
-        return self.fget.__get__(None, owner)()  # pylint: disable=no-member
+        return self.fget.__get__(None, owner)()
 
 
 class ResourceState:
@@ -273,9 +273,8 @@ class ResourceStateDescriptor:
                 """
                 state = self.__get__(resource)
                 if not isinstance(state, accepted_states):
-                    #TODO: why is no-member disabled?
                     raise WrongStateException("The method '{}' cannot be called in this state ({} / {}).".format(
-                        method.__name__, state.name, state.__class__.__name__  # pylint: disable=no-member
+                        method.__name__, state.name, state.__class__.__name__
                     ))
 
             descriptor = self
@@ -315,16 +314,11 @@ class ResourceStateDescriptor:
             """ The method that performs a specific transition """
             current_state = self.__get__(resource)
             if from_states and not isinstance(current_state, from_states):
-                #TODO: why is no-member disabled?
                 raise WrongStateException("This transition cannot be used to move from {} to {}".format(
-                    current_state.name, to_state.name  # pylint: disable=no-member
+                    current_state.name, to_state.name
                 ))
             if hasattr(resource, 'logger'):
-                resource.logger.info(
-                    'Transition from "%s" to "%s"',
-                    current_state.name,  # pylint: disable=no-member
-                    to_state.name
-                )
+                resource.logger.info('Transition from "%s" to "%s"', current_state.name, to_state.name)
             self._set_state(resource, to_state)
         do_transition.from_states = from_states  # Convenient way for other code to inspect this transition
         do_transition.to_state = to_state  # Convenient way for other code to inspect this transition

--- a/instance/newrelic.py
+++ b/instance/newrelic.py
@@ -97,7 +97,7 @@ def delete_synthetics_monitor(monitor_id):
         r = requests.delete(url, headers=_request_headers())
         r.raise_for_status()
     except requests.exceptions.HTTPError:
-        if r.status_code == requests.codes.not_found:  # pylint: disable=no-member
+        if r.status_code == requests.codes.not_found:
             logger.info('Monitor for %s has already been deleted. Proceeding.')
         else:
             raise

--- a/instance/openstack_utils.py
+++ b/instance/openstack_utils.py
@@ -97,7 +97,7 @@ def sync_security_group_rules(security_group, rule_definitions, network=None):
     group until it matches 'rules'.
     """
     assert all(isinstance(rule, SecurityGroupRuleDefinition) for rule in rule_definitions)
-    network = network or get_openstack_connection().network
+    network = network or get_openstack_connection().network  # pylint: disable=no-member
     rule_definitions_set = set(rule_definitions)
 
     existing_rules = network.security_group_rules(security_group_id=security_group.id)

--- a/instance/openstack_utils.py
+++ b/instance/openstack_utils.py
@@ -97,7 +97,7 @@ def sync_security_group_rules(security_group, rule_definitions, network=None):
     group until it matches 'rules'.
     """
     assert all(isinstance(rule, SecurityGroupRuleDefinition) for rule in rule_definitions)
-    network = network or get_openstack_connection().network  # pylint: disable=no-member
+    network = network or get_openstack_connection().network
     rule_definitions_set = set(rule_definitions)
 
     existing_rules = network.security_group_rules(security_group_id=security_group.id)

--- a/instance/tests/api/test_instance.py
+++ b/instance/tests/api/test_instance.py
@@ -45,10 +45,7 @@ class InstanceAPITestCase(APITestCase):
         """
         response = self.api_client.get('/api/v1/instance/')
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
-        self.assertEqual(
-            response.data,  # pylint: disable=no-member
-            {"detail": "Authentication credentials were not provided."}
-        )
+        self.assertEqual(response.data, {"detail": "Authentication credentials were not provided."})
 
     @ddt.data(
         'user1', 'user2',
@@ -60,10 +57,7 @@ class InstanceAPITestCase(APITestCase):
         self.api_client.login(username=username, password='pass')
         response = self.api_client.get('/api/v1/instance/')
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
-        self.assertEqual(
-            response.data,  # pylint: disable=no-member
-            {"detail": "You do not have permission to perform this action."}
-        )
+        self.assertEqual(response.data, {"detail": "You do not have permission to perform this action."})
 
     def test_get_authenticated(self):
         """
@@ -72,12 +66,12 @@ class InstanceAPITestCase(APITestCase):
         self.api_client.login(username='user3', password='pass')
         response = self.api_client.get('/api/v1/instance/')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.data, [])  # pylint: disable=no-member
+        self.assertEqual(response.data, [])
 
         instance = OpenEdXInstanceFactory()
         response = self.api_client.get('/api/v1/instance/')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.check_serialized_instance(response.data[0], instance)  # pylint: disable=no-member
+        self.check_serialized_instance(response.data[0], instance)
 
     @ddt.data(
         (None, 'Authentication credentials were not provided.'),
@@ -94,7 +88,7 @@ class InstanceAPITestCase(APITestCase):
         instance = OpenEdXInstanceFactory(sub_domain='domain.api')
         response = self.api_client.get('/api/v1/instance/{pk}/'.format(pk=instance.ref.pk))
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
-        self.assertEqual(response.data, {'detail': message})  # pylint: disable=no-member
+        self.assertEqual(response.data, {'detail': message})
 
     def check_serialized_instance(self, data, instance):
         """
@@ -115,7 +109,7 @@ class InstanceAPITestCase(APITestCase):
         instance = OpenEdXInstanceFactory(sub_domain='domain.api')
         response = self.api_client.get('/api/v1/instance/{pk}/'.format(pk=instance.ref.pk))
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.check_serialized_instance(response.data, instance)  # pylint: disable=no-member
+        self.check_serialized_instance(response.data, instance)
 
     def test_get_log_entries(self):
         """
@@ -133,7 +127,7 @@ class InstanceAPITestCase(APITestCase):
             {'level': 'INFO', 'text': 'instance.models.instance  | instance={inst_id} (Test!) | info'},
             {'level': 'ERROR', 'text': 'instance.models.instance  | instance={inst_id} (Test!) | error'},
         ]
-        log_entries = response.data['log_entries']  # pylint: disable=no-member
+        log_entries = response.data['log_entries']
         self.assertEqual(len(expected_list), len(log_entries))
 
         for expected_entry, log_entry in zip(expected_list, log_entries):

--- a/instance/tests/api/test_instance.py
+++ b/instance/tests/api/test_instance.py
@@ -45,7 +45,10 @@ class InstanceAPITestCase(APITestCase):
         """
         response = self.api_client.get('/api/v1/instance/')
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
-        self.assertEqual(response.data, {"detail": "Authentication credentials were not provided."})
+        self.assertEqual(
+            response.data,  # pylint: disable=no-member
+            {"detail": "Authentication credentials were not provided."}
+        )
 
     @ddt.data(
         'user1', 'user2',
@@ -57,7 +60,10 @@ class InstanceAPITestCase(APITestCase):
         self.api_client.login(username=username, password='pass')
         response = self.api_client.get('/api/v1/instance/')
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
-        self.assertEqual(response.data, {"detail": "You do not have permission to perform this action."})
+        self.assertEqual(
+            response.data,  # pylint: disable=no-member
+            {"detail": "You do not have permission to perform this action."}
+        )
 
     def test_get_authenticated(self):
         """
@@ -66,12 +72,12 @@ class InstanceAPITestCase(APITestCase):
         self.api_client.login(username='user3', password='pass')
         response = self.api_client.get('/api/v1/instance/')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.data, [])
+        self.assertEqual(response.data, [])  # pylint: disable=no-member
 
         instance = OpenEdXInstanceFactory()
         response = self.api_client.get('/api/v1/instance/')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.check_serialized_instance(response.data[0], instance)
+        self.check_serialized_instance(response.data[0], instance)  # pylint: disable=no-member
 
     @ddt.data(
         (None, 'Authentication credentials were not provided.'),
@@ -88,7 +94,7 @@ class InstanceAPITestCase(APITestCase):
         instance = OpenEdXInstanceFactory(sub_domain='domain.api')
         response = self.api_client.get('/api/v1/instance/{pk}/'.format(pk=instance.ref.pk))
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
-        self.assertEqual(response.data, {'detail': message})
+        self.assertEqual(response.data, {'detail': message})  # pylint: disable=no-member
 
     def check_serialized_instance(self, data, instance):
         """
@@ -109,7 +115,7 @@ class InstanceAPITestCase(APITestCase):
         instance = OpenEdXInstanceFactory(sub_domain='domain.api')
         response = self.api_client.get('/api/v1/instance/{pk}/'.format(pk=instance.ref.pk))
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.check_serialized_instance(response.data, instance)
+        self.check_serialized_instance(response.data, instance)  # pylint: disable=no-member
 
     def test_get_log_entries(self):
         """
@@ -127,8 +133,9 @@ class InstanceAPITestCase(APITestCase):
             {'level': 'INFO', 'text': 'instance.models.instance  | instance={inst_id} (Test!) | info'},
             {'level': 'ERROR', 'text': 'instance.models.instance  | instance={inst_id} (Test!) | error'},
         ]
-        self.assertEqual(len(expected_list), len(response.data['log_entries']))
+        log_entries = response.data['log_entries']  # pylint: disable=no-member
+        self.assertEqual(len(expected_list), len(log_entries))
 
-        for expected_entry, log_entry in zip(expected_list, response.data['log_entries']):
+        for expected_entry, log_entry in zip(expected_list, log_entries):
             self.assertEqual(expected_entry['level'], log_entry['level'])
             self.assertEqual(expected_entry['text'].format(inst_id=instance.ref.pk), log_entry['text'])

--- a/instance/tests/api/test_openedx_appserver.py
+++ b/instance/tests/api/test_openedx_appserver.py
@@ -47,10 +47,7 @@ class OpenEdXAppServerAPITestCase(APITestCase):
         """
         response = self.api_client.get('/api/v1/openedx_appserver/')
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
-        self.assertEqual(
-            response.data,  # pylint: disable=no-member
-            {"detail": "Authentication credentials were not provided."}
-        )
+        self.assertEqual(response.data, {"detail": "Authentication credentials were not provided."})
 
     @ddt.data(
         'user1', 'user2',
@@ -62,10 +59,7 @@ class OpenEdXAppServerAPITestCase(APITestCase):
         self.api_client.login(username=username, password='pass')
         response = self.api_client.get('/api/v1/openedx_appserver/')
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
-        self.assertEqual(
-            response.data,  # pylint: disable=no-member
-            {"detail": "You do not have permission to perform this action."}
-        )
+        self.assertEqual(response.data, {"detail": "You do not have permission to perform this action."})
 
     def test_get_authenticated(self):
         """
@@ -74,13 +68,13 @@ class OpenEdXAppServerAPITestCase(APITestCase):
         self.api_client.login(username='user3', password='pass')
         response = self.api_client.get('/api/v1/openedx_appserver/')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.data, [])  # pylint: disable=no-member
+        self.assertEqual(response.data, [])
 
         app_server = make_test_appserver()
         response = self.api_client.get('/api/v1/openedx_appserver/')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-        data = response.data[0]  # pylint: disable=no-member
+        data = response.data[0]
         data_entries = data.items()
         self.assertIn(('id', app_server.pk), data_entries)
         self.assertIn(
@@ -120,7 +114,7 @@ class OpenEdXAppServerAPITestCase(APITestCase):
         app_server = make_test_appserver()
         response = self.api_client.get('/api/v1/openedx_appserver/{pk}/'.format(pk=app_server.pk))
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
-        self.assertEqual(response.data, {'detail': message})  # pylint: disable=no-member
+        self.assertEqual(response.data, {'detail': message})
 
     @patch_url(settings.OPENSTACK_AUTH_URL)
     def test_get_details(self):
@@ -132,7 +126,7 @@ class OpenEdXAppServerAPITestCase(APITestCase):
         response = self.api_client.get('/api/v1/openedx_appserver/{pk}/'.format(pk=app_server.pk))
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-        data = response.data  # pylint: disable=no-member
+        data = response.data
         data_entries = data.items()
         self.assertIn(('id', app_server.pk), data_entries)
         self.assertIn(
@@ -156,7 +150,7 @@ class OpenEdXAppServerAPITestCase(APITestCase):
             data_entries
         )
         self.assertIn('server', data)
-        server_data = response.data['server'].items()  # pylint: disable=no-member
+        server_data = response.data['server'].items()
         self.assertIn(('id', app_server.server.pk), server_data)
         self.assertIn(('public_ip', None), server_data)
         # The API call will try to start the server, which will fail, since we're
@@ -182,7 +176,7 @@ class OpenEdXAppServerAPITestCase(APITestCase):
 
         response = self.api_client.post('/api/v1/openedx_appserver/', {'instance_id': instance.ref.pk})
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.data, {'status': 'Instance provisioning started'})  # pylint: disable=no-member
+        self.assertEqual(response.data, {'status': 'Instance provisioning started'})
         self.assertEqual(mock_provision.call_count, 1)
         instance.refresh_from_db()
 
@@ -210,7 +204,7 @@ class OpenEdXAppServerAPITestCase(APITestCase):
 
         response = self.api_client.post('/api/v1/openedx_appserver/{pk}/make_active/'.format(pk=app_server.pk))
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.data, {'status': 'App server activation initiated.'})  # pylint: disable=no-member
+        self.assertEqual(response.data, {'status': 'App server activation initiated.'})
         self.assertEqual(mock_run_playbook.call_count, 1)
 
         instance.refresh_from_db()
@@ -273,7 +267,7 @@ class OpenEdXAppServerAPITestCase(APITestCase):
             },
         ]
         self.check_log_list(
-            expected_list, response.data['log_entries'],  # pylint: disable=no-member
+            expected_list, response.data['log_entries'],
             inst_id=instance.ref.id, as_id=app_server.pk, server_id=server.pk, server_name=server.name,
         )
 
@@ -327,6 +321,6 @@ class OpenEdXAppServerAPITestCase(APITestCase):
         ]
 
         self.check_log_list(
-            expected_list, response.data['log_error_entries'],  # pylint: disable=no-member
+            expected_list, response.data['log_error_entries'],
             inst_id=instance.ref.id, as_id=app_server.pk, server_id=server.pk, server_name=server.name,
         )

--- a/instance/tests/api/test_openedx_appserver.py
+++ b/instance/tests/api/test_openedx_appserver.py
@@ -47,7 +47,10 @@ class OpenEdXAppServerAPITestCase(APITestCase):
         """
         response = self.api_client.get('/api/v1/openedx_appserver/')
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
-        self.assertEqual(response.data, {"detail": "Authentication credentials were not provided."})
+        self.assertEqual(
+            response.data,  # pylint: disable=no-member
+            {"detail": "Authentication credentials were not provided."}
+        )
 
     @ddt.data(
         'user1', 'user2',
@@ -59,7 +62,10 @@ class OpenEdXAppServerAPITestCase(APITestCase):
         self.api_client.login(username=username, password='pass')
         response = self.api_client.get('/api/v1/openedx_appserver/')
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
-        self.assertEqual(response.data, {"detail": "You do not have permission to perform this action."})
+        self.assertEqual(
+            response.data,  # pylint: disable=no-member
+            {"detail": "You do not have permission to perform this action."}
+        )
 
     def test_get_authenticated(self):
         """
@@ -68,32 +74,36 @@ class OpenEdXAppServerAPITestCase(APITestCase):
         self.api_client.login(username='user3', password='pass')
         response = self.api_client.get('/api/v1/openedx_appserver/')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.data, [])
+        self.assertEqual(response.data, [])  # pylint: disable=no-member
 
         app_server = make_test_appserver()
         response = self.api_client.get('/api/v1/openedx_appserver/')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-        data = response.data[0].items()
-        self.assertIn(('id', app_server.pk), data)
-        self.assertIn(('api_url', 'http://testserver/api/v1/openedx_appserver/{pk}/'.format(pk=app_server.pk)), data)
-        self.assertIn(('name', 'AppServer 1'), data)
+        data = response.data[0]  # pylint: disable=no-member
+        data_entries = data.items()
+        self.assertIn(('id', app_server.pk), data_entries)
+        self.assertIn(
+            ('api_url', 'http://testserver/api/v1/openedx_appserver/{pk}/'.format(pk=app_server.pk)),
+            data_entries
+        )
+        self.assertIn(('name', 'AppServer 1'), data_entries)
         # Status fields:
-        self.assertIn(('status', 'new'), data)
-        self.assertIn(('status_name', 'New'), data)
-        self.assertIn(('status_description', 'Newly created'), data)
-        self.assertIn(('is_steady', True), data)
-        self.assertIn(('is_healthy', True), data)
+        self.assertIn(('status', 'new'), data_entries)
+        self.assertIn(('status_name', 'New'), data_entries)
+        self.assertIn(('status_description', 'Newly created'), data_entries)
+        self.assertIn(('is_steady', True), data_entries)
+        self.assertIn(('is_healthy', True), data_entries)
         # Created/modified date:
-        self.assertIn('created', response.data[0])
-        self.assertIn('modified', response.data[0])
+        self.assertIn('created', data)
+        self.assertIn('modified', data)
         # Other details should not be in the list view:
-        self.assertNotIn('instance', response.data[0])
-        self.assertNotIn('server', response.data[0])
-        self.assertNotIn('configuration_settings', response.data[0])
-        self.assertNotIn('edx_platform_commit', response.data[0])
-        self.assertNotIn('log_entries', response.data[0])
-        self.assertNotIn('log_error_entries', response.data[0])
+        self.assertNotIn('instance', data)
+        self.assertNotIn('server', data)
+        self.assertNotIn('configuration_settings', data)
+        self.assertNotIn('edx_platform_commit', data)
+        self.assertNotIn('log_entries', data)
+        self.assertNotIn('log_error_entries', data)
 
     @ddt.data(
         (None, 'Authentication credentials were not provided.'),
@@ -110,7 +120,7 @@ class OpenEdXAppServerAPITestCase(APITestCase):
         app_server = make_test_appserver()
         response = self.api_client.get('/api/v1/openedx_appserver/{pk}/'.format(pk=app_server.pk))
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
-        self.assertEqual(response.data, {'detail': message})
+        self.assertEqual(response.data, {'detail': message})  # pylint: disable=no-member
 
     @patch_url(settings.OPENSTACK_AUTH_URL)
     def test_get_details(self):
@@ -122,34 +132,38 @@ class OpenEdXAppServerAPITestCase(APITestCase):
         response = self.api_client.get('/api/v1/openedx_appserver/{pk}/'.format(pk=app_server.pk))
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-        data = response.data.items()
-        self.assertIn(('id', app_server.pk), data)
-        self.assertIn(('api_url', 'http://testserver/api/v1/openedx_appserver/{pk}/'.format(pk=app_server.pk)), data)
-        self.assertIn(('name', 'AppServer 1'), data)
+        data = response.data  # pylint: disable=no-member
+        data_entries = data.items()
+        self.assertIn(('id', app_server.pk), data_entries)
+        self.assertIn(
+            ('api_url', 'http://testserver/api/v1/openedx_appserver/{pk}/'.format(pk=app_server.pk)),
+            data_entries
+        )
+        self.assertIn(('name', 'AppServer 1'), data_entries)
         # Status fields:
-        self.assertIn(('status', 'new'), data)
-        self.assertIn(('status_name', 'New'), data)
-        self.assertIn(('status_description', 'Newly created'), data)
-        self.assertIn(('is_steady', True), data)
-        self.assertIn(('is_healthy', True), data)
+        self.assertIn(('status', 'new'), data_entries)
+        self.assertIn(('status_name', 'New'), data_entries)
+        self.assertIn(('status_description', 'Newly created'), data_entries)
+        self.assertIn(('is_steady', True), data_entries)
+        self.assertIn(('is_healthy', True), data_entries)
         # Created/modified date:
-        self.assertIn('created', response.data)
-        self.assertIn('modified', response.data)
+        self.assertIn('created', data)
+        self.assertIn('modified', data)
         # Other details:
         instance_id = app_server.instance.ref.pk
         self.assertIn(
             ('instance', {'id': instance_id, 'api_url': 'http://testserver/api/v1/instance/{}/'.format(instance_id)}),
-            data
+            data_entries
         )
-        self.assertIn('server', response.data)
-        server_data = response.data['server'].items()
+        self.assertIn('server', data)
+        server_data = response.data['server'].items()  # pylint: disable=no-member
         self.assertIn(('id', app_server.server.pk), server_data)
         self.assertIn(('public_ip', None), server_data)
         # The API call will try to start the server, which will fail, since we're
         # not actually talking to an OpenStack instance when unit tests are running
         self.assertIn(('status', 'failed'), server_data)
-        self.assertIn('log_entries', response.data)
-        self.assertIn('log_error_entries', response.data)
+        self.assertIn('log_entries', data)
+        self.assertIn('log_error_entries', data)
 
     @patch_gandi
     @patch('instance.models.openedx_instance.OpenEdXAppServer.provision', return_value=True)
@@ -168,7 +182,7 @@ class OpenEdXAppServerAPITestCase(APITestCase):
 
         response = self.api_client.post('/api/v1/openedx_appserver/', {'instance_id': instance.ref.pk})
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.data, {'status': 'Instance provisioning started'})
+        self.assertEqual(response.data, {'status': 'Instance provisioning started'})  # pylint: disable=no-member
         self.assertEqual(mock_provision.call_count, 1)
         instance.refresh_from_db()
 
@@ -196,7 +210,7 @@ class OpenEdXAppServerAPITestCase(APITestCase):
 
         response = self.api_client.post('/api/v1/openedx_appserver/{pk}/make_active/'.format(pk=app_server.pk))
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.data, {'status': 'App server activation initiated.'})
+        self.assertEqual(response.data, {'status': 'App server activation initiated.'})  # pylint: disable=no-member
         self.assertEqual(mock_run_playbook.call_count, 1)
 
         instance.refresh_from_db()
@@ -259,7 +273,7 @@ class OpenEdXAppServerAPITestCase(APITestCase):
             },
         ]
         self.check_log_list(
-            expected_list, response.data['log_entries'],
+            expected_list, response.data['log_entries'],  # pylint: disable=no-member
             inst_id=instance.ref.id, as_id=app_server.pk, server_id=server.pk, server_name=server.name,
         )
 
@@ -313,6 +327,6 @@ class OpenEdXAppServerAPITestCase(APITestCase):
         ]
 
         self.check_log_list(
-            expected_list, response.data['log_error_entries'],
+            expected_list, response.data['log_error_entries'],  # pylint: disable=no-member
             inst_id=instance.ref.id, as_id=app_server.pk, server_id=server.pk, server_name=server.name,
         )

--- a/instance/tests/api/test_openedx_instance.py
+++ b/instance/tests/api/test_openedx_instance.py
@@ -44,12 +44,12 @@ class OpenEdXInstanceAPITestCase(APITestCase):
         """
         self.api_client.login(username='user3', password='pass')
         response = self.api_client.get('/api/v1/instance/')
-        self.assertEqual(response.data, [])
+        self.assertEqual(response.data, [])  # pylint: disable=no-member
 
         OpenEdXInstanceFactory(sub_domain='domain.api')
         response = self.api_client.get('/api/v1/instance/')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        instance_data = response.data[0].items()
+        instance_data = response.data[0].items()  # pylint: disable=no-member
         self.assertIn(('domain', 'domain.api.example.com'), instance_data)
         self.assertIn(('is_shut_down', False), instance_data)
         self.assertIn(('appserver_count', 0), instance_data)
@@ -69,7 +69,7 @@ class OpenEdXInstanceAPITestCase(APITestCase):
         response = self.api_client.get('/api/v1/instance/{pk}/'.format(pk=instance.ref.pk))
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-        instance_data = response.data.items()
+        instance_data = response.data.items()  # pylint: disable=no-member
         self.assertIn(('domain', 'domain.api.example.com'), instance_data)
         self.assertIn(('is_shut_down', False), instance_data)
         self.assertIn(('name', instance.name), instance_data)
@@ -83,10 +83,10 @@ class OpenEdXInstanceAPITestCase(APITestCase):
         self.assertIn(('additional_security_groups', []), instance_data)
         # AppServer info:
         self.assertIn(('appserver_count', 1), instance_data)
-        self.assertIn('active_appserver', response.data)
-        self.assertIn('newest_appserver', response.data)
+        self.assertIn('active_appserver', response.data)  # pylint: disable=no-member
+        self.assertIn('newest_appserver', response.data)  # pylint: disable=no-member
         for key in ('active_appserver', 'newest_appserver'):
-            app_server_data = response.data[key]
+            app_server_data = response.data[key]  # pylint: disable=no-member
             self.assertEqual(app_server_data['id'], app_server.pk)
             self.assertEqual(
                 app_server_data['api_url'], 'http://testserver/api/v1/openedx_appserver/{pk}/'.format(pk=app_server.pk)

--- a/instance/tests/api/test_openedx_instance.py
+++ b/instance/tests/api/test_openedx_instance.py
@@ -44,12 +44,12 @@ class OpenEdXInstanceAPITestCase(APITestCase):
         """
         self.api_client.login(username='user3', password='pass')
         response = self.api_client.get('/api/v1/instance/')
-        self.assertEqual(response.data, [])  # pylint: disable=no-member
+        self.assertEqual(response.data, [])
 
         OpenEdXInstanceFactory(sub_domain='domain.api')
         response = self.api_client.get('/api/v1/instance/')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        instance_data = response.data[0].items()  # pylint: disable=no-member
+        instance_data = response.data[0].items()
         self.assertIn(('domain', 'domain.api.example.com'), instance_data)
         self.assertIn(('is_shut_down', False), instance_data)
         self.assertIn(('appserver_count', 0), instance_data)
@@ -69,7 +69,7 @@ class OpenEdXInstanceAPITestCase(APITestCase):
         response = self.api_client.get('/api/v1/instance/{pk}/'.format(pk=instance.ref.pk))
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-        instance_data = response.data.items()  # pylint: disable=no-member
+        instance_data = response.data.items()
         self.assertIn(('domain', 'domain.api.example.com'), instance_data)
         self.assertIn(('is_shut_down', False), instance_data)
         self.assertIn(('name', instance.name), instance_data)
@@ -83,10 +83,10 @@ class OpenEdXInstanceAPITestCase(APITestCase):
         self.assertIn(('additional_security_groups', []), instance_data)
         # AppServer info:
         self.assertIn(('appserver_count', 1), instance_data)
-        self.assertIn('active_appserver', response.data)  # pylint: disable=no-member
-        self.assertIn('newest_appserver', response.data)  # pylint: disable=no-member
+        self.assertIn('active_appserver', response.data)
+        self.assertIn('newest_appserver', response.data)
         for key in ('active_appserver', 'newest_appserver'):
-            app_server_data = response.data[key]  # pylint: disable=no-member
+            app_server_data = response.data[key]
             self.assertEqual(app_server_data['id'], app_server.pk)
             self.assertEqual(
                 app_server_data['api_url'], 'http://testserver/api/v1/openedx_appserver/{pk}/'.format(pk=app_server.pk)

--- a/instance/tests/base.py
+++ b/instance/tests/base.py
@@ -112,7 +112,7 @@ class WithUserTestCase(DjangoTestCase):
         # User3 has InstanceManager privileges
         self.user3 = User.objects.create_user('user3', 'user3@example.com', 'pass')
         content_type = ContentType.objects.get_for_model(InstanceReference)
-        permission = Permission.objects.get(  # pylint: disable=no-member
+        permission = Permission.objects.get(
             content_type=content_type, codename='manage_all')
         self.user3.user_permissions.add(permission)
         self.user3.save()

--- a/instance/tests/integration/base.py
+++ b/instance/tests/integration/base.py
@@ -57,7 +57,7 @@ class IntegrationTestCase(TestCase):
         for instance in OpenEdXInstance.objects.iterator():
             instance.load_balancing_server = None
             instance.save()
-        for load_balancer in LoadBalancingServer.objects.iterator():  # pylint: disable=no-member
+        for load_balancer in LoadBalancingServer.objects.iterator():
             load_balancer.delete()
         for instance in OpenEdXInstance.objects.iterator():
             instance.delete()

--- a/instance/tests/integration/integration_instance.py
+++ b/instance/tests/integration/integration_instance.py
@@ -114,7 +114,6 @@ class InstanceIntegrationTestCase(IntegrationTestCase):
         """
         Verify that the appserver's configuration includes expected secret keys.
         """
-        instance_key = instance.secret_key_b64encoded
         for expected_key in self.EXPECTED_SECRET_KEYS:
             self.assertIn(instance.get_secret_key_for_var(expected_key), appserver.configuration_settings)
 

--- a/instance/tests/integration/utils.py
+++ b/instance/tests/integration/utils.py
@@ -46,9 +46,9 @@ def check_url_accessible(url, attempts=3, delay=15):
 
 
 def is_port_open(ip_addr, port):
-        """
-        Determine if the server at ip_addr is accepting connections on the given
-        port or not.
-        """
-        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        return sock.connect_ex((ip_addr, port)) == 0
+    """
+    Determine if the server at ip_addr is accepting connections on the given
+    port or not.
+    """
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    return sock.connect_ex((ip_addr, port)) == 0

--- a/instance/tests/models/test_database_server.py
+++ b/instance/tests/models/test_database_server.py
@@ -325,11 +325,11 @@ class DatabaseServerManagerTest(TestCase):
         MySQLServer.objects._create_default()
         MongoDBServer.objects._create_default()
 
-        self.assertEqual(MySQLServer.objects.count(), 1)  # pylint: disable=no-member
-        self.assertEqual(MongoDBServer.objects.count(), 1)  # pylint: disable=no-member
+        self.assertEqual(MySQLServer.objects.count(), 1)
+        self.assertEqual(MongoDBServer.objects.count(), 1)
 
-        mysql_server = MySQLServer.objects.get()  # pylint: disable=no-member
-        mongodb_server = MongoDBServer.objects.get()  # pylint: disable=no-member
+        mysql_server = MySQLServer.objects.get()
+        mongodb_server = MongoDBServer.objects.get()
 
         self._assert_default_settings(mysql_server, mongodb_server)
 
@@ -344,8 +344,8 @@ class DatabaseServerManagerTest(TestCase):
         MySQLServer.objects._create_default()
         MongoDBServer.objects._create_default()
 
-        self.assertEqual(MySQLServer.objects.count(), 0)  # pylint: disable=no-member
-        self.assertEqual(MongoDBServer.objects.count(), 0)  # pylint: disable=no-member
+        self.assertEqual(MySQLServer.objects.count(), 0)
+        self.assertEqual(MongoDBServer.objects.count(), 0)
 
     def test__create_default_exists_settings_match(self):
         """
@@ -359,15 +359,15 @@ class DatabaseServerManagerTest(TestCase):
         MongoDBServer.objects._create_default()
 
         # Precondition
-        self.assertEqual(MySQLServer.objects.count(), 1)  # pylint: disable=no-member
-        self.assertEqual(MongoDBServer.objects.count(), 1)  # pylint: disable=no-member
+        self.assertEqual(MySQLServer.objects.count(), 1)
+        self.assertEqual(MongoDBServer.objects.count(), 1)
 
         MySQLServer.objects._create_default()
         MongoDBServer.objects._create_default()
 
         # Number of database servers should not have changed
-        self.assertEqual(MySQLServer.objects.count(), 1)  # pylint: disable=no-member
-        self.assertEqual(MongoDBServer.objects.count(), 1)  # pylint: disable=no-member
+        self.assertEqual(MySQLServer.objects.count(), 1)
+        self.assertEqual(MongoDBServer.objects.count(), 1)
 
         log_entries = LogEntry.objects.all()
         self.assertFalse(any(
@@ -393,8 +393,8 @@ class DatabaseServerManagerTest(TestCase):
         MongoDBServer.objects._create_default()
 
         # Precondition
-        self.assertEqual(MySQLServer.objects.count(), 1)  # pylint: disable=no-member
-        self.assertEqual(MongoDBServer.objects.count(), 1)  # pylint: disable=no-member
+        self.assertEqual(MySQLServer.objects.count(), 1)
+        self.assertEqual(MongoDBServer.objects.count(), 1)
 
         with override_settings(
             DEFAULT_INSTANCE_MYSQL_URL='mysql://user:pass@{hostname}'.format(hostname=mysql_hostname),
@@ -404,8 +404,8 @@ class DatabaseServerManagerTest(TestCase):
             MongoDBServer.objects._create_default()
 
         # Number of database servers should not have changed
-        self.assertEqual(MySQLServer.objects.count(), 1)  # pylint: disable=no-member
-        self.assertEqual(MongoDBServer.objects.count(), 1)  # pylint: disable=no-member
+        self.assertEqual(MySQLServer.objects.count(), 1)
+        self.assertEqual(MongoDBServer.objects.count(), 1)
 
         # Log entries should contain two warnings about existing servers with different settings
         log_entries = LogEntry.objects.all()
@@ -467,8 +467,8 @@ class DatabaseServerManagerTest(TestCase):
         MongoDBServer.objects._create_default()
 
         # Precondition
-        self.assertEqual(MySQLServer.objects.count(), 1)  # pylint: disable=no-member
-        self.assertEqual(MongoDBServer.objects.count(), 1)  # pylint: disable=no-member
+        self.assertEqual(MySQLServer.objects.count(), 1)
+        self.assertEqual(MongoDBServer.objects.count(), 1)
 
         # Change name of MySQLServer and MongoDBServer
         mysql_server = MySQLServer.objects.get()
@@ -488,5 +488,5 @@ class DatabaseServerManagerTest(TestCase):
                 'It should ignore `name`.'
             )
         else:
-            self.assertEqual(MySQLServer.objects.count(), 1)  # pylint: disable=no-member
-            self.assertEqual(MongoDBServer.objects.count(), 1)  # pylint: disable=no-member
+            self.assertEqual(MySQLServer.objects.count(), 1)
+            self.assertEqual(MongoDBServer.objects.count(), 1)

--- a/instance/tests/models/test_load_balanced_mixin.py
+++ b/instance/tests/models/test_load_balanced_mixin.py
@@ -22,8 +22,6 @@ Load-balanced instance mixin - tests
 
 # Imports #####################################################################
 
-from unittest.mock import patch, call
-
 from django.test import override_settings
 
 from instance import gandi

--- a/instance/tests/models/test_openedx_database_mixins.py
+++ b/instance/tests/models/test_openedx_database_mixins.py
@@ -512,7 +512,8 @@ class RabbitMQInstanceTestCase(TestCase):
             self.instance.deprovision_rabbitmq()
         super().tearDown()
 
-    def request_overview(self):
+    @staticmethod
+    def request_overview():
         """
         A helper method to request the overview data for the configured RabbitMQ instance
         """

--- a/instance/tests/models/test_openedx_instance.py
+++ b/instance/tests/models/test_openedx_instance.py
@@ -854,7 +854,7 @@ class OpenEdXInstanceTestCase(TestCase):
             responses.add(
                 responses.DELETE,
                 '{0}/monitors/{1}'.format(newrelic.SYNTHETICS_API_URL, monitor_id),
-                status=requests.codes.not_found  # pylint: disable=no-member
+                status=requests.codes.not_found
             )
 
         # Preconditions

--- a/instance/tests/models/test_openedx_instance.py
+++ b/instance/tests/models/test_openedx_instance.py
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
+# pylint: disable=too-many-lines
 """
 OpenEdXInstance model - Tests
 """

--- a/instance/tests/models/test_openedx_monitoring_mixins.py
+++ b/instance/tests/models/test_openedx_monitoring_mixins.py
@@ -154,7 +154,7 @@ class OpenEdXMonitoringTestCase(TestCase):
             responses.add(
                 responses.DELETE,
                 '{0}/monitors/{1}'.format(newrelic.SYNTHETICS_API_URL, monitor_id),
-                status=requests.codes.not_found  # pylint: disable=no-member
+                status=requests.codes.not_found
             )
 
         # Precondition

--- a/instance/tests/models/test_openedx_secret_key_mixins.py
+++ b/instance/tests/models/test_openedx_secret_key_mixins.py
@@ -1,0 +1,100 @@
+# -*- coding: utf-8 -*-
+#
+# OpenCraft -- tools to aid developing and hosting free software projects
+# Copyright (C) 2015-2016 OpenCraft <contact@opencraft.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+"""
+OpenEdXInstance secret key mixins - Tests
+"""
+
+# Imports #####################################################################
+
+import codecs
+import re
+import yaml
+import six
+
+from instance.models.mixins.secret_keys import OPENEDX_SECRET_KEYS, OPENEDX_SHARED_KEYS
+from instance.tests.base import TestCase
+from instance.tests.models.factories.openedx_instance import OpenEdXInstanceFactory
+from instance.tests.utils import patch_services
+
+
+# Tests #######################################################################
+
+class OpenEdXSecretKeyInstanceMixinTestCase(TestCase):
+    """
+    Test cases for SecretKeyInstanceMixin models
+    """
+    def test_secret_key_creation(self):
+        """
+        Test that we can reliably produce derived secret keys for an instance with a particular
+        existing secret key.
+        """
+        instance = OpenEdXInstanceFactory()
+        instance.secret_key_b64encoded = 'esFyh7kbvbMQiYhRx9fISJw9gkcSCStGAfOWaPu9cfc6/tMu'
+        instance.save()
+
+        self.assertEqual(
+            instance.get_secret_key_for_var('THIS_IS_A_TEST'),
+            '95652a974218e2efc44f99feb6f2ab89a263746688ff428ca2c898ae44111f58',
+        )
+        self.assertEqual(
+            instance.get_secret_key_for_var('OTHER_TEST'),
+            '820b455b1f0e30b75ec0514ab172c588223b010de3beacce3cd27217adc7fe60',
+        )
+        self.assertEqual(
+            instance.get_secret_key_for_var('SUPER_SECRET'),
+            '21b5271f21ee6dacfde05cd97e20739f0e73dc8a43408ef14b657bfbf718e2b4',
+        )
+
+    def test_secret_key_settings(self):
+        """
+        Test the YAML settings returned by SecretKeyInstanceMixin.
+        """
+        instance = OpenEdXInstanceFactory()
+        secret_key_settings = yaml.load(instance.get_secret_key_settings())
+
+        # Test that all keys are hex-encoded strings.
+        for secret_key in secret_key_settings.values():
+            codecs.decode(secret_key, "hex")
+
+        # Make sure all independent secret keys are all different
+        independent_secrets = set(secret_key_settings[var] for var in OPENEDX_SECRET_KEYS)
+        self.assertEqual(len(independent_secrets), len(OPENEDX_SECRET_KEYS))
+
+        # Verify that API client keys are set to the matching server key.
+        for to_var, from_var in OPENEDX_SHARED_KEYS.items():
+            self.assertEqual(secret_key_settings[to_var], secret_key_settings[from_var])
+
+    @patch_services
+    def test_do_not_create_insecure_secret_keys(self, mocks):
+        """
+        Test that if we have a brand-new instance with no appservers, we refuse to create insecure
+        keys for those appservers if we don't have a secure secret key for the instance.
+        """
+        instance = OpenEdXInstanceFactory()
+        instance.secret_key_b64encoded = ''
+        instance.save()
+
+        expected_error_string = re.escape(
+            'Attempted to create secret key for instance {}, but no master key present.'.format(instance)
+        )
+
+        # Six provides a compatibility method for assertRaisesRegex, since the method
+        # is named differently between Py2k and Py3k.
+        with six.assertRaisesRegex(self, ValueError, expected_error_string):
+            instance.spawn_appserver()

--- a/instance/tests/models/test_utils.py
+++ b/instance/tests/models/test_utils.py
@@ -371,26 +371,22 @@ class SimpleResourceTestCase(TestCase):
         # In State 1, we can call method_one():
         res.return_value = 'A'
         self.assertEqual(res.method_one(), 'A')
-        # TODO: Why do we need to disable no-member for `is_available`?
-        self.assertEqual(res.method_one.is_available(), True) #pylint: disable=no-member
+        self.assertEqual(res.method_one.is_available(), True)
 
         # In State 1, we can call method_one_with_args():
         self.assertEqual(res.method_one_with_args(4, 5, c=6), 32)
-        # TODO: Why do we need to disable no-member for `is_available`?
-        self.assertEqual(res.method_one_with_args.is_available(), True) #pylint: disable=no-member
+        self.assertEqual(res.method_one_with_args.is_available(), True)
 
         # But not method_two()
         expected_message = "The method 'method_two' cannot be called in this state \\(State 1 / State1\\)."
         with self.assertRaisesRegex(WrongStateException, expected_message):
             res.method_two()
-        # TODO: Why do we need to disable no-member for `is_available`?
-        self.assertEqual(res.method_two.is_available(), False) #pylint: disable=no-member
+        self.assertEqual(res.method_two.is_available(), False)
 
         # In State 1, we can call method_odd():
         res.return_value = 'B'
         self.assertEqual(res.method_odd(), 'B')
-        # TODO: Why do we need to disable no-member for `is_available`?
-        self.assertEqual(res.method_odd.is_available(), True) #pylint: disable=no-member
+        self.assertEqual(res.method_odd.is_available(), True)
 
         # Go to State 2:
         res.increment_state()
@@ -399,13 +395,11 @@ class SimpleResourceTestCase(TestCase):
         expected_message = "The method 'method_one' cannot be called in this state \\(State 2 / State2\\)."
         with self.assertRaisesRegex(WrongStateException, expected_message):
             res.method_one()
-        # TODO: Why do we need to disable no-member for `is_available`?
-        self.assertEqual(res.method_one.is_available(), False) #pylint: disable=no-member
+        self.assertEqual(res.method_one.is_available(), False)
 
         res.return_value = 'C'
         self.assertEqual(res.method_two(), 'C')
-        # TODO: Why do we need to disable no-member for `is_available`?
-        self.assertEqual(res.method_two.is_available(), True) #pylint: disable=no-member
+        self.assertEqual(res.method_two.is_available(), True)
 
     def test_property_only_for(self):
         """

--- a/instance/tests/test_newrelic.py
+++ b/instance/tests/test_newrelic.py
@@ -173,8 +173,8 @@ class NewRelicTestCase(TestCase):
                 try:
                     newrelic.delete_synthetics_monitor(monitor_id)
                 except requests.exceptions.HTTPError:
-                    if error == requests.codes.not_found:  # pylint: disable=no-member
+                    if error == requests.codes.not_found:
                         self.fail('Should not raise an exception for {} response.'.format(error))
                 else:
-                    if not error == requests.codes.not_found:  # pylint: disable=no-member
+                    if not error == requests.codes.not_found:
                         self.fail('Should raise an exception for {} response.'.format(error))

--- a/instance/tests/test_tasks.py
+++ b/instance/tests/test_tasks.py
@@ -121,7 +121,7 @@ class CleanUpTestCase(TestCase):
 
     @patch('instance.logging.ModelLoggerAdapter.process')
     @patch('instance.models.openedx_instance.OpenEdXInstance.terminate_obsolete_appservers')
-    def test_terminate_obsolete_appservers(self, mock_terminate_obsolete_appservers, mock_logger):
+    def test_terminate_obsolete_appservers(self, mock_terminate_appservers, mock_logger):
         """
         Test that `terminate_obsolete_appservers_all_instances`
         calls `terminate_obsolete_appservers` on all existing instances.
@@ -133,7 +133,7 @@ class CleanUpTestCase(TestCase):
 
         tasks.terminate_obsolete_appservers_all_instances()
 
-        self.assertEqual(mock_terminate_obsolete_appservers.call_count, 5)
+        self.assertEqual(mock_terminate_appservers.call_count, 5)
         self.assertEqual(mock_logger.call_count, 5)
         mock_logger.assert_called_with("Terminating obsolete appservers for instance", {})
 

--- a/instance/tests/utils.py
+++ b/instance/tests/utils.py
@@ -44,7 +44,7 @@ def patch_gandi(func=None):
     return patcher
 
 
-def patch_url(url, method=responses.GET, status=requests.codes.ok):
+def patch_url(url, method=responses.GET, status=requests.codes.ok):  # pylint: disable=no-member
     """
     Decorator which mocks responses from the given url.
 
@@ -66,6 +66,7 @@ def patch_url(url, method=responses.GET, status=requests.codes.ok):
         def test_that_calls_nova(...):
             ...
     """
+    # pylint: disable=missing-docstring
     def function_wrapper(func):
         def responses_wrapper(*args, **kwargs):
             responses.add(

--- a/instance/tests/utils.py
+++ b/instance/tests/utils.py
@@ -44,7 +44,7 @@ def patch_gandi(func=None):
     return patcher
 
 
-def patch_url(url, method=responses.GET, status=requests.codes.ok):  # pylint: disable=no-member
+def patch_url(url, method=responses.GET, status=requests.codes.ok):
     """
     Decorator which mocks responses from the given url.
 

--- a/pr_watch/models.py
+++ b/pr_watch/models.py
@@ -247,4 +247,4 @@ class WatchedPullRequest(models.Model):
             instance.save()
             if not self.instance:
                 self.instance = instance
-                self.save(update_fields=["instance"])  # pylint: disable=no-member
+                self.save(update_fields=["instance"])

--- a/pr_watch/tests/test_api.py
+++ b/pr_watch/tests/test_api.py
@@ -53,12 +53,12 @@ class APITestCase(WithUserTestCase):
 
         response = self.api_client.get('/api/v1/pr_watch/')
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
-        self.assertEqual(response.data, forbidden_message)
+        self.assertEqual(response.data, forbidden_message)  # pylint: disable=no-member
 
         watched_pr = make_watched_pr_and_instance()
         response = self.api_client.get('/api/v1/pr_watch/{pk}/'.format(pk=watched_pr.pk))
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
-        self.assertEqual(response.data, forbidden_message)
+        self.assertEqual(response.data, forbidden_message)   # pylint: disable=no-member
 
     def test_get_authenticated(self):
         """
@@ -66,7 +66,7 @@ class APITestCase(WithUserTestCase):
         """
         self.api_client.login(username='user1', password='pass')
         response = self.api_client.get('/api/v1/pr_watch/')
-        self.assertEqual(response.data, [])
+        self.assertEqual(response.data, [])  # pylint: disable=no-member
 
         watched_pr = make_watched_pr_and_instance(branch_name='api-test-branch')
 
@@ -83,12 +83,12 @@ class APITestCase(WithUserTestCase):
 
         response = self.api_client.get('/api/v1/pr_watch/')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        check_output(response.data[0])
+        check_output(response.data[0])  # pylint: disable=no-member
 
         # And check the details view:
         response = self.api_client.get('/api/v1/pr_watch/{pk}/'.format(pk=watched_pr.pk))
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        check_output(response.data)
+        check_output(response.data)  # pylint: disable=no-member
 
     @patch('pr_watch.github.get_pr_by_number')
     def test_update_instance(self, mock_get_pr_by_number):
@@ -140,4 +140,7 @@ class APITestCase(WithUserTestCase):
         mock_get_pr_by_number.return_value = PRFactory(number=watched_pr.github_pr_number)
         response = self.api_client.post('/api/v1/pr_watch/{pk}/update_instance/'.format(pk=watched_pr.pk))
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertEqual(response.data, {'error': 'Could not fetch updated details from GitHub.'})
+        self.assertEqual(
+            response.data,  # pylint: disable=no-member
+            {'error': 'Could not fetch updated details from GitHub.'}
+        )

--- a/pr_watch/tests/test_api.py
+++ b/pr_watch/tests/test_api.py
@@ -53,12 +53,12 @@ class APITestCase(WithUserTestCase):
 
         response = self.api_client.get('/api/v1/pr_watch/')
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
-        self.assertEqual(response.data, forbidden_message)  # pylint: disable=no-member
+        self.assertEqual(response.data, forbidden_message)
 
         watched_pr = make_watched_pr_and_instance()
         response = self.api_client.get('/api/v1/pr_watch/{pk}/'.format(pk=watched_pr.pk))
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
-        self.assertEqual(response.data, forbidden_message)   # pylint: disable=no-member
+        self.assertEqual(response.data, forbidden_message)
 
     def test_get_authenticated(self):
         """
@@ -66,7 +66,7 @@ class APITestCase(WithUserTestCase):
         """
         self.api_client.login(username='user1', password='pass')
         response = self.api_client.get('/api/v1/pr_watch/')
-        self.assertEqual(response.data, [])  # pylint: disable=no-member
+        self.assertEqual(response.data, [])
 
         watched_pr = make_watched_pr_and_instance(branch_name='api-test-branch')
 
@@ -83,12 +83,12 @@ class APITestCase(WithUserTestCase):
 
         response = self.api_client.get('/api/v1/pr_watch/')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        check_output(response.data[0])  # pylint: disable=no-member
+        check_output(response.data[0])
 
         # And check the details view:
         response = self.api_client.get('/api/v1/pr_watch/{pk}/'.format(pk=watched_pr.pk))
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        check_output(response.data)  # pylint: disable=no-member
+        check_output(response.data)
 
     @patch('pr_watch.github.get_pr_by_number')
     def test_update_instance(self, mock_get_pr_by_number):
@@ -140,7 +140,4 @@ class APITestCase(WithUserTestCase):
         mock_get_pr_by_number.return_value = PRFactory(number=watched_pr.github_pr_number)
         response = self.api_client.post('/api/v1/pr_watch/{pk}/update_instance/'.format(pk=watched_pr.pk))
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertEqual(
-            response.data,  # pylint: disable=no-member
-            {'error': 'Could not fetch updated details from GitHub.'}
-        )
+        self.assertEqual(response.data, {'error': 'Could not fetch updated details from GitHub.'})

--- a/pr_watch/tests/test_models.py
+++ b/pr_watch/tests/test_models.py
@@ -83,7 +83,7 @@ class WatchedPullRequestTestCase(TestCase):
         watched_pr.set_fork_name('org2/another-repo')
         self.assertEqual(watched_pr.github_organization_name, 'org2')
         self.assertEqual(watched_pr.github_repository_name, 'another-repo')
-        watched_pr.save()  # pylint: disable=no-member
+        watched_pr.save()
 
         # Check values in DB
         watched_pr = WatchedPullRequest.objects.get(pk=watched_pr.pk)

--- a/pylintrc
+++ b/pylintrc
@@ -90,6 +90,7 @@ disable=
     fixme,
     locally-disabled,
     no-init,
+    no-member,
     too-few-public-methods,
     too-many-ancestors,
     protected-access,

--- a/registration/forms.py
+++ b/registration/forms.py
@@ -367,7 +367,7 @@ class BetaTestApplicationForm(NgModelFormMixin, NgFormValidationMixin, NgModelFo
         """
         Return a queryset for all users that are not the current user, if any.
         """
-        users = User.objects.all() #pylint: disable=no-member
+        users = User.objects.all()
         if self.instance and self.instance.user_id:
             users = users.exclude(pk=self.instance.user_id)
         return users

--- a/registration/models.py
+++ b/registration/models.py
@@ -135,7 +135,7 @@ class BetaTestApplication(ValidateModelMixin, TimeStampedModel):
         public contact email address have been verified.
         """
         email_addresses = {self.user.email, self.public_contact_email}
-        verified = EmailAddress.objects.exclude(confirmed_at=None).filter( #pylint: disable=no-member
+        verified = EmailAddress.objects.exclude(confirmed_at=None).filter(
             email__in=email_addresses
         )
         return verified.count() == len(email_addresses)

--- a/registration/tests/test_views.py
+++ b/registration/tests/test_views.py
@@ -517,7 +517,7 @@ class LoginTestCase(UserMixin, TestCase):
             data={'username': self.username, 'password': self.password},
             follow=True,
         )
-        self.assertEqual(response.context['user'], self.user)  # pylint: disable=no-member
+        self.assertEqual(response.context['user'], self.user)
 
     def test_redirect(self):
         """
@@ -544,7 +544,7 @@ class LogoutTestCase(UserMixin, TestCase):
         Test that the logout view logs the user out.
         """
         response = self.client.get(self.url, follow=True)
-        self.assertFalse(response.context['user'].is_authenticated)  # pylint: disable=no-member
+        self.assertFalse(response.context['user'].is_authenticated)
 
     def test_redirect(self):
         """

--- a/registration/tests/test_views.py
+++ b/registration/tests/test_views.py
@@ -88,7 +88,7 @@ class BetaTestApplicationViewTestMixin:
         self._assert_email_verification_sent(application)
         with patch('registration.provision._provision_instance', autospec=True) as mock_handler:
             expected_call_count = 0
-            for verification_email in mail.outbox:  # fix flaky pylint: disable=no-member,useless-suppression
+            for verification_email in mail.outbox:
                 verify_url = re.search(r'https?://[^\s]+',
                                        verification_email.body).group(0)
                 self.client.get(verify_url)
@@ -169,10 +169,10 @@ class BetaTestApplicationViewTestMixin:
         on the beta application.
         """
         addresses = {application.user.email, application.public_contact_email}
-        self.assertEqual(len(mail.outbox), len(addresses))  # fix flaky pylint: disable=no-member,useless-suppression
-        self.assertEqual(EmailAddress.objects.count(), len(addresses)) #pylint: disable=no-member
+        self.assertEqual(len(mail.outbox), len(addresses))
+        self.assertEqual(EmailAddress.objects.count(), len(addresses))
         for email_address in addresses:
-            email = EmailAddress.objects.get(email=email_address) #pylint: disable=no-member
+            email = EmailAddress.objects.get(email=email_address)
             self.assertIs(email.is_confirmed, False)
 
     def _assert_email_addresses_verified(self, application):
@@ -182,7 +182,7 @@ class BetaTestApplicationViewTestMixin:
         """
         for email_address in {application.user.email,
                               application.public_contact_email}:
-            email = EmailAddress.objects.get(email=email_address) #pylint: disable=no-member
+            email = EmailAddress.objects.get(email=email_address)
             self.assertIs(email.is_confirmed, True)
         response = self._get_response_body(self.url)
         self.assertNotIn('pending email confirmation',
@@ -200,7 +200,7 @@ class BetaTestApplicationViewTestMixin:
             self.assertEqual(self._get_error_messages(response),
                              expected_errors)
         self.assertEqual(BetaTestApplication.objects.count(), original_count)
-        self.assertEqual(len(mail.outbox), 0)  # fix flaky pylint: disable=no-member,useless-suppression
+        self.assertEqual(len(mail.outbox), 0)
 
     def test_valid_application(self):
         """
@@ -227,7 +227,7 @@ class BetaTestApplicationViewTestMixin:
             instance_name='I got here first',
             public_contact_email='test@example.com',
             project_description='test',
-            user=User.objects.create(username='test'), #pylint: disable=no-member
+            user=User.objects.create(username='test'),
         )
         self._assert_registration_fails(self.form_data, expected_errors={
             'subdomain': ['This domain is already taken.'],
@@ -281,7 +281,7 @@ class BetaTestApplicationViewTestMixin:
             instance_name='That username is mine',
             public_contact_email='test@example.com',
             project_description='test',
-            user=User.objects.create(username=self.form_data['username']), #pylint: disable=no-member
+            user=User.objects.create(username=self.form_data['username']),
         )
         self._assert_registration_fails(self.form_data, expected_errors={
             'username': ['This username is already taken.'],
@@ -305,8 +305,7 @@ class BetaTestApplicationViewTestMixin:
             instance_name='That email address is mine',
             public_contact_email='test@example.com',
             project_description='test',
-            user=User.objects.create(username='test', #pylint: disable=no-member
-                                     email=self.form_data['email']),
+            user=User.objects.create(username='test', email=self.form_data['email']),
         )
         self._assert_registration_fails(self.form_data, expected_errors={
             'email': ['This email address is already registered.'],
@@ -518,7 +517,7 @@ class LoginTestCase(UserMixin, TestCase):
             data={'username': self.username, 'password': self.password},
             follow=True,
         )
-        self.assertEqual(response.context['user'], self.user)
+        self.assertEqual(response.context['user'], self.user)  # pylint: disable=no-member
 
     def test_redirect(self):
         """
@@ -545,7 +544,7 @@ class LogoutTestCase(UserMixin, TestCase):
         Test that the logout view logs the user out.
         """
         response = self.client.get(self.url, follow=True)
-        self.assertFalse(response.context['user'].is_authenticated)
+        self.assertFalse(response.context['user'].is_authenticated)  # pylint: disable=no-member
 
     def test_redirect(self):
         """

--- a/registration/views.py
+++ b/registration/views.py
@@ -80,7 +80,7 @@ class BetaTestApplicationView(BetaTestApplicationMixin, UpdateView):
                                 password=form.cleaned_data['password'])
             login(self.request, user)
         for email_address in {user.email, self.object.public_contact_email}:
-            if not EmailAddress.objects.filter(email=email_address).exists(): #pylint: disable=no-member
+            if not EmailAddress.objects.filter(email=email_address).exists():
                 email = EmailAddress.objects.create_unconfirmed(email_address, user)
                 send_email_verification(email, self.request)
         return response

--- a/requirements.txt
+++ b/requirements.txt
@@ -95,7 +95,9 @@ pycodestyle==2.0.0
 pydocstyle==1.0.0
 pyflakes==1.3.0
 Pygments==2.1.3
-pylint==1.6.4
+# Pylint 1.6.* does not work with prospector 0.12.4, so we have to use 1.5.6 for now.
+# See: https://github.com/landscapeio/prospector/issues/183
+pylint==1.5.6
 pylint-celery==0.3
 pylint-common==0.2.2
 pylint-django==0.7.2


### PR DESCRIPTION
**Description**

Current version of prospector does not work with pylint 1.6.* (pylint warnings are silently suppressed).

This PR reverts pylint to 1.5.6 and fixes pylint violations that have accumulated while pylint wasn't working.

It also globally disables the `no-member` check, which is very unreliable and therefore not helpful.

For more info see https://tasks.opencraft.com/browse/OC-2143

**Testing Instructions**

1. Checkout this branch, update dependencies (`pip install -r requirements.txt`).
2. Run `make test_prospector`. It should report no violations.
3. Intentionally make some pylint violations (add an unused import somewhere, remove an existing `# pylint: disable=xxx` comment, etc...)
4. Run `make test_prospector` again, just to ensure that it correctly reports the violations you just made.

**Reviewer**:
- [ ] @e-kolpakov