### PR TITLE
Mock interactions with the RabbitMQ API in tests

### DIFF
--- a/instance/tests/utils.py
+++ b/instance/tests/utils.py
@@ -129,6 +129,9 @@ def patch_services(func):
                 mock_provision_mongo=stack_patch(
                     'instance.models.mixins.openedx_database.MongoDBInstanceMixin.provision_mongo',
                 ),
+                mock_provision_rabbitmq=stack_patch(
+                    'instance.models.mixins.rabbitmq.RabbitMQInstanceMixin.provision_rabbitmq',
+                ),
                 mock_provision_swift=stack_patch(
                     'instance.models.mixins.openedx_storage.SwiftContainerInstanceMixin.provision_swift'
                 ),


### PR DESCRIPTION
On top of mocking `provision_rabbitmq`, I also went ahead and removed the `test_rabbitmq_access` test since it has no purpose if the API is mocked. 

**Testing instructions:**

1. Checkout this branch
1. Run the [previously failing tests](https://github.com/open-craft/opencraft/pull/152#issuecomment-274225119) to verify that they're passing now:

   ```
   honcho -e .env.test run coverage run --source='.' --omit='*/tests/*' ./manage.py test instance.tests.models.test_openedx_instance.OpenEdXInstanceTestCase.test_spawn_appserver_with_external_databases --noinput
   honcho -e .env.test run coverage run --source='.' --omit='*/tests/*' ./manage.py test instance.tests.models.test_openedx_database_mixins.RabbitMQInstanceTestCase --noinput
   ```

**Reviewers:**

- [ ] @pomegranited 