### PR TITLE
Add Openstack settings for Ficus.

### DIFF
--- a/instance/templates/instance/ansible/swift.yml
+++ b/instance/templates/instance/ansible/swift.yml
@@ -1,4 +1,6 @@
 EDXAPP_SETTINGS: 'openstack'
+COMMON_EDXAPP_SETTINGS: 'openstack'
+COMMON_ENABLE_OPENSTACK_INTEGRATION: true
 XQUEUE_SETTINGS: 'openstack_settings'
 
 VHOST_NAME: 'openstack'
@@ -28,6 +30,7 @@ XQUEUE_UPLOAD_BUCKET: '{{ container_name }}'
 XQUEUE_UPLOAD_PATH_PREFIX: 'xqueue'
 
 # Tracking logs
+COMMON_SWIFT_LOG_SYNC: true
 COMMON_OBJECT_STORE_LOG_SYNC: true
 COMMON_OBJECT_STORE_LOG_SYNC_BUCKET: '{{ container_name }}'
 COMMON_OBJECT_STORE_LOG_SYNC_PREFIX: 'logs/tracking/'


### PR DESCRIPTION
This PR adds the settings needed to configure Swift in the Ficus release.  The settings have been tested  on the instance manager in [this appserver](https://console.opencraft.com/instance/2500/edx-appserver/910/).

I've left the old settings in place, so we can support both Ficus and Eucalyptus at once for now.  Some of the settings could be marked as to be removed once we are ready to drop Eucalyptus support.  However, I plan to do that wholesale at the time by a semi-automated process, so I won't bother now.