### PR TITLE
Sets the feature flag PREVENT_CONCURRENT_LOGINS to false

### DIFF
--- a/instance/templates/instance/ansible/vars.yml
+++ b/instance/templates/instance/ansible/vars.yml
@@ -141,6 +141,7 @@ EDXAPP_FEATURES:
   PREVIEW_LMS_BASE: '{{ instance.lms_preview_domain }}'
   REQUIRE_COURSE_EMAIL_AUTH: false
   USE_MICROSITES: false
+  PREVENT_CONCURRENT_LOGINS: false
   # These are not part of the standard install:
   # CUSTOM_COURSES_EDX: true
   # ENABLE_LTI_PROVIDER: true


### PR DESCRIPTION
This change allows a single user to maintain sessions in Django Admin, LMS, and CMS from different browsers at the same time.

**Testing instructions**:

1. Using this branch, spawn a new appserver.
1. Ensure that `PREVENT_CONCURRENT_LOGINS: false` in the generated configuration files.
1. Once the appserver is running, activate it, and ensure that you can maintain a session between two different browsers, using the same username.

**Author notes and concerns**:

1. [By default](http://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/latest/feature_flags/feature_flag_index.html), `PREVENT_CONCURRENT_LOGINS: true` for [security reasons](https://groups.google.com/forum/#!topic/edx-code/kqCS2tuvTk4).  But it's inconvenient for us and our users, and so we're choosing to unset it.

**Reviewers**
- [x] @bdero 