### PR TITLE
Return IPV4 openstack VM addresses

### DIFF
--- a/instance/openstack_utils.py
+++ b/instance/openstack_utils.py
@@ -156,19 +156,22 @@ def create_server(nova, server_name, flavor_selector, image_selector, key_name=N
     return nova.servers.create(server_name, image, flavor, key_name=key_name, security_groups=security_groups)
 
 
-def get_server_public_address(server):
+def get_server_public_address(server, ip_version=4):
     """
-    Retrieve the public IP of `server`
+    Retrieve the public IP of `server` with the given `ip_version` (default 4).
     """
     addresses = server.addresses
     if not addresses:
         return None
 
-    # TODO: Ensure it is public
-    first_address_key = list(addresses.keys())[0]
-    first_address = addresses[first_address_key][0]
+    # Return the first address with the given IP version
+    for address_list in addresses.values():
+        # TODO: Ensure it is public, e.g. OVH addresses have key='Ext-Net'
+        for address in address_list:
+            if int(address.get('version', 0)) == ip_version:
+                return address
 
-    return first_address
+    return None
 
 
 def swift_service(

--- a/instance/tests/models/factories/server.py
+++ b/instance/tests/models/factories/server.py
@@ -75,7 +75,7 @@ class OSServerMockManager:
         Returns the mock `os_server` for this `openstack_id`
         """
         if openstack_id not in self._os_server_dict.keys():
-            self._os_server_dict[openstack_id] = MagicMock(addresses={"Ext-Net": [{"addr": "1.1.1.1", }]})
+            self._os_server_dict[openstack_id] = MagicMock(addresses={"Ext-Net": [{"addr": "1.1.1.1", "version": 4}]})
         return self._os_server_dict[openstack_id]
 
     def set_os_server_attributes(self, openstack_id, **attributes):


### PR DESCRIPTION
OVH have recently started providing IPV6 addresses along with their IPV4 addresses for new VMs.
ref: http://travaux.ovh.net/?do=details&id=23185

Unfortunately, our logic for determining the public IP of a new VM was too simplistic, and so it broke when this change was rolled out.

This PR updates `openstack_utils.get_server_public_address()` and related tests to:

* Adds an optional `ip_version` parameter, default `4`.
* Returns the first address found which matches the requested `ip_version`.

*Reviewer*
- [ ] @bdero 