### PR TITLE
Configure notifier database.

### DIFF
--- a/instance/models/mixins/openedx_database.py
+++ b/instance/models/mixins/openedx_database.py
@@ -80,6 +80,10 @@ class OpenEdXDatabaseMixin(MySQLInstanceMixin, MongoDBInstanceMixin, RabbitMQIns
                 "priv": "SELECT,INSERT,UPDATE,DELETE",
             },
             {
+                "name": self._get_mysql_database_name("notifier"),
+                "user": self._get_mysql_user_name("notifier"),
+            },
+            {
                 "name": self._get_mysql_database_name("analytics_api"),
                 "user": self._get_mysql_user_name("api"),
             },

--- a/instance/templates/instance/ansible/mysql.yml
+++ b/instance/templates/instance/ansible/mysql.yml
@@ -49,6 +49,14 @@ EDX_NOTES_API_MYSQL_DB_USER: '{{ edx_notes_api_user }}'
 EDX_NOTES_API_MYSQL_DB_PASS: '{{ edx_notes_api_pass }}'
 EDX_NOTES_API_MYSQL_HOST: '{{ host }}'
 
+# notifier
+NOTIFIER_DATABASE_ENGINE: 'django.db.backends.mysql'
+NOTIFIER_DATABASE_NAME: '{{ notifier_database }}'
+NOTIFIER_DATABASE_USER: '{{ notifier_user }}'
+NOTIFIER_DATABASE_PASSWORD: '{{ notifier_pass }}'
+NOTIFIER_DATABASE_HOST: '{{ host }}'
+NOTIFIER_DATABASE_PORT: {{ port }}
+
 # programs
 PROGRAMS_DEFAULT_DB_NAME: '{{ programs_database }}'
 PROGRAMS_DATABASES:

--- a/instance/tests/models/test_openedx_database_mixins.py
+++ b/instance/tests/models/test_openedx_database_mixins.py
@@ -321,6 +321,10 @@ class MySQLInstanceTestCase(TestCase):
             "EDXAPP_MYSQL_": make_flat_group_info(database={"name": "edxapp", "user": "edxapp"}),
             "XQUEUE_MYSQL_": make_flat_group_info(database={"name": "xqueue", "user": "xqueue"}),
             "EDXAPP_MYSQL_CSMH_": make_flat_group_info(database={"name": "edxapp_csmh", "user": "edxapp"}),
+            "NOTIFIER_DATABASE_": make_flat_group_info(
+                var_names=["NAME", "USER", "PASSWORD", "HOST", "PORT"],
+                database={"name": "notifier", "user": "notifier"}
+            ),
             "EDX_NOTES_API_MYSQL_": make_flat_group_info(
                 var_names=["DB_NAME", "DB_USER", "DB_PASS", "HOST"],
                 database={"name": "edx_notes_api", "user": "notes"},


### PR DESCRIPTION
Configures notifier to use MySQL database (and creates it if it doesn't already exist).

Notifier uses a local sqlite database by default to be able to benefit from https://github.com/edx/notifier/pull/43.

**Testing instructions**:

1. Checkout this branch and start deploying a new instance.
2. Verify that the `notifier` database is created and that these ansible variables are correctly set:

```
NOTIFIER_DATABASE_ENGINE
NOTIFIER_DATABASE_NAME
NOTIFIER_DATABASE_USER
NOTIFIER_DATABASE_PASSWORD
NOTIFIER_DATABASE_HOST
NOTIFIER_DATABASE_PORT
```

Alternatively wait for me to deploy a sandbox that combines https://github.com/edx/configuration/pull/3695,  https://github.com/edx/notifier/pull/42, and https://github.com/edx/notifier/pull/43.

**Reviewers**:

- [x] @haikuginger 