### PR TITLE
Add ICMP ingress for IPv4 and IPv6

### DIFF
--- a/opencraft/settings.py
+++ b/opencraft/settings.py
@@ -373,6 +373,24 @@ OPENEDX_APPSERVER_SECURITY_GROUP_RULES = [
         "port_range_min": 443, "port_range_max": 443,
         "remote_ip_prefix": "0.0.0.0/0", "remote_group_id": None,
     },
+    {
+        "direction": "ingress",
+        "ether_type": "IPv4",
+        "protocol": "icmp",
+        "port_range_min": None,
+        "port_range_max": None,
+        "remote_ip_prefix": "0.0.0.0/0",
+        "remote_group_id": None,
+    },
+    {
+        "direction": "ingress",
+        "ether_type": "IPv6",
+        "protocol": "icmp",
+        "port_range_min": None,
+        "port_range_max": None,
+        "remote_ip_prefix": "::/0",
+        "remote_group_id": None,
+    },
 ]
 
 # Ansible #####################################################################


### PR DESCRIPTION
This pull request ensures that appservers are members of a security group that allow ICMP ingress on IPv6 and IPv4. This is useful as a diagnostic measure, as some health checks require ICMP pings.

Testing instructions:

1. In a development environment, ensure that `OPENEDX_APPSERVER_SECURITY_GROUP_NAME` points to a security group that either does not exist, or that does not contain any ICMP rules.

2. In a shell, create a new instance, or retrieve an existing instance, and spawn an appserver on that instance.

3. In your OpenStack control panel, verify that the security group pointed to by `OPENEDX_APPSERVER_SECURITY_GROUP_NAME` contains the existing rules, as well as allowing inbound ICMP requests on IPv4 and IPv6.