### PR TITLE
Facilitate bulk redeployments from the Django shell.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,8 @@
 
 # Config ######################################################################
 
-WORKERS = 4
+WORKERS = 3
+WORKERS_LOW_PRIORITY = 3
 SHELL = /bin/bash
 HONCHO_MANAGE := honcho run python3 manage.py
 RUN_JS_TESTS := xvfb-run --auto-servernum jasmine-ci --logs --browser firefox
@@ -78,13 +79,13 @@ migration_autogen: clean
 	$(HONCHO_MANAGE) makemigrations
 
 run: clean migration_check collectstatic
-	honcho start --concurrency "worker=$(WORKERS)"
+	honcho start --concurrency "worker=$(WORKERS),worker_low_priority=$(WORKERS_LOW_PRIORITY)"
 
 rundev: clean migration_check static_external
 	honcho start -f Procfile.dev
 
 shell:
-	$(HONCHO_MANAGE) shell_plus
+	HUEY_QUEUE_NAME=opencraft_low_priority $(HONCHO_MANAGE) shell_plus
 
 upgrade_dependencies:
 	pip freeze --local | grep -v '^\-e' | cut -d = -f 1  | xargs -n1 pip install -U

--- a/Procfile
+++ b/Procfile
@@ -1,4 +1,5 @@
 web: gunicorn opencraft.wsgi --timeout 60 --workers 4 --log-file -
 websocket: python3 websocket.py
 worker: python3 manage.py run_huey --no-periodic
+worker_low_priority: HUEY_QUEUE_NAME=opencraft_low_priority python3 manage.py run_huey --no-periodic
 periodic: python3 manage.py run_huey --workers=0

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,3 +1,4 @@
 web: python3 manage.py runserver_plus
 websocket: python3 websocket.py
 worker: python3 manage.py run_huey --no-periodic
+worker_low_priority: HUEY_QUEUE_NAME=opencraft_low_priority python3 manage.py run_huey --no-periodic

--- a/README.md
+++ b/README.md
@@ -201,6 +201,9 @@ edit its security group rules to only allow access to VMs in the
 * `REDIS_URL`: (default: `redis://localhost:6379/`)
 * `HUEY_ALWAYS_EAGER`: Set to True to run huey tasks synchronously, in the web
   process. Use in development only (default: False)
+* `HUEY_QUEUE_NAME`: The name of the Huey task queue.  This setting can be used
+  to run multiple separate worker queues, e.g. one for the web server and one
+  for batch jobs started from the Django shell.
 * `LOGGING_ROTATE_MAX_KBYTES`: The max size of each log file (in KB, default: 10MB)
 * `LOGGING_ROTATE_MAX_FILES`: The max number of log files to keep (default: 60)
 * `SUBDOMAIN_BLACKLIST`: A comma-separated list of subdomains that are to be

--- a/opencraft/settings.py
+++ b/opencraft/settings.py
@@ -213,7 +213,7 @@ CACHES = {
 # Huey (redis task queue) #####################################################
 
 HUEY = {
-    'name': 'opencraft',
+    'name': env('HUEY_QUEUE_NAME', default='opencraft'),
     'connection': {
         'host': REDIS_URL_OBJ.hostname,
         'port': REDIS_URL_OBJ.port,


### PR DESCRIPTION
In order to be able to run bulk deployments of appservers from the Django shell without congesting the Huey queue for periodic tasks and deployments triggered from the UI, this PR introduces a separate Huey queue for tasks started from the Django shell.  This makes it possible to redeploy instances in bulk using simple loops in the shell.

Eventually we would like to be able to trigger bulk deployments from the GUI.  Currently, the Django integration of Huey only supports a single queue to be configured per process, but it would be rather easy to change this.

To be able to mark the instances that failed or succeeded, the `spawn_appserver()` task got additional arguments for tags to apply in either case.

With these small changes applied, the redeployment of all instances tagged by `tag` could be executed like this:

    success_tag = InstanceTag.objects.create(name=tag.name + "-succeeded")
    failure_tag = InstanceTag.objects.create(name=tag.name + "-failed")
    for instance in tag.openedxinstance_set.iterator():
        spawn_appserver(instance.ref.pk, success_tag=success_tag, failure_tag=failure_tag)

The failed instances can be retried using this code

    for instance in failure_tag.openedxinstance_set.iterator():
        spawn_appserver(instance.ref.pk, success_tag=success_tag, failure_tag=failure_tag)

We can or course add convenience functions to make running this code even more convenient.