### PR TITLE
Sets EDXAPP_ENTERPRISE_*_ENROLLMENT_API_URL to ansible vars

### DIFF
--- a/instance/templates/instance/ansible/vars.yml
+++ b/instance/templates/instance/ansible/vars.yml
@@ -206,6 +206,10 @@ ECOMMERCE_PAYPAL_RECEIPT_URL: '{{ ECOMMERCE_LMS_URL_ROOT }}/commerce/checkout/re
 ECOMMERCE_PAYPAL_CANCEL_URL: '{{ ECOMMERCE_LMS_URL_ROOT }}/commerce/checkout/cancel/'
 ECOMMERCE_PAYPAL_ERROR_URL: '{{ ECOMMERCE_LMS_URL_ROOT }}/commerce/checkout/error/'
 
+# Enterprise
+EDXAPP_ENTERPRISE_ENROLLMENT_API_URL: 'http://localhost/api/enrollment/v1/'
+EDXAPP_ENTERPRISE_PUBLIC_ENROLLMENT_API_URL: '{{ EDXAPP_LMS_ROOT_URL }}/api/enrollment/v1/'
+
 # Default to an xqueue version that supports RabbitMQ
 xqueue_source_repo: https://github.com/open-craft/xqueue.git
 xqueue_version: opencraft-release/eucalyptus.2


### PR DESCRIPTION
Adds `EDXAPP_ENTERPRISE_ENROLLMENT_API_URL` and `EDXAPP_ENTERPRISE_PUBLIC_ENROLLMENT_API_URL`

to the ansible template, with defaults that will work for appservers like ours that sit behind an ssl-terminating load balancer.

**Dependencies**:

This PR can merge without these others, but requires them to function effectively:

* https://github.com/edx/edx-platform/pull/14671
* https://github.com/edx/edx-enterprise/pull/67
* https://github.com/edx/configuration/pull/3748

**Sandbox URL**:  sandbox is being provisioned.

* LMS: https://pr14671.sandbox.opencraft.hosting/
* Studio: https://studio-pr14671.sandbox.opencraft.hosting/

**Testing instructions**:

1. Create an new OCIM instance using this branch, and these settings:
  * edx-platform: `open-craft:jill/ent-test-public-enrollment-api-url`: https://github.com/edx/edx-platform/pull/14671 + installs https://github.com/edx/edx-enterprise/pull/67 ([compare](https://github.com/open-craft/edx-platform/compare/jill/enterprise-public-enrollment-api-url...jill/ent-test-public-enrollment-api-url))
  * configuration: `open-craft/jill/enterprise-enrollment-api-url`
1. Launch an appserver, and wait for it to provision.
1. Navigate to the LMS Admin, and add an EnterpriseCustomer.
1. Edit the EnterpriseCustomer, and click on Manage Learners
1. Enrol a user into `course-v1:edX+DemoX+Demo_Course`
1. Note that the Course enrolment mode drop-down gets populated with `Audit`.
1. Submit the enrolment, and note that it's accepted by the server.

**Reviewers**
- [ ] @haikuginger 