### PR TITLE
Remove XQueue version pinning.

### DIFF
--- a/instance/templates/instance/ansible/vars.yml
+++ b/instance/templates/instance/ansible/vars.yml
@@ -206,10 +206,6 @@ ECOMMERCE_PAYPAL_RECEIPT_URL: '{{ ECOMMERCE_LMS_URL_ROOT }}/commerce/checkout/re
 ECOMMERCE_PAYPAL_CANCEL_URL: '{{ ECOMMERCE_LMS_URL_ROOT }}/commerce/checkout/cancel/'
 ECOMMERCE_PAYPAL_ERROR_URL: '{{ ECOMMERCE_LMS_URL_ROOT }}/commerce/checkout/error/'
 
-# Default to an xqueue version that supports RabbitMQ
-xqueue_source_repo: https://github.com/open-craft/xqueue.git
-xqueue_version: opencraft-release/eucalyptus.2
-
 # Comprehensive theming
 # EDXAPP_ENABLE_COMPREHENSIVE_THEMING: true
 # EDXAPP_COMPREHENSIVE_THEME_DIRS:

--- a/opencraft/settings.py
+++ b/opencraft/settings.py
@@ -326,7 +326,7 @@ DEFAULT_CONFIGURATION_VERSION = env('DEFAULT_CONFIGURATION_VERSION', default=DEF
 
 # Git ref for stable Open edX release. Used as a default refspec for
 # configuration, edx-platform, forum, notifier, xqueue, and certs when creating production instances.
-OPENEDX_RELEASE_STABLE_REF = env('OPENEDX_RELEASE_STABLE_REF', default='named-release/dogwood.rc')
+OPENEDX_RELEASE_STABLE_REF = env('OPENEDX_RELEASE_STABLE_REF', default='open-release/ficus.1')
 
 # The edx-platform repository used by default for production instances
 STABLE_EDX_PLATFORM_REPO_URL = env(


### PR DESCRIPTION
This was only required for the Eucalyptus release to include [this commit](https://github.com/open-craft/xqueue/commit/7fbb72461b2f9c88f787ddc5ca51dda855735dd4).  Since this is included in the upstream Ficus release, we don't need to pin this anymore.