### PR TITLE
Security update - Django 1.10.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ ddt==1.1.1
 debtcollector==1.9.0
 decorator==4.0.10
 dj-static==0.0.6
-Django==1.10.3
+Django==1.10.7
 -e git+https://github.com/open-craft/django-angular.git@5f3e54f909b925eecb59dc4dd73b6e9fe27e9558#egg=django_angular
 django-appconf==1.0.2
 django-compressor==2.1


### PR DESCRIPTION
Cf https://github.com/open-craft/opencraft/blob/master/requirements.txt#L18

@bradenmacdonald FYI since you are the backup reviewer this week, want to have a look? Note that I haven't tested this, only bumped the version number to get the PR started.

FYI Django 1.11 has also just been released, so we will also need to create a task to upgrade it. https://docs.djangoproject.com/en/1.11/releases/1.11/