### PR TITLE
Make HAProxy only add the Authorization header if it is not present yet.

### DIFF
--- a/instance/templates/instance/haproxy/openedx.conf
+++ b/instance/templates/instance/haproxy/openedx.conf
@@ -2,7 +2,8 @@
     # Backend configuration for {{ domain }}
     stick-table type string len 128 size 20k expire 12h
     stick on req.cook(sessionid)
-    http-request set-header Authorization 'Basic {{ http_auth_info_base64 }}'
+    acl has-authorization req.hdr(Authorization) -m found
+    http-request set-header Authorization 'Basic {{ http_auth_info_base64 }}' unless has-authorization
     {% for server in appservers %}
     server {{ server.name }} {{ server.ip_address }}:80 check
     {% endfor %}


### PR DESCRIPTION
This allows passing OAuth bearer tokens to API endpoints via HAProxy.  The API endpoints are not protected by HTTP basic auth, so we don't need the basic auth credentials for these requests.

#### Testing instructions

It's easiest to test this on existing instances to save the time of deploying a new one.  I suggest testing this on stage.

1. Reconfigure the load balancer from the Django shell:

        lb = LoadBalancingServer.objects.get(accepts_new_backends=True)
        lb.reconfigure()

1. Verify that instances can still be accessed via HAProxy (i.e. by just navigating to the main URL in the browser).  This verifies that the Authorization header is still added in this case.

1. Log in as the staff user on some test instance, navigate to `/admin/oauth2/client` on tha instance and create a new OAuth client.  For the required fields "URL" and "Request URI" enter arbitrary valid URLs (they can be the same).  Save the client id and secret somewhere.

1. Get an OAuth token using

        curl \
            -X POST \
            -d "client_id={client id}&client_secret={client secret}&grant_type=password&username=staff&password=edx" \
            https://{instance domain}/oauth2/access_token/

    Substitute appropriate values for client id, client secret and instance domain.

1. Make an authenticated API call

        curl \
            -H "Authorization:Bearer {auth token}" \
            -H "Content-Type: application/json" \
            https://{instance domain}/api/user/v1/accounts/staff

    and verify that the call succeeds, i.e. you get some JSON back and not a 401.