### PR TITLE
Automate required vagrant plugin installation for any number of plugins.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -9,7 +9,7 @@ def install_plugins(plugins)
     end
   end
 
-  unless not_installed.empty?
+  if not_installed.any?
     puts "The following required plugins must be installed:"
     puts "'#{not_installed.join("', '")}'"
     print "Install? [y]/n: "

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,9 +1,38 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
-unless Vagrant.has_plugin?("vagrant-vbguest")
-  raise "Please install the vagrant-vbguest plugin by running `vagrant plugin install vagrant-vbguest`"
+def install_plugins(plugins)
+  not_installed = []
+  plugins.each do |plugin|
+    unless Vagrant.has_plugin?(plugin)
+      not_installed << plugin
+    end
+  end
+
+  unless not_installed.empty?
+    puts "The following required plugins must be installed:"
+    puts "'#{not_installed.join("', '")}'"
+    print "Install? [y]/n: "
+    unless STDIN.gets.chomp == "n"
+      not_installed.each { |plugin| install_plugin(plugin) }
+    else
+      exit
+    end
+    $? ? continue : ( raise 'Plugin installation failed, see errors above.' )
+  end
 end
+
+def install_plugin(plugin)
+  system("vagrant plugin install #{plugin}")
+end
+
+# If plugins successfully installed, restart vagrant to detect changes.
+def continue
+  exec("vagrant #{ARGV[0]}")
+end
+
+required_plugins = ["vagrant-vbguest"]
+install_plugins(required_plugins)
 
 Vagrant.configure(2) do |config|
   # TODO: Switch back to the official box once it is released


### PR DESCRIPTION
Had some time to kill: to save future users some typing.

In case `vagrant` needs more plugins in the future, one can simply add them to `required_plugins` in `Vagrantfile` and automate installation for all of them (given '`y`').

Because `vagrant` doesn't seem to detect the additional installed plugins mid-run, one has to manually kill the current `vagrant` process and restart it with Ruby's `exec`.