### PR TITLE
Install setuptools to 32 to fix deployment failing

### DIFF
--- a/bin/bootstrap
+++ b/bin/bootstrap
@@ -28,6 +28,7 @@ if [[ $USER == 'vagrant' ]]; then
 fi
 
 # Install python dependencies
+pip install setuptools==32  # This is currently necessary due to this bug: https://github.com/pypa/setuptools/issues/951
 pip install -r requirements.txt
 
 # TODO: Should only be needed for the unofficial vagrant image


### PR DESCRIPTION
See this issue for more information: https://github.com/pypa/setuptools/issues/951

To test this, checkout this branch and run `vagrant provision` to make sure the pip dependencies are installed without throwing a `FileNotFoundError`.

CC @itsjeyd @bradenmacdonald 