### PR TITLE
Update integration tests to use ficus.3.

### DIFF
--- a/instance/tests/integration/factories/instance.py
+++ b/instance/tests/integration/factories/instance.py
@@ -58,8 +58,8 @@ class OpenEdXInstanceFactory(DjangoModelFactory):
     # or a release candidate tag will work.  We point both the edx-platform and the configuration
     # versions to the branch "integration" in our own forks.  These branches are based on the
     # corresponding openedx_release versions from upstream, but can contain custom modifications.
-    openedx_release = 'open-release/ficus.1'
+    openedx_release = 'open-release/ficus.3'
     configuration_source_repo_url = 'https://github.com/open-craft/configuration.git'
     configuration_version = 'integration'
     edx_platform_repository_url = 'https://github.com/open-craft/edx-platform.git'
-    edx_platform_commit = 'opencraft-release/ficus.1'
+    edx_platform_commit = 'opencraft-release/ficus.3'

--- a/opencraft/settings.py
+++ b/opencraft/settings.py
@@ -326,7 +326,7 @@ DEFAULT_CONFIGURATION_VERSION = env('DEFAULT_CONFIGURATION_VERSION', default=DEF
 
 # Git ref for stable Open edX release. Used as a default refspec for
 # configuration, edx-platform, forum, notifier, xqueue, and certs when creating production instances.
-OPENEDX_RELEASE_STABLE_REF = env('OPENEDX_RELEASE_STABLE_REF', default='open-release/ficus.1')
+OPENEDX_RELEASE_STABLE_REF = env('OPENEDX_RELEASE_STABLE_REF', default='open-release/ficus.3')
 
 # The edx-platform repository used by default for production instances
 STABLE_EDX_PLATFORM_REPO_URL = env(


### PR DESCRIPTION
The `opencraft-release/ficus.3` branch includes a fix for the mathplotlib bug which prevents instances from building successfully.

/cc @haikuginger 