### PR TITLE
Remove dj-static

### DIFF
--- a/deploy/requirements.yml
+++ b/deploy/requirements.yml
@@ -21,24 +21,24 @@
 
 - name: backup-to-tarsnap
   src: https://github.com/open-craft/ansible-backup-to-tarsnap
-  version: 3d2f6f982ab02112ede9e39e1553b106e5079b87
+  version: origin/master
 
 - name: common-server
   src: https://github.com/open-craft/ansible-common-server
-  version: 8423f76a12f5ade7bd008efffedfee12f9506259
+  version: origin/master
 
 - name: configure-apt
   src: https://github.com/open-craft/ansible-configure-apt
-  version: 97877cadc7927dab043bff70a1e621af3b277b5f
+  version: origin/master
 
 - name: sanity-checker
   src: https://github.com/open-craft/ansible-sanity-checker/
-  version: 5387389cbb640e125595fd57e5ab787504a9537c
+  version: origin/master
 
 - name: forward-server-mail
   src: https://github.com/open-craft/ansible-forward-server-mail
-  version: c252ef531802fecace6c0173e647e0a0f13df256
+  version: origin/master
 
 - name: opencraft
   src: https://github.com/open-craft/ansible-opencraft
-  version: v0.0.3
+  version: origin/master

--- a/opencraft/wsgi.py
+++ b/opencraft/wsgi.py
@@ -30,10 +30,9 @@ https://docs.djangoproject.com/en/1.8/howto/deployment/wsgi/
 import os
 
 from django.core.wsgi import get_wsgi_application
-from dj_static import Cling
 
 
 # Main ########################################################################
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "opencraft.settings")
-application = Cling(get_wsgi_application())
+application = get_wsgi_application()

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,6 @@ coverage==4.2
 ddt==1.1.1
 debtcollector==1.9.0
 decorator==4.0.10
-dj-static==0.0.6
 Django==1.10.7
 -e git+https://github.com/open-craft/django-angular.git@5f3e54f909b925eecb59dc4dd73b6e9fe27e9558#egg=django_angular
 django-appconf==1.0.2


### PR DESCRIPTION
Since we will start serving static files through NGINX, we can drop dj-static.
I'm still working on this, just sending the PR upfront in case there is anything that should be considered too.

This change is tied to open-craft/ansible-opencraft#7

When we are good to go, I believe we should merge `ansible-opencraft` PR
and then update this PR to make `deploy/requirements.yml` point to the correct version of `ansible-opencraft`. 