### PR TITLE
Add ecommerce URL variables

### DIFF
--- a/instance/templates/instance/ansible/vars.yml
+++ b/instance/templates/instance/ansible/vars.yml
@@ -200,6 +200,8 @@ ECOMMERCE_NGINX_PORT: 80
 ECOMMERCE_SSL_NGINX_PORT: 443
 ECOMMERCE_HOSTNAME: '~{{ instance.ecommerce_domain_nginx_regex }}'
 ECOMMERCE_ECOMMERCE_URL_ROOT: 'https://{{ instance.ecommerce_domain }}'
+EDXAPP_ECOMMERCE_PUBLIC_URL_ROOT: 'https://{{ instance.ecommerce_domain }}'
+EDXAPP_ECOMMERCE_API_URL: 'https://{{ instance.ecommerce_domain }}/api/v2'
 ECOMMERCE_SUPPORT_URL: 'https://{{ instance.domain }}'
 ECOMMERCE_LMS_URL_ROOT: 'https://{{ instance.domain }}'
 ECOMMERCE_COURSE_CATALOG_URL: 'https://{{ instance.discovery_domain }}'


### PR DESCRIPTION
This PR adds additional variables that were missed in the first pass of #202.

Testing: On the `courses.pearsonx.com` instance (where these variables had to be set manually), verify that when selecting the edX Demo Course and the Verified course mode, you're successfully redirected to the ecommerce stack.