### PR TITLE
Revert "Pin setuptools to 32 as a bug workaround."

### DIFF
--- a/bin/bootstrap
+++ b/bin/bootstrap
@@ -28,7 +28,6 @@ if [[ $USER == 'vagrant' ]]; then
 fi
 
 # Install python dependencies
-pip install setuptools==32  # This is currently necessary due to this bug: https://github.com/pypa/setuptools/issues/951
 pip install -r requirements.txt
 
 # TODO: Should only be needed for the unofficial vagrant image


### PR DESCRIPTION
This reverts commit 694c7cc15bd6fd943bbd4b10ea854141ffbd5b65.

This should be merged when the source issue discussed in https://github.com/open-craft/opencraft/pull/205 is resolved.