### PR TITLE
Improve Gandi domain error message

### DIFF
--- a/instance/gandi.py
+++ b/instance/gandi.py
@@ -86,7 +86,7 @@ class GandiAPI():
                 subdomain = '.'.join(labels[:split_index]) or '@'
                 return subdomain, registered_domain
         raise ValueError(
-            'The given domain name does not match any domain registered in the Gandi account.'
+            'The given domain name "{}" does not match any domain registered in the Gandi account.'.format(domain)
         )
 
     def get_zone_id(self, domain):

--- a/instance/tests/test_gandi.py
+++ b/instance/tests/test_gandi.py
@@ -88,8 +88,12 @@ class GandiTestCase(TestCase):
         self.assertEqual(self.api.split_domain_name('sub.domain.test.com'), ('sub.domain', 'test.com'))
         self.assertEqual(self.api.split_domain_name('sub.domain.opencraft.co.uk'), ('sub.domain', 'opencraft.co.uk'))
         self.assertEqual(self.api.split_domain_name('example.com'), ('@', 'example.com'))
-        with self.assertRaises(ValueError):
+        with self.assertRaises(ValueError) as error:
             self.api.split_domain_name('sub.domain.unknown.com')
+        self.assertEqual(
+            str(error.exception),
+            'The given domain name "sub.domain.unknown.com" does not match any domain registered in the Gandi account.'
+        )
 
     def test_get_zone_id(self):
         """


### PR DESCRIPTION
This small PR improved the domain matching error message to include the actual domain name. This makes it easy to see specifically which domains are not in the record list whenever this exception is thrown.

CC @smarnach 