### PR TITLE
Don't shut down instances more than once

### DIFF
--- a/instance/tasks.py
+++ b/instance/tasks.py
@@ -100,7 +100,7 @@ def shut_down_obsolete_pr_sandboxes():
             instance.watchedpullrequest.target_fork_name,
             instance.watchedpullrequest.github_pr_number
         )
-        if pr['state'] == 'closed':
+        if pr['state'] == 'closed' and not instance.is_archived:
             closed_at = github.parse_date(pr['closed_at'])
             now = datetime.now()
             if sufficient_time_passed(closed_at, now, 7):

--- a/instance/tasks.py
+++ b/instance/tasks.py
@@ -100,7 +100,7 @@ def shut_down_obsolete_pr_sandboxes():
             instance.watchedpullrequest.target_fork_name,
             instance.watchedpullrequest.github_pr_number
         )
-        if pr['state'] == 'closed' and not instance.is_archived:
+        if pr['state'] == 'closed' and not instance.ref.is_archived:
             closed_at = github.parse_date(pr['closed_at'])
             now = datetime.now()
             if sufficient_time_passed(closed_at, now, 7):

--- a/instance/tests/test_tasks.py
+++ b/instance/tests/test_tasks.py
@@ -201,7 +201,7 @@ class CleanUpTestCase(TestCase):
         more than once.
         """
         for dummy in range(5):
-            instance = OpenEdXInstanceFactory(i)
+            instance = OpenEdXInstanceFactory()
             instance.ref.is_archived = True
             instance.save()
 

--- a/instance/tests/test_tasks.py
+++ b/instance/tests/test_tasks.py
@@ -194,6 +194,21 @@ class CleanUpTestCase(TestCase):
 
         self.assertEqual(mock_archive.call_count, 0)
 
+    @patch('instance.models.openedx_instance.OpenEdXInstance.archive')
+    def test_shut_down_obsolete_pr_sandboxes_archived(self, mock_archive):
+        """
+        Test that `shut_down_obsolete_pr_sandboxes` does not shut down instances
+        more than once.
+        """
+        for dummy in range(5):
+            instance = OpenEdXInstanceFactory(i)
+            instance.ref.is_archived = True
+            instance.save()
+
+        tasks.shut_down_obsolete_pr_sandboxes()
+
+        self.assertEqual(mock_archive.call_count, 0)
+
     @patch('instance.tasks.terminate_obsolete_appservers_all_instances')
     @patch('instance.tasks.shut_down_obsolete_pr_sandboxes')
     def test_clean_up_task(self, mock_shut_down_sandboxes, mock_terminate_appservers):  # pylint: disable=no-self-use


### PR DESCRIPTION
... when cleaning up obsolete instances.

This is to avoid unnecessarily creating and activating new versions of the Gandi zone file that we are using for opencraft.hosting.

Cf. [OC-2954](https://tasks.opencraft.com/browse/OC-2954)

**Reviewers**

- [x] @pomegranited 