### PR TITLE
Include User-Agent header in requests to GitHub API

### DIFF
--- a/pr_watch/github.py
+++ b/pr_watch/github.py
@@ -43,6 +43,7 @@ logger = logging.getLogger(__name__)
 
 GH_HEADERS = {
     'Authorization': 'token {}'.format(settings.GITHUB_ACCESS_TOKEN),
+    'User-Agent': 'open-craft',
     'Time-Zone': 'UTC',
 }
 
@@ -58,6 +59,7 @@ def get_object_from_url(url):
     """
     logger.info('GET URL %s', url)
     r = requests.get(url, headers=GH_HEADERS)
+    logger.info('Response body: %s', r.text)
     if r.status_code == 404:
         raise ObjectDoesNotExist('404 response from {0}'.format(url))
     r.raise_for_status()


### PR DESCRIPTION
... to satisfy https://developer.github.com/v3/#user-agent-required.

Also add some logging to make debugging easier in the future.

Follows up on https://github.com/open-craft/opencraft/pull/216.

The need for this change surfaced while deploying changes for [OC-2954](https://tasks.opencraft.com/browse/OC-2954) (https://github.com/open-craft/opencraft/pull/217) to stage. (Changes from https://github.com/open-craft/opencraft/pull/216) hadn't been deployed, and so were included in the deployment for OC-2954.) After restarting the workers we were getting a bunch of errors that looked like this:

```
10/Aug/2017 07:37:42 |    ERROR | process=29752 | huey.consumer.Worker      | Unhandled exception in worker thread
Traceback (most recent call last):
  File "/var/www/.virtualenvs/opencraft/lib/python3.5/site-packages/huey/consumer.py", line 151, in process_task
    self.huey.execute(task)
  File "/var/www/.virtualenvs/opencraft/lib/python3.5/site-packages/huey/api.py", line 266, in execute
    result = task.execute()
  File "/var/www/.virtualenvs/opencraft/lib/python3.5/site-packages/huey/api.py", line 560, in execute
    return func(*args, **kwargs)
  File "/var/www/.virtualenvs/opencraft/lib/python3.5/site-packages/huey/contrib/djhuey/__init__.py", line 91, in inner
    return fn(*args, **kwargs)
  File "/var/www/opencraft/pr_watch/tasks.py", line 51, in watch_pr
    for pr in get_pr_list_from_username(username, settings.WATCH_FORK):
  File "/var/www/opencraft/pr_watch/github.py", line 145, in get_pr_list_from_username
    r_pr_list = get_object_from_url('https://api.github.com/search/issues?sort=created&q={}'.format(q))
  File "/var/www/opencraft/pr_watch/github.py", line 63, in get_object_from_url
    r.raise_for_status()
  File "/var/www/.virtualenvs/opencraft/lib/python3.5/site-packages/requests/models.py", line 862, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
requests.exceptions.HTTPError: 403 Client Error: Forbidden for url: https://api.github.com/search/issues?sort=created&q=is:open%20is:pr%20author:mtyaka%20repo:open-craft/edx-platform
```

**Test instructions**

We tested this fix on stage before making this PR, so just access the `screen` session on stage and verify that the output from the workers does not contain errors like the one above.

**Reviewers**

- [x] @UmanShahzad 

CC @pomegranited 