### PR TITLE
Optional rabbitmq on dev vagrant VM

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,11 @@ edit its security group rules to only allow access to VMs in the
 * `DEFAULT_INSTANCE_RABBITMQ_URL`: The RabbitMQ AMQPS URI to be used by instances. E.g.,
   `amqps://rabbitmq.example.com:5671`
 
+It is possible to install and configure rabbitmq to run on the vagrant machine if wanted.
+This is an optional extra dependency which can be installed using `vagrant provision --provision-with rabbitmq`.
+This will add a user and queue locally and can be used with the settings `DEFAULT_INSTANCE_RABBITMQ_URL='amqps://127.0.0.1:5671'`
+and `DEFAULT_RABBITMQ_API_URL='http://ocim:ocim@127.0.0.1:15672'`
+
 ### DNS settings
 
 * `DEFAULT_INSTANCE_BASE_DOMAIN`: Instances are created as subdomains of this domain,

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -25,6 +25,10 @@ Vagrant.configure(2) do |config|
                       privileged: false,
                       keep_color: true
 
+  config.vm.provision 'rabbitmq',
+                      type: 'shell',
+                      path: 'bin/install-rabbit'
+
   config.vm.provider :virtualbox do |vb|
     vb.memory = 1024
     # Allow DNS to work for Ubuntu host

--- a/bin/install-rabbit
+++ b/bin/install-rabbit
@@ -1,0 +1,35 @@
+#!/bin/bash
+# This script installs and configures a rabbitmq server instance in the vagrant
+# development environment, allowing local connections rather than requiring an
+# external server
+
+set -e
+
+# Add the rabbit apt repository key
+wget -O- https://www.rabbitmq.com/rabbitmq-release-signing-key.asc | sudo apt-key add -
+
+
+# install the rabbitmq server
+echo 'deb http://www.rabbitmq.com/debian/ testing main' | sudo tee /etc/apt/sources.list.d/rabbitmq.list
+sudo apt-get update
+sudo apt-get install -y rabbitmq-server
+
+
+# install and configure the rabbitmq admin interface needed by OCIM
+sudo rabbitmq-plugins enable rabbitmq_management
+
+
+# Create an OCIM user and queue
+USERNAME=ocim
+PASSWORD=passw3rd
+VHOST=ocim
+
+sudo rabbitmqctl list_users | grep $USERNAME
+
+if [[ $? ]] ; then
+  echo "User $USERNAME exists"
+else
+  sudo rabbitmqctl add_user $USERNAME $PASSWORD
+  sudo rabbitmqctl add_vhost $VHOST
+  sudo rabbitmqctl set_permissions -p $VHOST $USERNAME ".*" ".*" ".*"
+fi


### PR DESCRIPTION
Adding instructions and helper provisioning script to include a rabbitmq server on the vagrant dev box.

This is useful if you do not have access to an external rabbitmq server.