### PR TITLE
Move instance log data to new API endpoint

### DIFF
--- a/instance/api/instance.py
+++ b/instance/api/instance.py
@@ -29,8 +29,11 @@ from rest_framework.response import Response
 
 from instance.models.instance import InstanceReference
 from instance.models.openedx_appserver import OpenEdXAppServer
-from instance.serializers.instance import (InstanceReferenceBasicSerializer, InstanceReferenceDetailedSerializer,
-                                           InstanceLogSerializer)
+from instance.serializers.instance import (
+    InstanceReferenceBasicSerializer,
+    InstanceReferenceDetailedSerializer,
+    InstanceLogSerializer
+)
 
 
 # Views - API #################################################################

--- a/instance/api/instance.py
+++ b/instance/api/instance.py
@@ -24,11 +24,13 @@ Instance API
 
 from django.db.models import Prefetch
 from rest_framework import viewsets
+from rest_framework.decorators import detail_route
 from rest_framework.response import Response
 
 from instance.models.instance import InstanceReference
 from instance.models.openedx_appserver import OpenEdXAppServer
-from instance.serializers.instance import InstanceReferenceBasicSerializer, InstanceReferenceDetailedSerializer
+from instance.serializers.instance import (InstanceReferenceBasicSerializer, InstanceReferenceDetailedSerializer,
+                                           InstanceLogSerializer)
 
 
 # Views - API #################################################################
@@ -81,3 +83,10 @@ class InstanceViewSet(viewsets.ReadOnlyModelViewSet):
             queryset = queryset.filter(is_archived=False)
         serializer = InstanceReferenceBasicSerializer(queryset, many=True, context={'request': request})
         return Response(serializer.data)
+
+    @detail_route(methods=['get'])
+    def logs(self, request, pk):
+        """
+        Get this Instance's log entries
+        """
+        return Response(InstanceLogSerializer(self.get_object()).data)

--- a/instance/models/instance.py
+++ b/instance/models/instance.py
@@ -105,6 +105,13 @@ class InstanceReference(TimeStampedModel):
         permission = '{}.{}'.format(cls._meta.app_label, "manage_all")
         return user.has_perm(permission)
 
+    @property
+    def log_entries(self):
+        """
+        Convenience method to return all log entries for the Instance this reference is for.
+        """
+        return self.instance.log_entries
+
 
 class Instance(ValidateModelMixin, models.Model):
     """

--- a/instance/serializers/instance.py
+++ b/instance/serializers/instance.py
@@ -98,9 +98,6 @@ class InstanceReferenceBasicSerializer(InstanceReferenceMinimalSerializer):
         # Merge instance details into the resulting dict, but never overwrite existing fields
         for key, val in details.items():
             output.setdefault(key, val)
-        if not self.summary_only:
-            # Add log entries:
-            output['log_entries'] = [LogEntrySerializer(entry).data for entry in obj.instance.log_entries]
         return output
 
 
@@ -110,3 +107,15 @@ class InstanceReferenceDetailedSerializer(InstanceReferenceBasicSerializer):
     more detail.
     """
     summary_only = False
+
+
+class InstanceLogSerializer(serializers.ModelSerializer):
+    """
+    Provide the log entries for an Instance
+    """
+    log_entries = LogEntrySerializer(many=True, read_only=True)
+    log_error_entries = LogEntrySerializer(many=True, read_only=True)
+
+    class Meta:
+        model = InstanceReference
+        fields = ('log_entries', 'log_error_entries',)

--- a/instance/serializers/instance.py
+++ b/instance/serializers/instance.py
@@ -59,6 +59,8 @@ class InstanceReferenceBasicSerializer(InstanceReferenceMinimalSerializer):
     # summary_only: Uses less detailed serializers for related instances
     summary_only = True
 
+    logs_url = serializers.HyperlinkedIdentityField(view_name='api:instance-logs')
+
     class Meta:
         model = InstanceReference
         fields = (
@@ -68,6 +70,7 @@ class InstanceReferenceBasicSerializer(InstanceReferenceMinimalSerializer):
             'created',
             'modified',
             'is_archived',
+            'logs_url',
         )
 
     def serialize_details(self, instance):
@@ -114,8 +117,7 @@ class InstanceLogSerializer(serializers.ModelSerializer):
     Provide the log entries for an Instance
     """
     log_entries = LogEntrySerializer(many=True, read_only=True)
-    log_error_entries = LogEntrySerializer(many=True, read_only=True)
 
     class Meta:
         model = InstanceReference
-        fields = ('log_entries', 'log_error_entries',)
+        fields = ('log_entries', )

--- a/instance/static/html/instance/details.html
+++ b/instance/static/html/instance/details.html
@@ -108,8 +108,11 @@
   </tab>
   <tab heading="Log" active="instance_active_tabs.log_tab">
     <p>This log does not include events from each App Server or VM. Select an App Server on the "App Servers" tab to view those logs.</p>
+    <div ng-if="isFetchingLogs">
+        Loading log...
+    </div>
     <div ng-attr-class="instance-log {{ line.level | lowercase }}"
-         ng-repeat="line in instance.log_entries track by $index">
+         ng-repeat="line in instanceLogs.log_entries track by $index">
       <span class="timestamp">{{ line.created | date:'yyyy-MM-dd HH:mm:ssZ' }}</span>
       <span class="log-level">{{ line.level }}</span>
       <pre>{{ line.text }}</pre>

--- a/instance/static/js/src/instance.js
+++ b/instance/static/js/src/instance.js
@@ -143,6 +143,10 @@ app.controller("Details", ['$scope', '$state', '$stateParams', 'OpenCraftAPI',
             $scope.is_updating_from_pr = false;
             $scope.instance_active_tabs = {};
             $scope.old_appserver_count = 0;
+
+            $scope.instanceLogs = false;
+            $scope.isFetchingLogs = false;
+
             $scope.refresh();
         };
 
@@ -166,6 +170,29 @@ app.controller("Details", ['$scope', '$state', '$stateParams', 'OpenCraftAPI',
                 $scope.is_updating_from_pr = false;
             });
         };
+
+        $scope.fetchLogs = function() {
+            if ($scope.instanceLogs || $scope.isFetchingLogs) {
+                return;
+            }
+            $scope.isFetchingLogs = true;
+            OpenCraftAPI.one("instance", $scope.instance.id).customGET("logs").then(function(logs) {
+                if (typeof logs.log_error_entries === "undefined") {
+                    logs.log_error_entries = [];  // This field is not always present.
+                }
+                $scope.instanceLogs = logs;
+                $scope.isFetchingLogs = false;
+            }, function() {
+                $scope.notify("Unable to load the logs for this appserver.");
+                $scope.isFetchingLogs = false;
+            });
+        };
+
+        $scope.$watch('instance_active_tabs.log_tab', function(tab_open){
+            if (tab_open) {
+                $scope.fetchLogs();
+            }
+        });
 
         $scope.refresh = function() {
             // [Re]load the instance data from the server.

--- a/instance/tests/api/test_instance.py
+++ b/instance/tests/api/test_instance.py
@@ -143,7 +143,7 @@ class InstanceAPITestCase(APITestCase):
         instance.logger.info("info")
         instance.logger.error("error")
 
-        response = self.api_client.get('/api/v1/instance/{pk}/'.format(pk=instance.ref.pk))
+        response = self.api_client.get('/api/v1/instance/{pk}/logs/'.format(pk=instance.ref.pk))
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         expected_list = [


### PR DESCRIPTION
This pull request references OC-2877. It removes log entry information from the `instance/:id` endpoint and moves it into a new `instance/:id/logs` endpoint instead. 

This means that log data will not be loaded by default when viewing an instance detail, thus saving unnecessary data being streamed to the frontend. When a user clicks on the "Logs" tab, the data is loaded at that point from the new endpoint.

**To Test:**

* Set up an OCIM and create some instances
* Verify that all tabs except Logs work as normal
* Click on Logs tab with a browser inspector open to verify that a new network request is made, and that the log data is loaded and displayed in the Logs tab (and a "Loading logs" placeholder message is there until log data arrives).
* See also the API end point for verification (`/api/v1/instance/:id/logs/`)
* Check that from `/api/v1/instance/:id/` you can follow a link to `/api/v1/instance/:id/logs/`