### PR TITLE
Allow to set WORKERS(_LOW_PRIORITY)? from environment.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,8 @@
 
 # Config ######################################################################
 
-WORKERS = 3
-WORKERS_LOW_PRIORITY = 3
+WORKERS ?= 3
+WORKERS_LOW_PRIORITY ?= 3
 SHELL = /bin/bash
 HONCHO_MANAGE := honcho run python3 manage.py
 RUN_JS_TESTS := xvfb-run --auto-servernum jasmine-ci --logs --browser firefox

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -51,7 +51,6 @@ To do this you'll need to:
 Run the playbook
 ----------------
 
-
 1. Install Ansible, e.g. by creating a new Python 2 virtualenv and running
 
         pip install -r requirements.txt
@@ -82,3 +81,18 @@ and run it manually inside a `screen` or `tmux` session:
 4. Run the server and workers: `/var/www/.virtualenvs/opencraft/bin/exec make run WORKERS=5`
 
 5. Detach the `screen` session to log out again, leaving the server running.
+
+Show changes that would be applied to `.env` file
+-------------------------------------------------
+
+To see the difference between the current `.env` file on the server and the
+version that will be created by the ansible playbook, you can use this command
+line:
+
+    ansible-playbook  opencraft.yml \
+        --check --diff --start-at-task="Install the configuration/environment file"
+        -u ubuntu --extra-vars @private.yml -i your.host.name.here,
+
+It will start a dry-run of Ansible in diff mode, starting at the task that
+creates the configuration file.  You can break using Ctrl-C after the diff has
+been shown.

--- a/deploy/requirements.txt
+++ b/deploy/requirements.txt
@@ -1,1 +1,1 @@
-ansible==2.0.1
+ansible==2.3.2.0


### PR DESCRIPTION
This allows to configure the number of workers in the environment, so we can set fixed values for them that don't need to be passed on the `make run` command line.

This PR also adds documentation how to diff the `.env` file on the live server against the version currently in Ansible.  This is useful to make sure that any updates we manually applied to the live server are also in Ansible.  I used this technique to make update the config in Ansible, see open-craft/deployment-secrets-services#26.

The `--start-at-task` flag to `ansible-playbook` is broken in the Ansible version we have been using, so I also updated the Ansible version.  The new version seems to work without any problems.