### PR TITLE
Enable debug toolbar in DEBUG at all pages including admin and api

### DIFF
--- a/opencraft/settings.py
+++ b/opencraft/settings.py
@@ -49,6 +49,8 @@ ALLOWED_HOSTS = env.json('ALLOWED_HOSTS', default=[])
 
 DEBUG = env.bool('DEBUG', default=False)
 
+ENABLE_DEBUG_TOOLBAR = env.bool('ENABLE_DEBUG_TOOLBAR', default=False)
+
 
 # Auth ########################################################################
 
@@ -108,9 +110,14 @@ MIDDLEWARE = (
     'django.middleware.security.SecurityMiddleware',
 )
 
-if DEBUG:
+if DEBUG and ENABLE_DEBUG_TOOLBAR:
     INSTALLED_APPS += ('debug_toolbar',)
     MIDDLEWARE += ('debug_toolbar.middleware.DebugToolbarMiddleware',)
+    # Enable in all pages
+    DEBUG_TOOLBAR_CONFIG = {
+        'SHOW_TOOLBAR_CALLBACK': lambda request: True,
+    }
+
 
 ROOT_URLCONF = 'opencraft.urls'
 

--- a/opencraft/urls.py
+++ b/opencraft/urls.py
@@ -22,6 +22,7 @@ Global URL Patterns
 
 # Imports #####################################################################
 
+from django.conf import settings
 from django.conf.urls import include, url
 from django.contrib import admin
 from django.views.generic.base import RedirectView
@@ -41,3 +42,12 @@ urlpatterns = [
     url(r'^favicon\.ico$', RedirectView.as_view(url='/static/img/favicon/favicon.ico', permanent=False)),
     url(r'^$', views.IndexView.as_view(), name='index'),
 ]
+
+if settings.DEBUG and settings.ENABLE_DEBUG_TOOLBAR:
+    # Enable debug toolbar URLs
+    import debug_toolbar # pylint: disable=wrong-import-position,wrong-import-order
+    # "debug" URL pattern must be before "site" URL pattern.
+    # See https://github.com/jazzband/django-debug-toolbar/issues/529
+    urlpatterns = [
+        url(r'^__debug__/', include(debug_toolbar.urls)),
+    ] + urlpatterns


### PR DESCRIPTION
There's already code to add django-debug-toolbar when `DEBUG==True`, but it's not working (it doesn't show).
- I had to add the setting `SHOW_TOOLBAR_CALLBACK` to force always showing it.
- Then it failed because the URL isn't added, so I added it to urls.py too. Tip from https://github.com/django-debug-toolbar/django-debug-toolbar/issues/529

It's disabled by default, and you can enable it by changing one setting as explained in settings.py