### PR TITLE
Adds variables required for OAuth2 and JWT

### DIFF
--- a/instance/templates/instance/ansible/vars.yml
+++ b/instance/templates/instance/ansible/vars.yml
@@ -13,6 +13,11 @@ COMMON_ENABLE_BASIC_AUTH: true
 COMMON_HTPASSWD_USER: '{{ instance.http_auth_user }}'
 COMMON_HTPASSWD_PASS: '{{ instance.http_auth_pass }}'
 
+# OAuth2 / JWT issuer settings
+COMMON_OAUTH_BASE_URL: "{{ EDXAPP_LMS_ROOT_URL }}"
+COMMON_JWT_SECRET_KEY: "{{ EDXAPP_JWT_SECRET_KEY }}"
+COMMON_JWT_AUDIENCE: 'lms-key'
+
 # edxapp
 EDXAPP_PLATFORM_NAME: "{{ instance.name }}"
 EDXAPP_SITE_NAME: '{{ instance.domain }}'


### PR DESCRIPTION
These are used to determine the "issuer" fields for OAuth and JWT authentication, and the "audience" field for JWT.

Noticed this error reported by the Ginkgo Insights deployments listed below, when trying to authenticate via their Gingko edxapp instances: 
```
Sep 24 11:37:24 ip-172-31-93-161 [service_variant=insights][django.request][env:no_env] ERROR [ip-172-31-93-161  2474] [exception.py:135] - Internal Server Error: /complete/edx-oidc/
Traceback (most recent call last):
  File "/edx/app/insights/venvs/insights/local/lib/python2.7/site-packages/django/core/handlers/exception.py", line 41, in inner
    response = get_response(request)
  File "/edx/app/insights/venvs/insights/local/lib/python2.7/site-packages/django/core/handlers/base.py", line 249, in _legacy_get_response
    response = self._get_response(request)
  File "/edx/app/insights/venvs/insights/local/lib/python2.7/site-packages/django/core/handlers/base.py", line 187, in _get_response
    response = self.process_exception_by_middleware(e, request)
  File "/edx/app/insights/venvs/insights/local/lib/python2.7/site-packages/django/core/handlers/base.py", line 185, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/edx/app/insights/venvs/insights/local/lib/python2.7/site-packages/django/views/decorators/cache.py", line 57, in _wrapped_view_func
    response = view_func(request, *args, **kwargs)
  File "/edx/app/insights/venvs/insights/local/lib/python2.7/site-packages/django/views/decorators/csrf.py", line 58, in wrapped_view
    return view_func(*args, **kwargs)
  File "/edx/app/insights/venvs/insights/local/lib/python2.7/site-packages/social_django/utils.py", line 50, in wrapper
    return func(request, backend, *args, **kwargs)
  File "/edx/app/insights/venvs/insights/local/lib/python2.7/site-packages/social_django/views.py", line 32, in complete
    redirect_name=REDIRECT_FIELD_NAME, *args, **kwargs)
  File "/edx/app/insights/venvs/insights/local/lib/python2.7/site-packages/social_core/actions.py", line 41, in do_complete
    user = backend.complete(user=user, *args, **kwargs)
  File "/edx/app/insights/venvs/insights/local/lib/python2.7/site-packages/social_core/backends/base.py", line 40, in complete
    return self.auth_complete(*args, **kwargs)
  File "/edx/app/insights/venvs/insights/local/lib/python2.7/site-packages/auth_backends/backends.py", line 164, in auth_complete
    user = super(EdXOpenIdConnect, self).auth_complete(*args, **kwargs)
  File "/edx/app/insights/venvs/insights/local/lib/python2.7/site-packages/social_core/utils.py", line 252, in wrapper
    return func(*args, **kwargs)
  File "/edx/app/insights/venvs/insights/local/lib/python2.7/site-packages/social_core/backends/oauth.py", line 394, in auth_complete
    method=self.ACCESS_TOKEN_METHOD
  File "/edx/app/insights/venvs/insights/local/lib/python2.7/site-packages/social_core/backends/open_id_connect.py", line 181, in request_access_token
    self.id_token = self.validate_and_return_id_token(response['id_token'])
  File "/edx/app/insights/venvs/insights/local/lib/python2.7/site-packages/social_core/backends/open_id_connect.py", line 171, in validate_and_return_id_token
    self.validate_claims(id_token)
  File "/edx/app/insights/venvs/insights/local/lib/python2.7/site-packages/auth_backends/backends.py", line 189, in validate_claims
    raise AuthTokenError(self, 'Invalid issuer')
AuthTokenError: Token error: Invalid issuer
```

**JIRA tickets**: OC-3041, OC-3012.

**Merge deadline**: ASAP

**Testing instructions**:

Verifying this issue in a requires setting up an OAuth2 client service to one of the Open edX services, e.g. ecommerce, course discovery, or insights.

**Reviewers**
- [ ] @UmanShahzad or @bdero 