### PR TITLE
Fix lms user creation

### DIFF
--- a/instance/templates/instance/ansible/lms_users.yml
+++ b/instance/templates/instance/ansible/lms_users.yml
@@ -1,3 +1,5 @@
+EDXAPP_SETTINGS: 'openstack'
+
 django_users:
 {% for user in lms_users %}
   - email: '{{ user.email }}'


### PR DESCRIPTION
Fixes LMS superuser creation by setting the `EDXAPP_SETTINGS` ansible variable, which must now be overridden when running the [edx-east/manage_edxapp_users_and_groups.yml](https://github.com/edx/configuration/blob/master/playbooks/edx-east/manage_edxapp_users_and_groups.yml#L80) playbook.

LMS user creation stopped when we shifted to `open-release/ginkgo.1` as our base stable branch, which caused new beta appservers to fail on creation.

**JIRA tickets**: OC-3150

**Merge deadline**: ASAP

**Testing instructions**:

1. Ensure your .env file contains:
```
DEFAULT_CONFIGURATION_REPO_URL='https://github.com/open-craft/configuration' 
DEFAULT_OPENEDX_RELEASE='open-release/ginkgo.1'
DEFAULT_CONFIGURATION_VERSION='opencraft-release/ginkgo.1'

OPENEDX_RELEASE_STABLE_REF='open-release/ginkgo.1'
STABLE_EDX_PLATFORM_COMMIT='opencraft-release/ginkgo.1'
STABLE_CONFIGURATION_VERSION='opencraft-release/ginkgo.1'
```
1. Launch Ocim: `make rundev`
1. Register a new beta instance: http://localhost:5000/registration
1. Ensure that the appserver is created successfully.
1. Ensure that the new edxapp service contains a user whose email address matches your registered user.  You should be able to reset its password and login.

**Reviewers**
- [ ] TBD