### PR TITLE
Protect references to Ansible variables from the Django template engine.

### DIFF
--- a/instance/templates/instance/ansible/swift.yml
+++ b/instance/templates/instance/ansible/swift.yml
@@ -4,8 +4,6 @@ EDXAPP_SETTINGS: 'openstack'
 XQUEUE_SETTINGS: 'openstack_settings'
 
 VHOST_NAME: 'openstack'
-# COMMON_VHOST_ROLE_NAME is deprecated; keeping it around for compatibility
-COMMON_VHOST_ROLE_NAME: '{{ VHOST_NAME }}'
 
 EDXAPP_DEFAULT_FILE_STORAGE: 'swift.storage.SwiftStorage'
 EDXAPP_FILE_UPLOAD_STORAGE_BUCKET_NAME: '{{ container_name }}'
@@ -24,7 +22,9 @@ XQUEUE_SWIFT_USERNAME: '{{ user }}'
 XQUEUE_SWIFT_KEY: '{{ password }}'
 XQUEUE_SWIFT_TENANT_NAME: '{{ tenant }}'
 XQUEUE_SWIFT_AUTH_URL: '{{ auth_url }}'
+{% verbatim %}
 XQUEUE_SWIFT_AUTH_VERSION: '{{ EDXAPP_SWIFT_AUTH_VERSION }}'
+{% endverbatim %}
 XQUEUE_SWIFT_REGION_NAME: '{{ region }}'
 XQUEUE_UPLOAD_BUCKET: '{{ container_name }}'
 XQUEUE_UPLOAD_PATH_PREFIX: 'xqueue'

--- a/instance/templates/instance/ansible/vars.yml
+++ b/instance/templates/instance/ansible/vars.yml
@@ -14,8 +14,10 @@ COMMON_HTPASSWD_USER: '{{ instance.http_auth_user }}'
 COMMON_HTPASSWD_PASS: '{{ instance.http_auth_pass }}'
 
 # OAuth2 / JWT issuer settings
+{% verbatim %}
 COMMON_OAUTH_BASE_URL: "{{ EDXAPP_LMS_ROOT_URL }}"
 COMMON_JWT_SECRET_KEY: "{{ EDXAPP_JWT_SECRET_KEY }}"
+{% endverbatim %}
 COMMON_JWT_AUDIENCE: 'lms-key'
 
 # edxapp
@@ -212,6 +214,7 @@ EDXAPP_ECOMMERCE_API_URL: 'https://{{ instance.ecommerce_domain }}/api/v2'
 ECOMMERCE_SUPPORT_URL: 'https://{{ instance.domain }}'
 ECOMMERCE_LMS_URL_ROOT: 'https://{{ instance.domain }}'
 ECOMMERCE_COURSE_CATALOG_URL: 'https://{{ instance.discovery_domain }}'
+{% verbatim %}
 ECOMMERCE_PLATFORM_NAME: "{{ EDXAPP_PLATFORM_NAME }}"
 # Set your own ECOMMERCE_PAYMENT_PROCESSOR_CONFIG, or update the variables for the appropriate processor:
 # * CyberSource
@@ -231,6 +234,7 @@ ECOMMERCE_PAYPAL_CLIENT_SECRET: 'SET-ME-PLEASE'
 ECOMMERCE_PAYPAL_RECEIPT_URL: '{{ ECOMMERCE_LMS_URL_ROOT }}/commerce/checkout/receipt/'
 ECOMMERCE_PAYPAL_CANCEL_URL: '{{ ECOMMERCE_LMS_URL_ROOT }}/commerce/checkout/cancel/'
 ECOMMERCE_PAYPAL_ERROR_URL: '{{ ECOMMERCE_LMS_URL_ROOT }}/commerce/checkout/error/'
+{% endverbatim %}
 
 # Comprehensive theming
 # EDXAPP_ENABLE_COMPREHENSIVE_THEMING: true


### PR DESCRIPTION
The Ansible variable templates get rendered by two different template engines with similar syntax.  First the whole file is rendered by the Django template engine before being passed on to Ansible.  Ansible then renders the values with the Jinja2 template engine.  The syntax for variable references in both template engines is identical, so all variable references that are meant to be rendered by Jinja2 are already rendered by Django.  Django ignores unknown variables and replaces them by empty strings.

This fix protects all variables that should actually be rendered by Jinja2 with verbatim blocks.