### PR TITLE
Rebuild the forum index from persistent mongo storage

### DIFF
--- a/instance/templates/instance/ansible/mongo.yml
+++ b/instance/templates/instance/ansible/mongo.yml
@@ -9,3 +9,4 @@ FORUM_MONGO_PASSWORD: '{{ pass }}'
 FORUM_MONGO_HOSTS: ['{{ host }}']
 FORUM_MONGO_PORT: {{ port }}
 FORUM_MONGO_DATABASE: '{{ forum_database }}'
+FORUM_REBUILD_INDEX: true


### PR DESCRIPTION
Because we're currently using localhost ElasticSearch for Ocim instances, we need to rebuild the forum index when creating new appservers.

This setting can be removed when we have shared, persistent ElasticSearch storage, but will not harm anything by remaining.

**JIRA tickets**: OC-3205

**Sandbox URL**:

LMS: https://oc3205.sandbox.stage.opencraft.hosting
CMS: https://studio-oc3205.sandbox.stage.opencraft.hosting

**Merge deadline**: ASAP

**Testing instructions**:

1. Spawn a new appserver with `use_ephemeral_storage: False`.
1. Ensure that the `[forum : rebuild elasticsearch indexes]` is run (not skipped).

To verify that the rebuilt index task actually does the job (see [DemoX course on sandbox instance](https://oc3205.sandbox.stage.opencraft.hosting/courses/course-v1:edX+DemoX+Demo_Course/discussion/forum/)):
1. Add some test posts and replies to a course on your new appserver.
1. Spawn and activate a second appserver.
1. Ensure that you can reply to your old posts, and find them via search.

**Reviewers**
- [ ] @haikuginger 