### PR TITLE
To deal with memory issues, default to less edxapp workers.

### DIFF
--- a/instance/templates/instance/ansible/vars.yml
+++ b/instance/templates/instance/ansible/vars.yml
@@ -173,7 +173,12 @@ COMMON_USER_INFO:{% for github_username in github_username_list %}
 {% endif %}
 {% endwith %}
 
-# Workers
+# Gunicorn workers
+EDXAPP_WORKERS:
+  lms: 3
+  cms: 2
+
+# Celery workers
 EDXAPP_WORKER_DEFAULT_STOPWAITSECS: 1200
 
 # Monitoring


### PR DESCRIPTION
We've noted some memory issues that can be solved by reducing the number of LMS/CMS workers.

**Sandbox URL**: TBD - sandbox is being provisioned.

**Testing instructions**:

1. See stage for a new instance (TBD).
1. See its configuration setup and make sure you see:

```yaml
EDXAPP_WORKERS:
  lms: 3
  cms: 2
```