### PR TITLE
[OC-3036] Fixed double quotes issue in OCIM's JSON fields

### DIFF
--- a/instance/admin.py
+++ b/instance/admin.py
@@ -23,6 +23,7 @@ Admin for the instance app
 # Imports #####################################################################
 
 from django.contrib import admin
+from django_extensions.db.fields.json import JSONField
 
 from instance.models.database_server import MySQLServer, MongoDBServer
 from instance.models.instance import InstanceReference, InstanceTag
@@ -32,6 +33,7 @@ from instance.models.openedx_appserver import OpenEdXAppServer
 from instance.models.openedx_instance import OpenEdXInstance
 from instance.models.rabbitmq_server import RabbitMQServer
 from instance.models.server import OpenStackServer
+from instance.widgets import JSONWidget
 
 
 # ModelAdmins #################################################################
@@ -55,6 +57,7 @@ class InstanceTagAdmin(admin.ModelAdmin): # pylint: disable=missing-docstring
 
 class OpenEdXInstanceAdmin(admin.ModelAdmin): # pylint: disable=missing-docstring
     list_display = ('internal_lms_domain', 'name', 'created', 'modified')
+    formfield_overrides = {JSONField: {'widget': JSONWidget}}
 
 
 class OpenEdXAppServerAdmin(admin.ModelAdmin): # pylint: disable=missing-docstring

--- a/instance/tests/test_widgets.py
+++ b/instance/tests/test_widgets.py
@@ -1,0 +1,67 @@
+# -*- coding: utf-8 -*-
+#
+# OpenCraft -- tools to aid developing and hosting free software projects
+# Copyright (C) 2015-2016 OpenCraft <contact@opencraft.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+"""
+Tests Django Widgets
+"""
+import re
+
+from instance.tests.base import TestCase
+from instance.widgets import JSONWidget
+
+
+class JSONWidgetTestCase(TestCase):
+    """
+    Tests the JSONWidget class.
+    """
+
+    def setUp(self):
+        self.html_front = re.compile(r'^.+?\>')
+        self.html_back = re.compile(r'\<.+?\>$')
+
+    def _strip_html(self, html_text):
+        """
+        Strips the front and end off an HTML string.
+        """
+        front_match = self.html_front.search(html_text).group()
+        back_match = self.html_back.search(html_text).group()
+        cleaned = html_text.replace(front_match, '')
+        cleaned = cleaned.replace(back_match, '')
+        return cleaned
+
+    def test_render_string_json(self):
+        """
+        Tests rendering a string into json.
+        """
+        data = '{"valid": "json"}'
+        widget = JSONWidget()
+        result = widget.render("test", data)
+        cleaned = self._strip_html(result)
+        expected = '\r\n{&quot;valid&quot;: &quot;json&quot;}'
+        self.assertEqual(expected, cleaned)
+
+    def test_render_dict_json(self):
+        """
+        Tests rendering a python dictionary into json.
+        """
+        data = {"valid": "json"}
+        widget = JSONWidget()
+        result = widget.render("test", data)
+        cleaned = self._strip_html(result)
+        expected = '\r\n{&quot;valid&quot;: &quot;json&quot;}'
+        self.assertEqual(expected, cleaned)

--- a/instance/widgets.py
+++ b/instance/widgets.py
@@ -1,9 +1,37 @@
+# -*- coding: utf-8 -*-
+#
+# OpenCraft -- tools to aid developing and hosting free software projects
+# Copyright (C) 2015-2016 OpenCraft <contact@opencraft.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+"""
+Django widgets
+"""
 from django.forms import Textarea
 from django.core.serializers.json import DjangoJSONEncoder
 
 
 class JSONWidget(Textarea):
+    """
+    A widget for displaying and encoding JSON correctly.
+    """
+
     def render(self, name, value, attrs=None):
+        """
+        Renders the json correctly.
+        """
         if not isinstance(value, str):
             value = DjangoJSONEncoder().encode(value)
         return super(JSONWidget, self).render(name, value, attrs)

--- a/instance/widgets.py
+++ b/instance/widgets.py
@@ -26,6 +26,11 @@ from django.core.serializers.json import DjangoJSONEncoder
 class JSONWidget(Textarea):
     """
     A widget for displaying and encoding JSON correctly.
+
+    Note:
+    This widget is only needed until a postgresql upgrade occurs and
+    the django_extensions JSONField is replaced with the Django field.
+
     """
 
     def render(self, name, value, attrs=None):

--- a/instance/widgets.py
+++ b/instance/widgets.py
@@ -1,0 +1,9 @@
+from django.forms import Textarea
+from django.core.serializers.json import DjangoJSONEncoder
+
+
+class JSONWidget(Textarea):
+    def render(self, name, value, attrs=None):
+        if not isinstance(value, str):
+            value = DjangoJSONEncoder().encode(value)
+        return super(JSONWidget, self).render(name, value, attrs)


### PR DESCRIPTION
This pull request fixes a double quotes json bug that occurs when adding a new application instance on OCIM. This fixes an issue with deserializing the django_extensions library's JSONField where invalid json would be created.


**JIRA tickets**: OC-3036

**Dependencies**: None

**Sandbox URL**: TBD - sandbox is being provisioned.

**Merge deadline**: "None" 

**Testing instructions**:

1. Open up a running version of OCIM with this pull request. 
2. Go to the django admin.
3. Attempt to add a new "Open edX Instances"
4. Scrolling down "Openstack server flavor" and "Openstack server base image" contain valid json where all string values are encased in double quotes rather than single quotes.
5. Put in valid values for all required fields.
6. Save. There should be no exceptions that occur.

**Author notes and concerns**:

1. In the long run it is probably better to use Django's own JSONField, but that requires upgrading postgresql's version. For now this works.

**Reviewers**
- [ ] mtyaka
