### PR TITLE
Fix error message when VM creation times out

### DIFF
--- a/instance/models/server.py
+++ b/instance/models/server.py
@@ -214,6 +214,7 @@ class Server(ValidateModelMixin, TimeStampedModel):
         # to avoid the possibility of entering an infinite loop (if timeout is negative)
         # or reaching the timeout right away (if timeout is zero)
         assert timeout > 0, "Timeout must be greater than 0 to be able to do anything useful"
+        initial_timeout = timeout
 
         self.logger.info('Waiting to reach status from which we can proceed...')
 
@@ -235,8 +236,8 @@ class Server(ValidateModelMixin, TimeStampedModel):
 
         # If we get here, this means we've reached the timeout
         raise TimeoutError(
-            "Waited {minutes:.2f} to reach appropriate status, and got nowhere. "
-            "Aborting with a status of {status}.".format(minutes=timeout / 60, status=self.status.name)
+            "Waited {minutes:.2f} minutes to reach appropriate status, and got nowhere. "
+            "Aborting with a status of {status}.".format(minutes=initial_timeout / 60, status=self.status.name)
         )
 
     def save(self, *args, **kwargs):

--- a/instance/tests/models/test_server.py
+++ b/instance/tests/models/test_server.py
@@ -253,9 +253,10 @@ class OpenStackServerTestCase(TestCase):
             server._status_to_building()
         mock_update_status.side_effect = update_status
 
-        with self.assertRaises(TimeoutError):
+        with self.assertRaises(TimeoutError) as timeout_error:
             server.sleep_until(lambda: server.status.accepts_ssh_commands, timeout=1)
             self.assertEqual(mock_sleep.call_count, 1)
+            self.assertIn("Waited 0.01", timeout_error.exception)
 
     def test_sleep_until_invalid_timeout(self):
         """


### PR DESCRIPTION
This fixes the message logged when VM creation times out.
The timeout counter was used to generate the error message and would always read 0, since it was decremented until 0 to check for the timeout.

**JIRA tickets**: OC-3354

**Testing instructions**:

1. I've added a unit test to check this error message, not sure if there's a way to trigger a build to timeout.

**Reviewers**
- [ ] (UmanShahzad )