### PR TITLE
Fix the "Launch new app server" button

### DIFF
--- a/instance/static/js/src/instance.js
+++ b/instance/static/js/src/instance.js
@@ -142,7 +142,7 @@ app.controller("Details", ['$scope', '$state', '$stateParams', 'OpenCraftAPI',
             $scope.is_spawning_appserver = false;
             $scope.is_updating_from_pr = false;
             $scope.instance_active_tabs = {};
-            $scope.old_appserver_count = 0;
+            $scope.old_appserver_count = 0; // Remembers number of servers to detect when a new one appears
 
             $scope.instanceLogs = false;
             $scope.isFetchingLogs = false;
@@ -206,12 +206,12 @@ app.controller("Details", ['$scope', '$state', '$stateParams', 'OpenCraftAPI',
             // [Re]load the instance data from the server.
             return OpenCraftAPI.one("instance", $stateParams.instanceId).get().then(function(instance) {
                 $scope.instance = instance;
-                if (instance.appservers.length > $scope.old_appserver_count) {
+                if (instance.appserver_count > $scope.old_appserver_count) {
                     // There is a new AppServer. If we were expecting one, it is here now.
                     // So stop animations and re-enable the "Launch new AppServer" button.
                     $scope.is_spawning_appserver = false;
                 }
-                $scope.old_appserver_count = instance.appservers.length;
+                $scope.old_appserver_count = instance.appserver_count;
             });
         };
 

--- a/instance/tests/js/instance_app_spec.js
+++ b/instance/tests/js/instance_app_spec.js
@@ -233,6 +233,7 @@ describe('Instance app', function () {
                 const mockAppServer = {"id": 8, };
                 instanceDetail.newest_appserver = mockAppServer;
                 instanceDetail.appservers.push(mockAppServer);
+                instanceDetail.appserver_count = instanceDetail.appservers.length;
                 swampdragon.sendChannelMessage({type: "openedx_appserver_update", instance_id: instanceDetail.id});
                 flushHttpBackend();
                 expect($scope.is_spawning_appserver).toBe(false);


### PR DESCRIPTION
This fixes a bug where the button was left disabled.

# Testing instructions

1. I suggest you apply this patch to disable the spawning of appservers and to make testing faster 
```
modified   instance/models/openedx_instance.py
@@ -172,7 +172,7 @@ class OpenEdXInstance(DomainNameInstance, LoadBalancedInstance, OpenEdXAppConfig
 
         Returns the ID of the new AppServer on success or None on failure.
         """
-        if not self.load_balancing_server:
+        if False and not self.load_balancing_server:
             self.load_balancing_server = LoadBalancingServer.objects.select_random()
             self.save()
             self.reconfigure_load_balancer()
@@ -180,10 +180,11 @@ class OpenEdXInstance(DomainNameInstance, LoadBalancedInstance, OpenEdXAppConfig
         # We unconditionally set the DNS records here, though this would only be strictly needed
         # when the first AppServer is spawned.  However, there is no easy way to tell whether the
         # DNS records have already been successfully set, and it doesn't hurt to alway do it.
-        self.set_dns_records()
+        if False:
+            self.set_dns_records()
 
         # Provision external databases:
-        if not self.use_ephemeral_databases:
+        if False and not self.use_ephemeral_databases:
             # TODO: Use db row-level locking to ensure we don't get any race conditions when creating these DBs.
             # Use select_for_update(nowait=True) to lock this object's row, then do these steps, then refresh_from_db
             self.logger.info('Provisioning MySQL database...')
@@ -197,8 +198,8 @@ class OpenEdXInstance(DomainNameInstance, LoadBalancedInstance, OpenEdXAppConfig
 
         app_server = self._create_owned_appserver()
 
-        if app_server.provision():
-            self.logger.info('Provisioned new app server, %s', app_server.name)
+        if True or app_server.provision():
+            self.logger.info('Provisioned new app server [BUENO, NO…), %s', app_server.name)
             self.successfully_provisioned = True
             self.save()
             return app_server.pk

```
2. Go to an instance with 0 appservers
3. Click the the „Launch new appserver“, wait, reclick (it should be reclickable)
4. See it advance in the special cases: 0→1, 4→5, 5→6, and after 5.  (5 is special because the list is limited to 5).
