### PR TITLE
Catch `EndpointNotFound` error for getting server status update.

### DIFF
--- a/instance/models/server.py
+++ b/instance/models/server.py
@@ -359,8 +359,10 @@ class OpenStackServer(Server):
                 # server must have been terminated.
                 self.logger.debug('Server does not exist anymore: %s', self)
                 self._status_to_terminated()
-            except (requests.RequestException, novaclient.exceptions.ClientException):
-                self.logger.debug('Could not reach the OpenStack API')
+            except (requests.RequestException,
+                    novaclient.exceptions.ClientException,
+                    novaclient.exceptions.EndpointNotFound) as exc:
+                self.logger.debug('Could not reach the OpenStack API due to %s', exc)
                 if self.status != Status.Unknown:
                     self._status_to_unknown()
             else:
@@ -390,8 +392,8 @@ class OpenStackServer(Server):
                 key_name=key_name,
                 **kwargs
             )
-        except novaclient.exceptions.ClientException as e:
-            self.logger.error('Failed to start server: %s', e)
+        except (novaclient.exceptions.ClientException, novaclient.exceptions.EndpointNotFound) as exc:
+            self.logger.error('Failed to start server: %s', exc)
             self._status_to_build_failed()
         else:
             self.openstack_id = os_server.id
@@ -434,3 +436,5 @@ class OpenStackServer(Server):
             self.os_server.delete()
         except novaclient.exceptions.NotFound:
             self.logger.error('Error while attempting to terminate server: could not find OS server')
+        except (novaclient.exceptions.ClientException, novaclient.exceptions.EndpointNotFound) as exc:
+            self.logger.error('Unable to reach the OpenStack API due to %s', exc)

--- a/instance/tests/models/test_openedx_storage_mixins.py
+++ b/instance/tests/models/test_openedx_storage_mixins.py
@@ -185,7 +185,10 @@ class SwiftContainerInstanceTestCase(TestCase):
             'SWIFT_LOG_SYNC_REGION_NAME': instance.swift_openstack_region,
             'COMMON_OBJECT_STORE_LOG_SYNC_BUCKET': instance.swift_container_name,
         }
-        ansible_vars = appserver.configuration_settings
+        # Replace any \' occurrences because some settings may have it while we do a blanket assertion without it.
+        # For example: we assert "EDXAPP_SWIFT_TENANT_NAME: 9999999999" is in `ansible_vars`, which would have
+        # "EDXAPP_SWIFT_TENANT_NAME: \'9999999999\'", causing a mismatch unless we strip the \'.
+        ansible_vars = str(appserver.configuration_settings).replace("\'", '')
         for ansible_var, value in expected_settings.items():
             if expected:
                 self.assertIn('{}: {}'.format(ansible_var, value), ansible_vars)


### PR DESCRIPTION
While testing the new region in OVH, we're having to use a new project with new creds that Ocim uses for both spawning new appservers and getting appserver information for currently running appservers. Since the currently running appservers are in the old region and project that require a different set of credentials, we get errors when attempting to access their detail view. This is a tiny patch to catch that error and log it to handle the case gracefully, until we improve Ocim with the ability to handle multi-OpenStack-project deployments.

*Testing instructions:*

1. On stage, don't be on this branch, and make sure the `.env` file contains the new OpenStack credentials for all `OPENSTACK_X` variables (i.e. user/pass/tenant/region).
2. See an instance that is setup to use the new region (i.e. 'Theme Academy'). Click on the older active instance and notice you get an error message (top right, or for a traceback see logs) when clicking on it to see the detail view.
3. With this patch, see that clicking on it does not raise an error.