### PR TITLE
Add setting to avoid memory leak, and add comment about number of workers

### DIFF
--- a/instance/models/mixins/openedx_config.py
+++ b/instance/models/mixins/openedx_config.py
@@ -206,7 +206,11 @@ class OpenEdXConfigMixin(models.Model):
             },
 
             # Restart workers regularly to work around a memory leak
-            "EDXAPP_LMS_MAX_REQ": 80000,
+            # Tailor the max_requests number to suit the average request load on the server.
+            # e.g if the instance receives an average of around 42000 requests per day,
+            # with 10% for static assets, restarting after 20000 requests means
+            # restarting each of the 4 LMS workers about every 2-3 days.
+            "EDXAPP_LMS_MAX_REQ": 20000,
 
             # Celery workers
             "EDXAPP_WORKER_DEFAULT_STOPWAITSECS": 1200,

--- a/instance/models/mixins/openedx_config.py
+++ b/instance/models/mixins/openedx_config.py
@@ -198,10 +198,15 @@ class OpenEdXConfigMixin(models.Model):
             },
 
             # Gunicorn workers
+            # By default, the number of workers is num_cores*4 for LMS, num_cores*2 for CMS,
+            # which turns out to be too much.
             "EDXAPP_WORKERS": {
                 "lms": 3,
                 "cms": 2,
             },
+
+            # Restart workers regularly to work around a memory leak
+            "EDXAPP_LMS_MAX_REQ": 80000,
 
             # Celery workers
             "EDXAPP_WORKER_DEFAULT_STOPWAITSECS": 1200,


### PR DESCRIPTION
Steps taken to alleviate memory-related performance issues and errors occurring since the Ginkgo upgrade.

Note that 80000 is an arbitrary number that should restart workers every few days. With 3 LMS this gives 240k requests, +10% static 260k, this means that only after 260k requests will a worker restart, this can be 6 days if 40k requests/day, 12 days if 20k requests/day, etc.

An alternative solution would be to do this change in the `configuration` branch instead of Ocim.

## Testing
- deploy an appserver in an instance that has already appservers 
- check that the new setting has been correctly applied to the new appserver (but not changed in the old ones)

## Reviewers
- [ ] @kaizoku 