### PR TITLE
Use `cached_db` session engine to persist sessions

### DIFF
--- a/instance/models/mixins/openedx_config.py
+++ b/instance/models/mixins/openedx_config.py
@@ -161,7 +161,8 @@ class OpenEdXConfigMixin(models.Model):
 
             # Available as ENV_TOKENS in the django setting files.
             "EDXAPP_ENV_EXTRA": {
-                "LANGUAGE_CODE": 'en'
+                "LANGUAGE_CODE": 'en',
+                "SESSION_ENGINE": 'django.contrib.sessions.backends.cached_db',
             },
 
             # Features


### PR DESCRIPTION
Switch to using ``django.contrib.sessions.backends.cached_db``  for sessions so redeploying an Instance doesn't lead to expired sessions. 

**Merge deadline**: ASAP

**Testing instructions**:
1. Deploy an instance using an Ocim with this path
2. Sessions running on that AppServer for that instance should persist as a new AppServer is launched, or if the running AppServer is restarted.