### PR TITLE
WIP: New application to periodically build edx/edx-platform, and notification system when deployment fails

### DIFF
--- a/instance/emails.py
+++ b/instance/emails.py
@@ -1,0 +1,94 @@
+# -*- coding: utf-8 -*-
+#
+# OpenCraft -- tools to aid developing and hosting free software projects
+# Copyright (C) 2015-2016 OpenCraft <contact@opencraft.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+"""
+Send notification emails when certain deployment events happen.
+"""
+
+import traceback
+
+from functools import wraps
+from django.conf import settings
+from django.core.mail import send_mail
+from django.template.loader import get_template
+
+def send_emails_on_deployment_failure(method):
+    """
+    Decorator around spawn_appserver that catches all the emited exceptions and notifies by email
+    when it detects that a server deployment failed because of infrastructure problems.
+    It doesn't change spawn_server's behaviour (it will still raise exceptions on error).
+    It is done as a decorator to separate the e-mail code from the server-spawning code.
+
+    Different instances might have different e-mail requirements. E.g. an instance that builds the 'master'
+    branch of edx/edx-platform will send an e-mail to edX devops in case of failure.
+    In a future version, we could detect the 'owner' of the instance (e.g. the person who created the PR) and notify
+    them by e-mail when a deployment finished with or without error.
+    """
+    @wraps(method)
+    def wrapper(self, *args, **kwds): #pylint: disable=missing-docstring
+
+        try:
+            result = method(self, *args, **kwds)
+        except Exception as e:
+            # This means that the deployment failed due to infrastructure problems (which raise exceptions), e.g.
+            # OVH down, or an incorrect MySQL/MongoDB login/password, etc.
+            # Notify OpenCraft
+            if settings.INFRASTRUCTURE_DEPLOYMENT_PROBLEMS_EMAIL:
+                stacktrace = traceback.format_exc()
+                context = {
+                    'instance': self,
+                    'exception': e,
+                    'exception_type': e.__class__.__name__,
+                    'stacktrace': stacktrace,
+                }
+                subject = get_template('instance/emails/infrastructure_deployment_error_subject.txt').render(context)
+                subject = ''.join(subject.splitlines())
+                text = get_template('instance/emails/infrastructure_deployment_error_body.txt').render(context)
+                sender = settings.DEFAULT_FROM_EMAIL
+                dest = [settings.INFRASTRUCTURE_DEPLOYMENT_PROBLEMS_EMAIL]
+                send_mail(subject, text, sender, dest)
+
+            raise
+
+        if not result:
+            # This means that the deployment failed not due to infrastructure problems (which raise exceptions) but
+            # due to the Open edX ansible playbook not finishing correctly.
+            # Notify OpenCraft, and in the case of building edx/edx-platform's master notify upstream too
+
+            # One of our instances is for CI of edx/edx-platform and a failure on it must send e-mail to upstream devops
+            is_upstream_edx_build = self.internal_lms_domain.startswith('master.') and \
+                self.name.startswith('Integration') and \
+                'edx/edx-platform' in self.edx_platform_repository_url and \
+                self.edx_platform_commit == 'master'
+
+            if settings.OPENEDX_DEPLOYMENT_PROBLEMS_EMAIL:
+                context = { 'instance': self }
+                subject = get_template('instance/emails/openedx_deployment_error_subject.txt').render(context)
+                subject = ''.join(subject.splitlines())
+                text = get_template('instance/emails/openedx_deployment_error_body.txt').render(context)
+                sender = settings.DEFAULT_FROM_EMAIL
+                dest = [settings.OPENEDX_DEPLOYMENT_PROBLEMS_EMAIL]
+                if is_upstream_edx_build and settings.INFRASTRUCTURE_DEPLOYMENT_PROBLEMS_EMAIL:
+                    dest.append(settings.INFRASTRUCTURE_DEPLOYMENT_PROBLEMS_EMAIL)
+
+                send_mail(subject, text, sender, dest)
+
+        return result
+
+    return wrapper

--- a/instance/emails.py
+++ b/instance/emails.py
@@ -28,6 +28,7 @@ from django.conf import settings
 from django.core.mail import send_mail
 from django.template.loader import get_template
 
+
 def send_emails_on_deployment_failure(method):
     """
     Decorator around spawn_appserver that catches all the emited exceptions and notifies by email
@@ -41,14 +42,14 @@ def send_emails_on_deployment_failure(method):
     them by e-mail when a deployment finished with or without error.
     """
     @wraps(method)
-    def wrapper(self, *args, **kwds): #pylint: disable=missing-docstring
+    def wrapper(self, *args, **kwds):  #pylint: disable=missing-docstring
 
         try:
             result = method(self, *args, **kwds)
         except Exception as e:
             # This means that the deployment failed due to infrastructure problems (which raise exceptions), e.g.
             # OVH down, or an incorrect MySQL/MongoDB login/password, etc.
-            # Notify OpenCraft
+            # Notify OpenCraft.  FIXME here and below, don't mention OpenCraft by name but say ~~~ "the devops team"
             if settings.INFRASTRUCTURE_DEPLOYMENT_PROBLEMS_EMAIL:
                 stacktrace = traceback.format_exc()
                 context = {

--- a/instance/models/openedx_instance.py
+++ b/instance/models/openedx_instance.py
@@ -29,6 +29,7 @@ from django.template import loader
 from django.utils import timezone
 
 from instance import gandi
+from instance.emails import send_emails_on_deployment_failure
 from instance.logging import log_exception
 from instance.signals import appserver_spawned
 from instance.models.appserver import Status as AppServerStatus
@@ -265,6 +266,7 @@ class OpenEdXInstance(
 
         return self._create_owned_appserver()
 
+    @send_emails_on_deployment_failure
     @log_exception
     def spawn_appserver(self,
                         mark_active_on_success=False,

--- a/instance/templates/instance/emails/infrastructure_deployment_error_body.txt
+++ b/instance/templates/instance/emails/infrastructure_deployment_error_body.txt
@@ -1,0 +1,10 @@
+Something failed in our infrastructure (OVH, OpenStack) while spawning an appserver for instance "{{ instance }}" (ID {{ instance.id }})
+Infrastructure errors usually happen before starting Open edX's ansible playbook.
+
+Exception:
+{{exception_type}}: {{exception}}
+
+Stack trace:
+{% autoescape off %}
+{{stacktrace}}
+{% endautoescape %}

--- a/instance/templates/instance/emails/infrastructure_deployment_error_subject.txt
+++ b/instance/templates/instance/emails/infrastructure_deployment_error_subject.txt
@@ -1,0 +1,2 @@
+Infrastructure error {{ exception_type }} when deploying appserver for {{ instance.name }}
+

--- a/instance/templates/instance/emails/openedx_deployment_error_body.txt
+++ b/instance/templates/instance/emails/openedx_deployment_error_body.txt
@@ -1,0 +1,3 @@
+The appserver failed to deploy while running the ansible playbook for instance "{{ instance.name }}" (ID {{instance.id}}).
+
+Check the log for the latest appserver in Ocim's admin.

--- a/instance/templates/instance/emails/openedx_deployment_error_subject.txt
+++ b/instance/templates/instance/emails/openedx_deployment_error_subject.txt
@@ -1,0 +1,1 @@
+Deployment appserver failure (playbook failed) for instance {{ instance.name }}

--- a/opencraft/settings.py
+++ b/opencraft/settings.py
@@ -517,6 +517,11 @@ EMAIL_SUBJECT_PREFIX = env('EMAIL_SUBJECT_PREFIX', default='[OpenCraft] ')
 # Destination e-mail for notifications like "The user changed the logo"
 VARIABLES_NOTIFICATION_EMAIL = env('VARIABLES_NOTIFICATION_EMAIL', default=None)
 
+# Destination e-mail for notifications like "OVH failed when deploying a server"
+INFRASTRUCTURE_DEPLOYMENT_PROBLEMS_EMAIL = env('INFRASTRUCTURE_DEPLOYMENT_PROBLEMS_EMAIL', default=None)
+# Destination e-mail for notifications like "The ansible playbook to deploy Open edX failed"
+OPENEDX_DEPLOYMENT_PROBLEMS_EMAIL = env('OPENEDX_DEPLOYMENT_PROBLEMS_EMAIL', default=None)
+
 # SMTP configuration
 EMAIL_HOST = env('EMAIL_HOST', default='localhost')
 EMAIL_PORT = env('EMAIL_PORT', default=25)

--- a/opencraft/settings.py
+++ b/opencraft/settings.py
@@ -82,6 +82,7 @@ LOCAL_APPS = (
     'instance',
     'email_verification',
     'pr_watch',
+    'periodic_builds',
     'userprofile',
     'registration',
     'reports',

--- a/opencraft/settings.py
+++ b/opencraft/settings.py
@@ -517,6 +517,7 @@ EMAIL_SUBJECT_PREFIX = env('EMAIL_SUBJECT_PREFIX', default='[OpenCraft] ')
 # Destination e-mail for notifications like "The user changed the logo"
 VARIABLES_NOTIFICATION_EMAIL = env('VARIABLES_NOTIFICATION_EMAIL', default=None)
 
+# FIXME consider renaming these variables, or at least document them. One (infrastructure) is due to devops problems here, the other one is due to the upstream playbook or code. The former should notify us, the latter should notify edX. (Also check that they're correctly used in the code)
 # Destination e-mail for notifications like "OVH failed when deploying a server"
 INFRASTRUCTURE_DEPLOYMENT_PROBLEMS_EMAIL = env('INFRASTRUCTURE_DEPLOYMENT_PROBLEMS_EMAIL', default=None)
 # Destination e-mail for notifications like "The ansible playbook to deploy Open edX failed"

--- a/periodic_builds/__init__.py
+++ b/periodic_builds/__init__.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+#
+# OpenCraft -- tools to aid developing and hosting free software projects
+# Copyright (C) 2015-2018 OpenCraft <contact@opencraft.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+"""
+Periodic Builds app
+"""
+
+default_app_config = 'periodic_builds.apps.PeriodicBuildsAppConfig'

--- a/periodic_builds/apps.py
+++ b/periodic_builds/apps.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+#
+# OpenCraft -- tools to aid developing and hosting free software projects
+# Copyright (C) 2015-2018 OpenCraft <contact@opencraft.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+"""
+AppConfig for the periodic builds app
+"""
+from django.apps import AppConfig
+
+
+class PeriodicBuildsAppConfig(AppConfig):
+    """
+    AppConfig for the periodic builds app
+    """
+    name = 'periodic_builds'
+    verbose_name = 'Periodic Builds'

--- a/periodic_builds/tasks.py
+++ b/periodic_builds/tasks.py
@@ -62,7 +62,7 @@ def deploy_edx_edxplatform():
 
     instance, created = OpenEdXInstance.objects.get_or_create(
         internal_lms_domain=generate_internal_lms_domain('master'),
-        # github_admin_organizations=['open-craft'], # FIXME reenable, but it needs GitHub user with API access to it
+        # github_admin_organizations=['open-craft'], # FIXME reenable, but it needs a GitHub user with API access to it
         use_ephemeral_databases=False, # FIXME this is causing a problem with SWIFT because the "openstack" role is not in edx_sandbox.yml; see discovery document. Setting it to True probably avoids the error
         edx_platform_repository_url='https://github.com/edx/edx-platform',
         configuration_source_repo_url='https://github.com/edx/configuration',
@@ -72,9 +72,16 @@ def deploy_edx_edxplatform():
         deploy_simpletheme=True, # FIXME add extra configuration variables that actually change some color
         #mongodb_server=mongodb_server.pk, # FIXME remove, see above
     )
-    # Name is set separately because it's stored in InstanceReference
-    instance.name = 'Integration - Open edX master periodic build'
+    if created:
+        # Name is set separately because it's stored in InstanceReference
+        instance.name = 'Integration - Open edX master periodic build'
+        instance.save()
 
+    # There is a wrapper around spawn_appserver that will check the build result and will send e-mails,
+    # see in send_emails_on_deployment_failure
     spawn_appserver(instance.ref.pk, mark_active_on_success=False, num_attempts=2)
 
-    # FIXME check exit status, maybe in another task with smaller interval
+
+# FIXME add another function to test other branches:
+# "cf OC-3150 – also add a second VM run that checks the stable branches used for beta instances are still working. Be sure to include an additional test lms_user, to mimic the beta instance creation logic."
+# But first finish deploy_edx_platform and make it correctly deploy

--- a/periodic_builds/tasks.py
+++ b/periodic_builds/tasks.py
@@ -52,16 +52,9 @@ def deploy_edx_edxplatform():
     Because a deployment can take up to 2 hours, don't run this task more often than that, or else you'll have appserver overflow.
     """
 
-    # Find suitable MongoDB server to avoid choosing one randomly
-    # FIXME probably delete this part, we should not hardcode values. Check whether we need to tell which server to use vs. when it's randomly selected (the default) and decide whether to use this code or not
-    # try:
-    #     mongodb_server = MongoDBServer.objects.get(name="OCIM Default")
-    # except MongoDBServer.DoesNotExist:
-    #     mongodb_server = select_random_mongodb_server()
-
 
     instance, created = OpenEdXInstance.objects.get_or_create(
-        internal_lms_domain=generate_internal_lms_domain('master'),
+        internal_lms_domain=generate_internal_lms_domain('master'), # FIXME just pass subdomain='master' or similar
         # github_admin_organizations=['open-craft'], # FIXME reenable, but it needs a GitHub user with API access to it
         use_ephemeral_databases=False, # FIXME this is causing a problem with SWIFT because the "openstack" role is not in edx_sandbox.yml; see discovery document. Setting it to True probably avoids the error
         edx_platform_repository_url='https://github.com/edx/edx-platform',
@@ -70,7 +63,6 @@ def deploy_edx_edxplatform():
         edx_platform_commit='master',
         openedx_release='master',
         deploy_simpletheme=True, # FIXME add extra configuration variables that actually change some color
-        #mongodb_server=mongodb_server.pk, # FIXME remove, see above
     )
     if created:
         # Name is set separately because it's stored in InstanceReference
@@ -79,7 +71,7 @@ def deploy_edx_edxplatform():
 
     # There is a wrapper around spawn_appserver that will check the build result and will send e-mails,
     # see in send_emails_on_deployment_failure
-    spawn_appserver(instance.ref.pk, mark_active_on_success=False, num_attempts=2)
+    spawn_appserver(instance.ref.pk, mark_active_on_success=False)
 
 
 # FIXME add another function to test other branches:

--- a/periodic_builds/tasks.py
+++ b/periodic_builds/tasks.py
@@ -1,0 +1,80 @@
+# -*- coding: utf-8 -*-
+#
+# OpenCraft -- tools to aid developing and hosting free software projects
+# Copyright (C) 2018 OpenCraft <xavier@opencraft.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+"""
+Worker tasks for building servers from edx/edx-platform at fixed time intervals.
+"""
+
+# Imports #####################################################################
+
+import logging
+
+from huey.contrib.djhuey import crontab, db_periodic_task
+
+from instance.models.database_server import MongoDBServer
+from instance.models.mixins.domain_names import generate_internal_lms_domain
+from instance.models.mixins.database import select_random_mongodb_server
+from instance.models.openedx_instance import OpenEdXInstance
+from instance.tasks import spawn_appserver
+
+
+# Logging #####################################################################
+
+logger = logging.getLogger(__name__)
+
+
+# Tasks #######################################################################
+
+@db_periodic_task(crontab(hour='*/2'))
+def deploy_edx_edxplatform():
+    """
+    Automatically deploy a new server with the latest version of Open edX.
+    It uses the master branch from https://github.com/edx/edx-platform, https://github.com/edx/configuration and
+    downloads all dependencies specified in the requirements files.
+    It acts as a "continuous integration" system that uses Ocim's servers, including OVH and OpenStack, instead of
+    the other technologies used in edX's CI system.
+    The built version doesn't depend on any PRs (see WatchedFork and pr_watch for that).
+    Because a deployment can take up to 2 hours, don't run this task more often than that, or else you'll have appserver overflow.
+    """
+
+    # Find suitable MongoDB server to avoid choosing one randomly
+    # FIXME probably delete this part, we should not hardcode values. Check whether we need to tell which server to use vs. when it's randomly selected (the default) and decide whether to use this code or not
+    # try:
+    #     mongodb_server = MongoDBServer.objects.get(name="OCIM Default")
+    # except MongoDBServer.DoesNotExist:
+    #     mongodb_server = select_random_mongodb_server()
+
+
+    instance, created = OpenEdXInstance.objects.get_or_create(
+        internal_lms_domain=generate_internal_lms_domain('master'),
+        # github_admin_organizations=['open-craft'], # FIXME reenable, but it needs GitHub user with API access to it
+        use_ephemeral_databases=False, # FIXME this is causing a problem with SWIFT because the "openstack" role is not in edx_sandbox.yml; see discovery document. Setting it to True probably avoids the error
+        edx_platform_repository_url='https://github.com/edx/edx-platform',
+        configuration_source_repo_url='https://github.com/edx/configuration',
+        configuration_version='master',
+        edx_platform_commit='master',
+        openedx_release='master',
+        deploy_simpletheme=True, # FIXME add extra configuration variables that actually change some color
+        #mongodb_server=mongodb_server.pk, # FIXME remove, see above
+    )
+    # Name is set separately because it's stored in InstanceReference
+    instance.name = 'Integration - Open edX master periodic build'
+
+    spawn_appserver(instance.ref.pk, mark_active_on_success=False, num_attempts=2)
+
+    # FIXME check exit status, maybe in another task with smaller interval

--- a/periodic_builds/tasks.py
+++ b/periodic_builds/tasks.py
@@ -73,6 +73,7 @@ def deploy_edx_edxplatform():
     # see in send_emails_on_deployment_failure
     spawn_appserver(instance.ref.pk, mark_active_on_success=False)
 
+    # The servers will be automatically cleaned by a periodic task after some days
 
 # TODO (after deploying 'master' works): add a similar function to deploy other branches
 # E.g. apart from 'master', deploy and test also 'open-release/hawthorn.1'

--- a/periodic_builds/tests/test_tasks.py
+++ b/periodic_builds/tests/test_tasks.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+#
+# OpenCraft -- tools to aid developing and hosting free software projects
+# Copyright (C) 2015-2018 OpenCraft <contact@opencraft.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+"""
+Worker tasks - Tests
+"""
+
+# Imports #####################################################################
+
+import textwrap
+from unittest.mock import patch
+import yaml
+
+from django.test import TestCase, override_settings
+
+from instance.models.openedx_instance import OpenEdXInstance
+from pr_watch import tasks
+from pr_watch.github import RateLimitExceeded
+from pr_watch.models import WatchedPullRequest
+from pr_watch.tests.factories import WatchedForkFactory, PRFactory
+
+
+# Tests #######################################################################
+
+raise NotImplementedError("FIXME write tests, similar to the ones in pr_watch")
+


### PR DESCRIPTION
Prototype for https://tasks.opencraft.com/browse/OC-2167 ([discovery document](https://docs.google.com/document/d/1kZUGgFp-rl-YVzRBOp8QaK20mDS4vB418HN0dX0725w/edit?ts=5a46a3d2#)).

This adds two features:
- a task that regularly (every two hours) builds `edx/edx-platform` (`master` branch) at its current status, using `edx/configuration`.
- a notification system for appserver deployment failures, it will send e-mails to DevOps OpenCraft when OVH or the ansible playbook fails. This applies to all appservers. In the case of the servers built for the previous task (edx CI), it will also send e-mails to edX devops.

WIP because there are still FIXMEs for things that need to be decided or improved..

**JIRA tickets**: None
**Discussions**: None
**Dependencies**: Please merge https://github.com/open-craft/documentation/pull/240 too
**Screenshots**: None
**Sandbox URL**: None
**Merge deadline**: None

**Testing instructions**:

1. Define variables in your `.env`
```
INFRASTRUCTURE_DEPLOYMENT_PROBLEMS_EMAIL = "ops@example.com"
OPENEDX_DEPLOYMENT_PROBLEMS_EMAIL = "edx-devops@example.com"
```
2. `honcho run python3 ./manage.py shell_plus`
3. `from periodic_builds.tasks import deploy_edx_edxplatform; deploy_edx_edxplatform()` to test that the task runs. But from now on, you can also use `instance=OpenEdXInstance.objects.get(internal_lms_domain__startswith='master')` and then just `spawn_appserver(instance.ref.pk, mark_active_on_success=False, num_attempts=2)` each time you test (no need to reload `shell_plus`, but Ocim itself needs to be reloaded)
4. The first time, an `OpenEdXInstance` will be created and a server spawned (check it in Django's admin). Watch the logs from console or from Ocim's admin to check that it's deploying
5. Repeat the past steps in many more situations, including different types of failures. Details follow:
6. To simulate an OVH failure, go to `instance/models/mixins/load_balanced.py`, at `set_dns_records` function, and add a `raise Exception("DNS on strike today")`. This should cause an infrastructure error and en e-mail should be sent to OpenCraft only, with a stack trace
7. To simulate an ansible playbook failure, go to `instance/models/openedx_instance.py`, at `spawn_appserver` and a `return None` very early. This should cause an openedx error, with e-mail sent to OpenCraft and edX
8. Verify that the server deploys correctly. WIP. This won't happen yet in the prototype due to a missing "openstack" role; see the discovery document or https://github.com/edx/configuration/pull/3522
9. Delete all test servers from OVH

**Reviewers**
- [ ] TBD, not yet

**Author concerns**: None
**Settings**: None
