### PR TITLE
Mail admins when exceptions occur

### DIFF
--- a/opencraft/settings.py
+++ b/opencraft/settings.py
@@ -448,7 +448,7 @@ SIMPLE_EMAIL_CONFIRMATION_AUTO_ADD = False
 
 ADMINS = env.json('ADMINS', default=set())
 
-BASE_HANDLERS = env.json('BASE_HANDLERS', default=["file", "console"])
+BASE_HANDLERS = env.json('BASE_HANDLERS', default=["file", "console", "mail_admins"])
 HANDLERS = BASE_HANDLERS + ['db']
 LOGGING_ROTATE_MAX_KBYTES = env.json('LOGGING_ROTATE_MAX_KBYTES', default=10 * 1024)
 LOGGING_ROTATE_MAX_FILES = env.json('LOGGING_ROTATE_MAX_FILES', default=60)
@@ -477,6 +477,10 @@ LOGGING = {
             'level': 'INFO',
             'class': 'instance.logging.DBHandler',
             'formatter': 'db'
+        },
+        'mail_admins': {
+            'level': 'ERROR',
+            'class': 'django.utils.log.AdminEmailHandler'
         },
     },
     'loggers': {


### PR DESCRIPTION
Enable sending e-mail to ADMINS on failure. This includes exceptions in huey tasks.

Done as part of https://tasks.opencraft.com/browse/OC-2044

**JIRA tickets**: None
**Discussions**: None
**Dependencies**: None
**Screenshots**: None
**Sandbox URL**: None
**Merge deadline**: None

**Testing instructions**:

1. Add ADMINS to settings.py, e.g. `ADMINS=[("You","aaaaa@example.com")]`, or the equivalent syntax in `.env` (with lists instead of tuples, and everything surrounded by single quotes)
2. Add to your `.env`:
```
DEBUG=false
ADMINS='["something@example.com"]'
ALLOWED_HOSTS='["localhost"]'
SERVER_EMAIL='something@example.com'
DEFAULT_FROM_EMAIL='something@example.com'
EMAIL_HOST='localhost'
``` 
3. (You don't really need a mail server because Django will show the message in the console)
4. In `watch_pr/tasks.py`, add a `raise ValueError("something")` inside the task
5. `make run`
6. After less than 2 minutes you'll see an exception raised and the e-mail it would be sent 

**Reviewers**
- [ ] TBD

**Author concerns**: None
**Settings**: None
