### PR TITLE
Fix an edge case in get_pr_list_from_usernames.

### DIFF
--- a/pr_watch/github.py
+++ b/pr_watch/github.py
@@ -152,6 +152,9 @@ def get_pr_list_from_usernames(user_names, fork_name):
     """
     Retrieve the current active PRs for a given set of users
     """
+    if not user_names:
+        return []
+
     authors = ' '.join('author:{author}'.format(author=author) for author in user_names)
     q = 'is:open is:pr {authors} repo:{repo}'.format(authors=authors, repo=fork_name)
     r_pr_list = get_object_from_url('https://api.github.com/search/issues?sort=created&q={}'.format(q))

--- a/pr_watch/tests/test_github.py
+++ b/pr_watch/tests/test_github.py
@@ -199,6 +199,9 @@ class GitHubTestCase(TestCase):
         """
         Get list of open PR for a list of users
         """
+        # Verify we get no PRs when invoking the function with an empty username list.
+        self.assertEqual(github.get_pr_list_from_usernames([], 'edx/edx-platform'), [])
+
         responses.add(
             responses.GET, 'https://api.github.com/search/issues?sort=created&q=is:open '
                            'is:pr author:itsjeyd author:haikuginger repo:edx/edx-platform',


### PR DESCRIPTION
When invoked with an empty username list, the function would construct the Github API query as `is:open is:pr  repo:edx/edx-platform`, which returns all PRs from the requested fork, instead of no PRs.

**Testing instructions**:

1. Without this patch, start the django shell. Invoke `pr_watch.github.get_pr_list_from_usernames([], 'edx/edx-platform')` and observe it fetches a page of *all* PRs from the Github API.
1. Install the patch & restart the shell.
1. Invoke the function again, verify it returns an empty list.

**Reviewers**:
- @pomegranited 