### PR TITLE
Log more information on the failure of swift container download.

### DIFF
--- a/backup_swift/tasks.py
+++ b/backup_swift/tasks.py
@@ -65,6 +65,9 @@ def do_backup_swift():
                 error_report += "#. {name}; Failed files: {count}.\n".format(
                     name=container.name, count=container.number_of_failures
                 )
+                error_report += "Extra information: \n{extra_info}".format(
+                    extra_info=container.extra_information
+                )
 
         # In case of downloading errors run tarsnap nevertheless, so we at least backup something.
 


### PR DESCRIPTION
This PR introduces enhanced logging of errors on the failure of swift container download.

**JIRA tickets**: This PR is a first step in investigation for the issue in [OC-3611](https://tasks.opencraft.com/browse/OC-3611). Another PR might be needed, once the source of the issue is found.

**Dependencies**: None

**Screenshots**: None

**Sandbox URL**: None

**Merge deadline**: If possible, very soon so that further investigation of issue from [OC-3611](https://tasks.opencraft.com/browse/OC-3611) can be made.

**Testing instructions**:

1. Run the existing tests.

**Author notes and concerns**:

1. It would be great to test it with the connection to OpenStack configured - I haven't done it yet as I don't have one.

**Reviewers**
- [x] @kaizoku 

CC: @smarnach 

Squashed and rebased from de9479af5a83b9a9df4e866412e7d1876a1e0bc1 onto master.

Signed-off-by: Tomasz Gargas <tomasz@opencraft.com>