### PR TITLE
Fix LB stickiness by inserting a dedicated cookie.

### DIFF
--- a/instance/templates/instance/haproxy/openedx.conf
+++ b/instance/templates/instance/haproxy/openedx.conf
@@ -1,10 +1,10 @@
 {% autoescape off %}
     # Backend configuration for {{ domain }}
-    stick-table type string len 128 size 20k expire 12h
-    stick on req.cook(sessionid)
+    cookie openedx-backend insert postonly indirect
     acl has-authorization req.hdr(Authorization) -m found
     http-request set-header Authorization 'Basic {{ http_auth_info_base64 }}' unless has-authorization
+    option httpchk /heartbeat
     {% for server in appservers %}
-    server {{ server.name }} {{ server.ip_address }}:80 check
+    server {{ server.name }} {{ server.ip_address }}:80 cookie {{ server.name }} check
     {% endfor %}
 {% endautoescape %}


### PR DESCRIPTION
Also use /heartbeat for health checking; the current version only verifies the
server accepts TCP connections.

I'm going to try and expedite this fix by @smarnach on [OC-3169](https://tasks.opencraft.com/browse/OC-3169) through this week. See the ticket for details. In a nutshell, our method of populating the sticky map (hashing by the session cookie) broke for Ginkgo, which causes requests from the same client/session to be uniformly distributed between all servers in the backend. Of course, this causes all kinds of problems for any instance with more than one appserver, including:
* Static asset 404s if, for any reason, static assets happen to not be hashed the same during collection between different appservers (we saw this happen on an ecommerce deployment recently).
* Issues starting sessions when not using the persistent session backend (we also saw this happen).
* Issues with any highly ephemeral state stored between requests in memcached.