### PR TITLE
Update ecommerce database configuration

### DIFF
--- a/instance/models/mixins/openedx_database.py
+++ b/instance/models/mixins/openedx_database.py
@@ -234,14 +234,20 @@ class OpenEdXDatabaseMixin(MySQLInstanceMixin, MongoDBInstanceMixin, RabbitMQIns
             "EDXAPP_MYSQL_PORT": self.mysql_server.port,
 
             # ecommerce
-            "ECOMMERCE_DEFAULT_DB_NAME": self._get_mysql_database_name("ecommerce"),
+            "ECOMMERCE_DATABASE_NAME": self._get_mysql_database_name("ecommerce"),
+            "ECOMMERCE_DATABASE_USER": self._get_mysql_user_name("ecommerce"),
+            "ECOMMERCE_DATABASE_PASSWORD": self._get_mysql_pass_from_dbname("ecommerce"),
+            "ECOMMERCE_DATABASE_HOST": self.mysql_server.hostname,
+
+            # Old ecommerce database settings kept around for compatibility with Ginkgo.
+            "ECOMMERCE_DEFAULT_DB_NAME": "{{ ECOMMERCE_DATABASE_NAME }}",
             "ECOMMERCE_DATABASES": {
                 "default": {
                     "ENGINE": 'django.db.backends.mysql',
-                    "NAME": self._get_mysql_database_name("ecommerce"),
-                    "USER": self._get_mysql_user_name("ecommerce"),
-                    "PASSWORD": self._get_mysql_pass_from_dbname("ecommerce"),
-                    "HOST": self.mysql_server.hostname,
+                    "NAME": "{{ ECOMMERCE_DATABASE_NAME }}",
+                    "USER": "{{ ECOMMERCE_DATABASE_USER }}",
+                    "PASSWORD": "{{ ECOMMERCE_DATABASE_PASSWORD }}",
+                    "HOST": "{{ ECOMMERCE_DATABASE_HOST }}",
                     "PORT": self.mysql_server.port,
                     "ATOMIC_REQUESTS": True,
                     "CONN_MAX_AGE": 60

--- a/instance/tests/models/test_openedx_database_mixins.py
+++ b/instance/tests/models/test_openedx_database_mixins.py
@@ -321,12 +321,24 @@ class MySQLInstanceTestCase(TestCase):
                 database={"name": "edx_notes_api", "user": "notes"},
                 include_port=False
             ),
-            "ECOMMERCE_": make_nested_group_info(
-                ["DEFAULT_DB_NAME", "DATABASES"],
-                [{"name": "ecommerce", "user": "ecommerce", "additional_settings": {
-                    "ATOMIC_REQUESTS": True,
-                    "CONN_MAX_AGE": 60,
-                }}]
+            "ECOMMERCE_": {
+                "vars": ["DATABASES"],
+                "values": [{
+                    "default": {
+                        "ENGINE": 'django.db.backends.mysql',
+                        "NAME": "{{ ECOMMERCE_DATABASE_NAME }}",
+                        "USER": "{{ ECOMMERCE_DATABASE_USER }}",
+                        "PASSWORD": "{{ ECOMMERCE_DATABASE_PASSWORD }}",
+                        "HOST": "{{ ECOMMERCE_DATABASE_HOST }}",
+                        "PORT": expected_port,
+                        "ATOMIC_REQUESTS": True,
+                        "CONN_MAX_AGE": 60
+                    }
+                }]
+            },
+            "ECOMMERCE_DATABASE_": make_flat_group_info(
+                var_names=["NAME", "USER", "PASSWORD", "HOST"],
+                database={"name": "ecommerce", "user": "ecommerce"}
             ),
             "PROGRAMS_": make_nested_group_info(
                 ["DEFAULT_DB_NAME", "DATABASES"],


### PR DESCRIPTION
The Ansible variables for ecommerce database configuration have changed such that Ocim can no longer deploy an instance based on the standard edx/configuration repo. 

This change adds variables to support the new variables for configuring ecommerce. 

**Sandboxes**:

`edx:master`:
* LMS: https://ocpr268.sandbox.stage.opencraft.hosting/
* Studio: https://studio-ocpr268.sandbox.stage.opencraft.hosting/
* Ecommerce: https://ecommerce-ocpr268.sandbox.stage.opencraft.hosting/

`open-craft:opencraft-release/ginkgo.1`
* LMS: https://ocpr268-ginkgo.sandbox.stage.opencraft.hosting/
* Studio: https://studio-ocpr268-ginkgo.sandbox.stage.opencraft.hosting/
* Ecommerce: https://ecommerce-ocpr268-ginkgo.sandbox.stage.opencraft.hosting/

**Merge deadline**: None

**Testing instructions**:
1. Set up an Ocim instance based on this pull request. 
2. Create an instance based on edx/configuration:master and edx/edx-platform:master
3. Launch an AppServer for that instance
4. If all else works, the ecommerce configuration step should not fail during database migrations.

**Reviewers**
- [ ] @pomegranited 