### PR TITLE
Revert #258 use `cached_db` session engine to persist sessions

### DIFF
--- a/instance/models/mixins/openedx_config.py
+++ b/instance/models/mixins/openedx_config.py
@@ -162,7 +162,6 @@ class OpenEdXConfigMixin(models.Model):
             # Available as ENV_TOKENS in the django setting files.
             "EDXAPP_ENV_EXTRA": {
                 "LANGUAGE_CODE": 'en',
-                "SESSION_ENGINE": 'django.contrib.sessions.backends.cached_db',
             },
 
             # Features


### PR DESCRIPTION
The setting change might have had unforeseen consequences and is being reverted until its impact can be better analysed.