### PR TITLE
Disables the certificates service by default on new instances

### DIFF
--- a/instance/factories.py
+++ b/instance/factories.py
@@ -129,6 +129,8 @@ def production_instance_factory(**kwargs):
         # Don't create default users on production instances
         "DEMO_CREATE_STAFF_USER": False,
         "demo_test_users": [],
+        # Disable certificates process to reduce load on RabbitMQ and MySQL
+        "SANDBOX_ENABLE_CERTIFICATES": False,
     }
     configuration_extra_settings = kwargs.pop("configuration_extra_settings", "")
     configuration_extra_settings = yaml.load(configuration_extra_settings) if configuration_extra_settings else {}

--- a/instance/tests/test_factories.py
+++ b/instance/tests/test_factories.py
@@ -40,7 +40,8 @@ class FactoriesTestCase(TestCase):
     Test cases for functions in the factories module
     """
 
-    CONFIGURATION_EXTRA_SETTINGS = "{'demo_test_users': [], 'DEMO_CREATE_STAFF_USER': False}"
+    CONFIGURATION_EXTRA_SETTINGS = "{'demo_test_users': [], 'DEMO_CREATE_STAFF_USER': False, "
+                                   "'SANDBOX_ENABLE_CERTIFICATES': False}"
     SANDBOX_DEFAULTS = {
         "use_ephemeral_databases": True,
         "configuration_version": settings.DEFAULT_CONFIGURATION_VERSION,

--- a/instance/tests/test_factories.py
+++ b/instance/tests/test_factories.py
@@ -41,7 +41,7 @@ class FactoriesTestCase(TestCase):
     """
 
     CONFIGURATION_EXTRA_SETTINGS = "{'demo_test_users': [], 'DEMO_CREATE_STAFF_USER': False, "
-                                   "'SANDBOX_ENABLE_CERTIFICATES': False}"
+    "'SANDBOX_ENABLE_CERTIFICATES': False}"
     SANDBOX_DEFAULTS = {
         "use_ephemeral_databases": True,
         "configuration_version": settings.DEFAULT_CONFIGURATION_VERSION,


### PR DESCRIPTION
Will need to be manually added to existing (i.e. unmaintained) before
reprovisioning in order to take effect.

cf https://github.com/open-craft/configuration/pull/35

**JIRA issues**: OC-3839
