### PR TITLE
Completely disable health checks in the haproxy config.

### DIFF
--- a/instance/templates/instance/haproxy/openedx.conf
+++ b/instance/templates/instance/haproxy/openedx.conf
@@ -5,6 +5,6 @@
     http-request set-header Authorization 'Basic {{ http_auth_info_base64 }}' unless has-authorization
     option httpchk /heartbeat
     {% for server in appservers %}
-    server {{ server.name }} {{ server.ip_address }}:80 cookie {{ server.name }} check
+    server {{ server.name }} {{ server.ip_address }}:80 cookie {{ server.name }} {# check (disabled for now – see OC-3880) #}
     {% endfor %}
 {% endautoescape %}


### PR DESCRIPTION
The health checks have proven problematic, since they will completely disable a backend even if we only have intermittent connection failures to MongoDB.  Since the health cheks are only useful in a multi-appserver setting we completely disable them for now, and plan to implement a fix for enabling them only for multi-appserver instances next week.