### PR TITLE
Update haproxy backend config to add redirect in case of failure

### DIFF
--- a/instance/templates/instance/haproxy/openedx.conf
+++ b/instance/templates/instance/haproxy/openedx.conf
@@ -1,8 +1,12 @@
 {% autoescape off %}
     # Backend configuration for {{ domain }}
     cookie openedx-backend insert postonly indirect
+    acl fail_mode status 500
+    acl fail_mode status 502
+    acl fail_mode status 504
     acl has-authorization req.hdr(Authorization) -m found
     http-request set-header Authorization 'Basic {{ http_auth_info_base64 }}' unless has-authorization
+    http-response redirect location /maintenance if fail_mode
     option httpchk /heartbeat
     {% for server in appservers %}
     server {{ server.name }} {{ server.ip_address }}:80 cookie {{ server.name }} {# check (disabled for now – see OC-3880) #}


### PR DESCRIPTION
This pull request updates the HAProxy backend configuration template used by the Ocim to redirect to the /maintenance page in case of an 500, 502 or 504 error. This page will display a maintenance message served by the load-balancer.

**Reviewers**
- [ ] @smarnach 