### PR TITLE
Update activity stats to use OpenStack settings

### DIFF
--- a/playbooks/collect_activity/stats.py
+++ b/playbooks/collect_activity/stats.py
@@ -17,7 +17,7 @@ LOG_PATH = '/edx/var/log/nginx'
 
 if __name__ == '__main__':
     # Set up the environment so that edX can be initialized as the LMS with the correct settings.
-    os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'lms.envs.aws')
+    os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'lms.envs.openstack')
     os.environ.setdefault('SERVICE_VARIANT', 'lms')
     django.setup()
 


### PR DESCRIPTION
The current stats script for collecting data from an AppServer is throwing errors when running against the current ``ginkgo.1``-based AppServers. This pull request updates the activity stats collection script to use openstack settings instead of AWS settings. 

**Testing instructions**:

1. Setup Ocim to this pull request. 
2. Run the [activity_csv](/instance/management/commands/activity_csv.py) command to collect usage activity of instances.
3. The command should complete successfully without errors and report the full statistics for all valid instances

**Author notes and concerns**:
I tested this script on a master instance as well, and this change fixes it for those cases as well.

**Reviewers**
- [ ] @e-kolpakov 
