### PR TITLE
Enable LB health checks if more than one app server is active.

### DIFF
--- a/instance/models/openedx_instance.py
+++ b/instance/models/openedx_instance.py
@@ -137,6 +137,7 @@ class OpenEdXInstance(DomainNameInstance, LoadBalancedInstance, OpenEdXAppConfig
             domain=self.domain,
             http_auth_info_base64=self.http_auth_info_base64(),
             appservers=appserver_vars,
+            health_check=len(appserver_vars) > 1,
         ))
         backend_map = [(domain, backend_name) for domain in self.get_load_balanced_domains()]
         backend_conf = [(backend_name, config)]

--- a/instance/templates/instance/haproxy/openedx.conf
+++ b/instance/templates/instance/haproxy/openedx.conf
@@ -5,6 +5,6 @@
     http-request set-header Authorization 'Basic {{ http_auth_info_base64 }}' unless has-authorization
     option httpchk /heartbeat
     {% for server in appservers %}
-    server {{ server.name }} {{ server.ip_address }}:80 cookie {{ server.name }} {# check (disabled for now – see OC-3880) #}
+    server {{ server.name }} {{ server.ip_address }}:80 cookie {{ server.name }} {{ health_check|yesno:"check," }}
     {% endfor %}
 {% endautoescape %}


### PR DESCRIPTION
We have disabled the load balancer health checks in #277 since they proved to cause more harm than good for single-VM instances.  We still need them for multi-VM instances, though – otherwise the load balancer would keep sending traffic to a server that is down, so this PR re-enables them if more than one app server is active.

For testing, activate two app servers for an instance and verify that health checks in the generated config are only configured for the instance with two active app servers.  Log into the instance with two active app servers and check the stickiness cookie to learn what app server you are routed to.  Then stop the LMS on that app server, and verify that you can still successfully access the instance.