### PR TITLE
Disable New Relic agent in Vagrant build

### DIFF
--- a/deploy/vagrant_vars.yml
+++ b/deploy/vagrant_vars.yml
@@ -21,6 +21,9 @@ security_fail2ban_enabled: false
 security_autoupdate_enabled: false
 security_sudoers_passwordless: [ 'vagrant' ]
 
+# Disable reporting to New Relic
+COMMON_SERVER_ENABLE_NEWRELIC: false
+
 # The default .env file configuration for Vagrant. These settings can be
 # overridden in the private.yml file.
 OPENCRAFT_ENV_TOKENS:


### PR DESCRIPTION
This disables installing {{nrsysmond}} when creating the Vagrant build, because the Vagrant build is for development only and we don't want reporting. There's no license key either.

Testing instructions in your Ocim:
1. create a virtualenv and install Ocim's `deploy/requirements.txt`
2. download the roles (`ansible-galaxy install -r requirements.yml -f`)
3. replace the `common-server` role folder with the branch from this PR
3. `vagrant provision`, this will run the ansible script
4. the script should run correctly instead of crashing
5. check that the New Relic tasks were skipped, and the agent wasn't installed. You should see this
```
TASK [common-server : Copy security update check script] ***********************
changed: [default]

TASK [common-server : Schedule cron job to track security updates of held packages] ***
changed: [default]

TASK [common-server : Add apt key for New Relic] *******************************
skipping: [default]

TASK [common-server : Install apt repository for New Relic] ********************
skipping: [default]

TASK [common-server : Install newrelic related system packages for Ubuntu] *****
skipping: [default]

TASK [common-server : Configure the agent] *************************************
skipping: [default]

TASK [common-server : Ensure started and enabled] ******************************
skipping: [default]

TASK [forward-server-mail : install deps] **************************************
skipping: [default] => (item=[]) 

TASK [forward-server-mail : template postfix] **********************************
skipping: [default]

TASK [forward-server-mail : template aliases] **********************************
skipping: [default]
```

This list can be simplified by just running `vagrant up` for the first time when you didn't have an Ocim VM yet.