### PR TITLE
Bump python version used by CircleCI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   python:
-    version: 3.5.1
+    version: 3.5.3
   services:
     - redis
   environment:


### PR DESCRIPTION
Updates the version of python used by CircleCI to address issues noticed with the gandi client library.

**JIRA issues**

OC-3949

**Testing instructions**

Since this change only affects the circle.yml file used by CircleCI, passing tests should be enough to verify it.

**Reviewer**
- [ ] @clemente - ?