### PR TITLE
Add filebeat to Ocim.

### DIFF
--- a/deploy/opencraft.yml
+++ b/deploy/opencraft.yml
@@ -20,3 +20,4 @@
       when: vagrant_mode is undefined or not vagrant_mode
     - opencraft
     - pmbauer.tarsnap
+    - filebeat

--- a/deploy/requirements.yml
+++ b/deploy/requirements.yml
@@ -39,6 +39,10 @@
   src: https://github.com/open-craft/ansible-forward-server-mail
   version: origin/master
 
+- name: filebeat
+  src: https://github.com/open-craft/ansible-role-filebeat
+  version: uman/updates
+
 - name: opencraft
   src: https://github.com/open-craft/ansible-opencraft
   version: origin/master


### PR DESCRIPTION
We want to have Filebeat getting logs that Ocim generates.

A separate PR is needed to get logs from individual Open edX instances that Ocim provisions.