### PR TITLE
Migrate config to CircleCI 2

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,8 +1,8 @@
 DEBUG=true
 SECRET_KEY='tests'
 DATABASE_URL='postgres://localhost/opencraft'
-DEFAULT_INSTANCE_MYSQL_URL='mysql://root@localhost'
-DEFAULT_INSTANCE_MONGO_URL='mongodb://localhost'
+DEFAULT_INSTANCE_MYSQL_URL='mysql://root@127.0.0.1'
+DEFAULT_INSTANCE_MONGO_URL='mongodb://127.0.0.1'
 SWIFT_ENABLE=true
 HUEY_ALWAYS_EAGER=true
 OPENSTACK_USER='test'

--- a/.prospector/opencraft.yml
+++ b/.prospector/opencraft.yml
@@ -5,7 +5,7 @@ dodgy:
   enable: []
   options: {}
   run: null
-ignore-paths: ['migrations', 'deploy/roles']
+ignore-paths: ['migrations', 'deploy/roles', 'venv/']
 ignore-patterns: [^setup.py$, (^|/)\..+, '^docs?/']
 max-line-length: null
 mccabe:

--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ install_system_dependencies: apt_get_update ## Install system-level dependencies
 	sudo -E apt-get install -y `grep -v '^#' debian_packages.lst | tr -d '\r'`
 
 create_db: ## Create blanket DBs, i.e. `opencraft`.
-	createdb --encoding utf-8 --template template0 opencraft || \
+	createdb --host 127.0.0.1 --encoding utf-8 --template template0 opencraft || \
 	    echo "Could not create database 'opencraft' - it probably already exists"
 
 .PHONY: static
@@ -100,7 +100,7 @@ test.quality: clean ## Run quality tests.
 	prospector --profile opencraft --uses django
 
 test.unit: clean static_external ## Run all unit tests.
-	honcho -e .env.test run coverage run --source='.' --omit='*/tests/*' ./manage.py test --noinput
+	honcho -e .env.test run coverage run --source='.' --omit='*/tests/*,venv/*' ./manage.py test --noinput
 	coverage html
 	@echo "\nCoverage HTML report at file://`pwd`/build/coverage/index.html\n"
 	@coverage report --fail-under $(COVERAGE_THRESHOLD) || (echo "\nERROR: Coverage is below $(COVERAGE_THRESHOLD)%\n" && exit 2)

--- a/bin/run-circleci-tests
+++ b/bin/run-circleci-tests
@@ -4,25 +4,6 @@ set -e
 
 make install_system_dependencies
 
-# Try to get Redis up and running before launching tests.
-# In the past, individual tests from our unit test suite would sometimes fail with a "ConnectionRefusedError"
-# that was caused by Redis being unavailable in the container running the tests.
-# The solution below is based on suggestions from the following support thread:
-# https://discuss.circleci.com/t/redis-server-problems-unable-to-connect-localhost-6379/4040
-ATTEMPTS=0
-until bash -c "sudo service redis-server status"; do
-    if [ $ATTEMPTS -lt 300 ]
-    then
-        >&2 echo "Redis not running, trying to kick start it"
-        bash -c "sudo service redis-server start"
-        sleep 1
-        ATTEMPTS=$((ATTEMPTS+1))
-    else
-        >&2 echo "Redis is not running, so tests that depend on it will fail. Aborting."
-        exit 1
-    fi
-done
-
 case $CIRCLE_NODE_INDEX in
     0)
         make test

--- a/circle.yml
+++ b/circle.yml
@@ -1,35 +1,81 @@
-machine:
-  python:
-    version: 3.5.3
-  services:
-    - redis
-  environment:
-    # Don't add sensitive information (e.g. passwords) here but in https://circleci.com/gh/open-craft/opencraft/edit#env-vars
-    DEBUG: 'true'
-    DEFAULT_FORK: 'open-craft/edx-platform'
-    INSTANCE_EPHEMERAL_DATABASES: 'false'
-    LOAD_BALANCER_FRAGMENT_NAME_PREFIX: 'integration-'
-    TEST_RUNNER: 'opencraft.tests.utils.CircleCIParallelTestRunner'
-dependencies:
-  pre:
-    - pip install --upgrade pip
-    - pip install --upgrade virtualenv
-    # Update python to latest 2.6.* release from the deadsnakes PPA.
-    # Ubuntu 14.04 which we currently use on CircleCI comes with 2.7.6 preinstalled,
-    # which does not support SNI. When CircleCI starts providing Ubuntu 16.04 images,
-    # this won't be needed anymore.
-    - sudo add-apt-repository ppa:fkrull/deadsnakes-python2.7 -y
-    - sudo apt-get update; sudo apt-get install python2.7 python2.7-dev
-  override:
-    - pip install -r requirements.txt
-database:
-  override:
-    - make create_db
-test:
-  override:
-    - bin/run-circleci-tests:
-        timeout: 2800
-        parallel: true
-  post:
-    - make test.integration_cleanup:
-        timeout: 1200
+version: 2
+jobs:
+  build:
+    docker:
+      - image: circleci/python:3.5.4-browsers
+        environment:
+          DEBUG: 'true'
+          DEFAULT_FORK: 'open-craft/edx-platform'
+          INSTANCE_EPHEMERAL_DATABASES: 'false'
+          LOAD_BALANCER_FRAGMENT_NAME_PREFIX: 'integration-'
+          TEST_RUNNER: 'opencraft.tests.utils.CircleCIParallelTestRunner'
+      - image: redis
+      - image: mongo
+      - image: mysql
+        environment:
+          MYSQL_ALLOW_EMPTY_PASSWORD: True
+      - image: circleci/postgres:10.1-alpine
+        environment:
+          PG_HOST: 127.0.0.1
+          POSTGRES_USER: circleci
+          POSTGRES_DB: circle_test
+    parallelism: 4
+    steps:
+      - checkout
+      - restore_cache:
+          key: dependencies-{{ checksum "requirements.txt" }}
+      - run:
+          name: Wait for Redis
+          command: |
+            while ! nc -z localhost 6379; do
+              sleep 0.1
+            done
+      - run:
+          name: Wait for Postgres
+          command: |
+            while ! nc -z localhost 5432; do
+              sleep 0.1
+            done
+      - run:
+          name: Wait for MySQL
+          command: |
+            while ! nc -z localhost 3306; do
+              sleep 0.1
+            done
+      - run:
+          name: Wait for MongoDB
+          command: |
+            while ! nc -z localhost 27017; do
+              sleep 0.1
+            done
+      - run:
+          name: Install Dependencies
+          command: |
+            python3 -m venv venv
+            . venv/bin/activate
+            pip install --upgrade pip
+            pip install --upgrade virtualenv
+            sudo apt-get update; sudo apt-get install python2.7-dev
+            sudo apt-get install mysql-client
+            pip install -r requirements.txt
+            sudo apt-get install postgresql-client
+      - save_cache:
+          key: dependencies-{{ checksum "requirements.txt" }}
+          paths:
+            - "venv"
+      - run:
+          name: Create Database
+          command: make create_db
+      - run:
+          name: Run Tests
+          command: |
+            . venv/bin/activate
+            bin/run-circleci-tests
+          no_output_timeout: 47m
+          environment:
+            ANSIBLE_HOST_KEY_CHECKING: False
+      - run:
+          name: Cleanup
+          command: make test.integration_cleanup
+          no_output_timeout: 20m
+

--- a/debian_packages.lst
+++ b/debian_packages.lst
@@ -1,4 +1,3 @@
-firefox
 git
 libffi-dev
 libmysqlclient-dev

--- a/instance/tests/models/test_openedx_database_mixins.py
+++ b/instance/tests/models/test_openedx_database_mixins.py
@@ -74,7 +74,8 @@ class MySQLInstanceTestCase(TestCase):
             # Pass password using MYSQL_PWD environment variable rather than the --password
             # parameter so that mysql command doesn't print a security warning.
             env = {'MYSQL_PWD': password}
-            mysql_cmd = "mysql -u {user} -e 'SHOW TABLES' {db_name}".format(user=user, db_name=database_name)
+            mysql_cmd = "mysql -h 127.0.0.1 -u {user} -e 'SHOW TABLES' {db_name}".format(user=user,
+                                                                                         db_name=database_name)
             tables = subprocess.call(mysql_cmd, shell=True, env=env)
             self.assertEqual(tables, 0)
 
@@ -85,7 +86,7 @@ class MySQLInstanceTestCase(TestCase):
         self.assertIs(self.instance.mysql_provisioned, True)
         self.assertTrue(self.instance.mysql_user)
         self.assertTrue(self.instance.mysql_pass)
-        databases = subprocess.check_output("mysql -u root -e 'SHOW DATABASES'", shell=True).decode()
+        databases = subprocess.check_output("mysql -h 127.0.0.1 -u root -e 'SHOW DATABASES'", shell=True).decode()
         for database in self.instance.mysql_databases:
             # Check if database exists
             database_name = database["name"]
@@ -243,7 +244,7 @@ class MySQLInstanceTestCase(TestCase):
         self.instance.mysql_server = None
         self.instance.save()
         self.instance.provision_mysql()
-        databases = subprocess.check_output("mysql -u root -e 'SHOW DATABASES'", shell=True).decode()
+        databases = subprocess.check_output("mysql -h 127.0.0.1 -u root -e 'SHOW DATABASES'", shell=True).decode()
         for database in self.instance.mysql_databases:
             self.assertNotIn(database["name"], databases)
 


### PR DESCRIPTION
Migrating to CircleCI version 2.

JIRA Ticket: OC-4053

Testing instructions:

Check that tests are passing.

Notes to reviewer:

- Had to upgrade to python version 3.5.4, since 3.5.3 is not in the list of docker images: https://github.com/CircleCI-Public/circleci-dockerfiles/tree/master/python/images.
- Using browsers image, so that it comes with firefox already installed
- Had to add hosts to mysql commands and also update links from localhost to 127.0.0.1, so that mysql connects using tcp (required when using docker images for dbs)
- Added cache for python requirements

Reviewers:

[Sven]