### PR TITLE
Set background colors for header/footer in hawthorn compatible way in openedx_theme mixin

### DIFF
--- a/instance/models/mixins/openedx_theme.py
+++ b/instance/models/mixins/openedx_theme.py
@@ -73,14 +73,6 @@ class OpenEdXThemeMixin(models.Model):
                     "value": application.link_color,
                 },
                 {
-                    "variable": "header-bg",
-                    "value": application.header_bg_color,
-                },
-                {
-                    "variable": "footer-bg",
-                    "value": application.footer_bg_color,
-                },
-                {
                     "variable": "button-color",
                     "value": application.main_color,
                 },
@@ -91,6 +83,13 @@ class OpenEdXThemeMixin(models.Model):
                 {
                     "variable": "action-secondary-bg",
                     "value": application.main_color,
+                },
+                {
+                    "variable": "theme-colors",
+                    "value": "(\"primary\": {primary}, \"secondary\": {secondary})".format(
+                        primary=application.main_color,
+                        secondary=application.main_color
+                    ),
                 },
             ],
             "SIMPLETHEME_STATIC_FILES_URLS": [
@@ -105,6 +104,14 @@ class OpenEdXThemeMixin(models.Model):
             ],
             "SIMPLETHEME_ENABLE_DEPLOY": True,
             "EDXAPP_DEFAULT_SITE_THEME": "simple-theme",
+            "SIMPLETHEME_EXTRA_SASS": """
+                .global-header {{
+                    background: {header_bg};
+                }}
+                .wrapper-footer {{
+                    background: {footer_bg};
+                }}""".format(header_bg=application.header_bg_color,
+                             footer_bg=application.footer_bg_color)
         }
 
         return yaml.dump(settings, default_flow_style=False)

--- a/instance/tests/models/test_openedx_theme_mixins.py
+++ b/instance/tests/models/test_openedx_theme_mixins.py
@@ -85,19 +85,24 @@ class OpenEdXThemeMixinTestCase(TestCase):
                 'SIMPLETHEME_SASS_OVERRIDES': [
                     {'variable': 'link-color',
                      'value': '#003344', },
-                    {'variable': 'header-bg',
-                     'value': '#caaffe', },
-                    {'variable': 'footer-bg',
-                     'value': '#ffff11', },
                     {'variable': 'button-color',
                      'value': '#001122', },
                     {'variable': 'action-primary-bg',
                      'value': '#001122', },
                     {'variable': 'action-secondary-bg',
                      'value': '#001122', },
+                    {'variable': 'theme-colors',
+                     'value': '("primary": #001122, "secondary": #001122)'}
                 ],
                 'EDXAPP_DEFAULT_SITE_THEME': 'simple-theme',
                 # for SIMPLETHEME_STATIC_FILES_URLS, see below
+                'SIMPLETHEME_EXTRA_SASS': '''
+                .global-header {
+                    background: #caaffe;
+                }
+                .wrapper-footer {
+                    background: #ffff11;
+                }'''
             }
             for ansible_var, value in expected_settings.items():
                 self.assertEqual(value, parsed_vars[ansible_var])


### PR DESCRIPTION
Set background colors for header/footer in hawthorn compatible way in openedx_theme mixin

**Dependencies**: https://github.com/edx/configuration/pull/4396

**Merge deadline**: None

**Testing instructions**:

1. Deploy a new instance and set theme colors

**Reviewers**
- [ ] clemente

Rebased d36cc1f77cdfc38f1b27cae1188c41d96f3f3d54 onto master.
