### PR TITLE
Add catch for gandi timeouts

### DIFF
--- a/instance/gandi.py
+++ b/instance/gandi.py
@@ -140,7 +140,7 @@ class GandiAPI():
                     result = callback(zone_id, new_zone_version)
                     self.set_zone_version(zone_id, new_zone_version)
                     break
-                except xmlrpc.client.Fault:
+                except (xmlrpc.client.Fault, TimeoutError):
                     if i == attempts:
                         raise
                     time.sleep(retry_delay)

--- a/instance/tests/test_gandi.py
+++ b/instance/tests/test_gandi.py
@@ -129,6 +129,19 @@ class GandiTestCase(TestCase):
         self.assertEqual(sleep.mock_calls, [call(1), call(2)])
 
     @patch('time.sleep')
+    def test_set_dns_record_timeout_retry_and_fail(self, sleep):
+        """
+        Test retry behaviour returns timeout exception. Fail all attempts.
+        """
+        self.api.client.make_version_creation_fail(10, timeout=True)
+        with self.assertRaises(TimeoutError):
+            self.api.set_dns_record(
+                'sub.domain.test.com',
+                type='A', value='192.168.99.99'
+            )
+        self.assertEqual(sleep.mock_calls, [call(1), call(2), call(4)])
+
+    @patch('time.sleep')
     def test_set_dns_record_error_retry_and_fail(self, sleep):
         """
         Test retry behaviour when setting a DNS record.  Fail all attempts.


### PR DESCRIPTION
Adds catch for Gandi timeouts and tests

JIRA Ticket: OC-4149