### PR TITLE
Safer load balancer reconfigurations

### DIFF
--- a/instance/api/openedx_appserver.py
+++ b/instance/api/openedx_appserver.py
@@ -96,11 +96,11 @@ class OpenEdXAppServerViewSet(viewsets.ReadOnlyModelViewSet):
         Add this AppServer to the list of active app server for the instance.
         """
         app_server = self.get_object()
-        if not app_server.status.is_healthy_state:
+        if not app_server.status.is_healthy_state or not make_appserver_active(app_server.pk):
             return Response(
                 {"error": "Cannot make an unhealthy app server active."}, status=status.HTTP_400_BAD_REQUEST
             )
-        make_appserver_active(app_server.pk)
+
         return Response({'status': 'App server activation initiated.'})
 
     @detail_route(methods=['post'])

--- a/instance/models/server.py
+++ b/instance/models/server.py
@@ -70,6 +70,10 @@ class ServerState(ResourceState):
     # until the target server has reached one of these statuses.
     vm_available = False
 
+    # We can only reconfigure the load balancer in case the server is in Status.Ready.
+    # This field is to be set just in the Ready state and False in other states.
+    is_healthy_state = False
+
 
 class Status(ResourceState.Enum):
     """
@@ -94,6 +98,7 @@ class Status(ResourceState.Enum):
         is_steady_state = True
         accepts_ssh_commands = True
         vm_available = True
+        is_healthy_state = True
 
     class Terminated(ServerState):
         """ Stopped forever """

--- a/instance/serializers/server.py
+++ b/instance/serializers/server.py
@@ -50,8 +50,6 @@ class OpenStackServerSerializer(serializers.ModelSerializer):
         )
 
     def to_representation(self, obj):
-        # Make sure we have an up-to-date representation of the server
-        obj.update_status()
         output = super().to_representation(obj)
         # Convert the state values from objects to strings:
         output['status'] = obj.status.state_id

--- a/instance/tests/models/factories/openedx_appserver.py
+++ b/instance/tests/models/factories/openedx_appserver.py
@@ -28,7 +28,7 @@ from instance.tests.models.factories.openedx_instance import OpenEdXInstanceFact
 # Functions ###################################################################
 
 
-def make_test_appserver(instance=None):
+def make_test_appserver(instance=None, server=None):
     """
     Factory method to create an OpenEdXAppServer (and OpenStackServer).
     """
@@ -37,4 +37,10 @@ def make_test_appserver(instance=None):
     if not instance.load_balancing_server:
         instance.load_balancing_server = LoadBalancingServer.objects.select_random()
         instance.save()
-    return instance._create_owned_appserver()
+    appserver = instance._create_owned_appserver()
+
+    if server:
+        appserver.server = server
+        appserver.save()
+
+    return appserver


### PR DESCRIPTION
Added a called to update_status() if an active server was found without IP address. If the IP is still missing after the call, allow the load balancer configuration to fail.

**JIRA tickets**: OC-4205

**Testing instructions**:

1. Spawn an appserver. but before making it active, terminate the OpenStack VM server. If we then try to make the appserver active. It should not be allowed to be made active. The VM server should be in the Ready state before making the appserver active.

2. When reconfiguring the loadbalancer, the VM server should have a public IP address, otherwise it will throw an exception. 

**Reviewers**
- [ ] @UmanShahzad
