### PR TITLE
S3 as default storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,6 +314,23 @@ edit its security group rules to only allow access to VMs in the
 * `OPENSTACK_AUTH_URL`: Your openstack auth url (required)
 * `OPENSTACK_REGION`: The openstack region to deploy sandboxes in (required)
 
+### AWS S3 Storage
+
+Permissions required for master AWS account are:
+* iam:PutUserPolicy
+* iam:CreateUser
+* iam:CreateAccessKey
+* iam:DeleteUser
+* iam:DeleteAccessKey
+* iam:DeleteUserPolicy
+
+Required settings:
+* `SWIFT_ENABLE`: Default is True, it should be set to False when using s3.
+* `AWS_ACCESS_KEY_ID`: AWS Access Key Id from account with accesses listed above.
+* `AWS_SECRET_ACCESS_KEY`: AWS Secret Key with accesses listed above.
+* `AWS_S3_BUCKET_PREFIX`: Prefix used for bucket naming (default: "ocim")
+* `AWS_IAM_USER_PREFIX`: Prefix used for IAM username (default: "ocim")
+
 ### Load balancer settings
 * `DEFAULT_LOAD_BALANCING_SERVER`: The load-balancing server to be used in the
   form `ssh_username@domain.name`.  The server will be represented as an

--- a/instance/factories.py
+++ b/instance/factories.py
@@ -43,8 +43,11 @@ def _check_environment():
     """
     Check environment and report potential problems for production instances
     """
-    if not settings.SWIFT_ENABLE:
-        logger.warning("Swift support is currently disabled. Adjust SWIFT_ENABLE setting.")
+    if not settings.SWIFT_ENABLE and not(settings.AWS_ACCESS_KEY_ID and settings.AWS_SECRET_ACCESS_KEY):
+        logger.warning(
+            "Swift and AWS support is currently disabled. Add AWS_ACCESS_KEY_ID and "
+            "AWS_SECRET_ACCESS_KEY settings or adjust SWIFT_ENABLE setting."
+        )
         return
     if not MySQLServer.objects.exists() and settings.DEFAULT_INSTANCE_MYSQL_URL is None:
         logger.warning(

--- a/instance/factories.py
+++ b/instance/factories.py
@@ -129,6 +129,8 @@ def production_instance_factory(**kwargs):
         # Don't create default users on production instances
         "DEMO_CREATE_STAFF_USER": False,
         "demo_test_users": [],
+        # Disable certificates process to reduce load on RabbitMQ and MySQL
+        "SANDBOX_ENABLE_CERTIFICATES": False,
     }
     configuration_extra_settings = kwargs.pop("configuration_extra_settings", "")
     configuration_extra_settings = yaml.load(configuration_extra_settings) if configuration_extra_settings else {}

--- a/instance/models/mixins/openedx_storage.py
+++ b/instance/models/mixins/openedx_storage.py
@@ -80,16 +80,16 @@ class OpenEdXStorageMixin(SwiftContainerInstanceMixin):
             "XQUEUE_AWS_ACCESS_KEY_ID": self.s3_access_key,
             "XQUEUE_AWS_SECRET_ACCESS_KEY": self.s3_secret_access_key,
             "XQUEUE_UPLOAD_BUCKET": self.s3_bucket_name,
-            "XQUEUE_UPLOAD_PATH_PREFIX": 'xqueue',
+            "XQUEUE_UPLOAD_PATH_PREFIX": '{}/{}'.format(self.swift_container_name, 'xqueue'),
 
             "EDXAPP_GRADE_STORAGE_TYPE": 's3',
             "EDXAPP_GRADE_BUCKET": self.s3_bucket_name,
-            "EDXAPP_GRADE_ROOT_PATH": 'grades-download',
+            "EDXAPP_GRADE_ROOT_PATH": '{}/{}'.format(self.swift_container_name, 'grades-download'),
 
             # Tracking logs
             "COMMON_OBJECT_STORE_LOG_SYNC": True,
             "COMMON_OBJECT_STORE_LOG_SYNC_BUCKET": self.s3_bucket_name,
-            "COMMON_OBJECT_STORE_LOG_SYNC_PREFIX": 'logs/tracking/',
+            "COMMON_OBJECT_STORE_LOG_SYNC_PREFIX": '{}/{}'.format(self.swift_container_name, 'logs/tracking/'),
             "AWS_S3_LOGS": True,
             "AWS_S3_LOGS_ACCESS_KEY_ID": self.s3_access_key,
             "AWS_S3_LOGS_SECRET_KEY": self.s3_secret_access_key,

--- a/instance/models/mixins/openedx_storage.py
+++ b/instance/models/mixins/openedx_storage.py
@@ -67,6 +67,7 @@ class OpenEdXStorageMixin(SwiftContainerInstanceMixin):
             # Required when s3 storage is the default for all Ocim beta instances,
             # using shared s3 buckets
             "AWS_S3_KEY_PREFIX": self.swift_container_name,
+            "EDXAPP_AWS_LOCATION": '{{ AWS_S3_KEY_PREFIX }}',
 
             "EDXAPP_DEFAULT_FILE_STORAGE": 'storages.backends.s3boto.S3BotoStorage',
             "EDXAPP_AWS_ACCESS_KEY_ID": self.s3_access_key,

--- a/instance/models/mixins/openedx_storage.py
+++ b/instance/models/mixins/openedx_storage.py
@@ -68,7 +68,7 @@ class OpenEdXStorageMixin(SwiftContainerInstanceMixin):
             # using shared s3 buckets
             "AWS_S3_KEY_PREFIX": self.swift_container_name,
 
-            "EDXAPP_DEFAULT_FILE_STORAGE": 'storages.backends.s3boto3.S3Boto3Storage',
+            "EDXAPP_DEFAULT_FILE_STORAGE": 'storages.backends.s3boto.S3BotoStorage',
             "EDXAPP_AWS_ACCESS_KEY_ID": self.s3_access_key,
             "EDXAPP_AWS_SECRET_ACCESS_KEY": self.s3_secret_access_key,
             "EDXAPP_AUTH_EXTRA": {

--- a/instance/models/mixins/openedx_storage.py
+++ b/instance/models/mixins/openedx_storage.py
@@ -79,6 +79,9 @@ class OpenEdXStorageMixin(SwiftContainerInstanceMixin):
             "EDXAPP_FILE_UPLOAD_STORAGE_PREFIX": '{}/{}'.format(self.swift_container_name, 'submissions_attachments'),
 
             "EDXAPP_GRADE_STORAGE_CLASS": 'storages.backends.s3boto.S3BotoStorage',
+            "EDXAPP_GRADE_STORAGE_TYPE": 's3',
+            "EDXAPP_GRADE_BUCKET": self.s3_bucket_name,
+            "EDXAPP_GRADE_ROOT_PATH": '{}/{}'.format(self.swift_container_name, 'grades-download'),
             "EDXAPP_GRADE_STORAGE_KWARGS": {
                 "bucket": self.s3_bucket_name,
                 "location": '{}/{}'.format(self.swift_container_name, 'grades-download'),

--- a/instance/models/mixins/openedx_storage.py
+++ b/instance/models/mixins/openedx_storage.py
@@ -78,15 +78,16 @@ class OpenEdXStorageMixin(SwiftContainerInstanceMixin):
             "EDXAPP_FILE_UPLOAD_BUCKET_NAME": self.s3_bucket_name,
             "EDXAPP_FILE_UPLOAD_STORAGE_PREFIX": '{}/{}'.format(self.swift_container_name, 'submissions_attachments'),
 
+            "EDXAPP_GRADE_STORAGE_CLASS": 'storages.backends.s3boto.S3BotoStorage',
+            "EDXAPP_GRADE_STORAGE_KWARGS": {
+                "bucket": self.s3_bucket_name,
+                "location": '{}/{}'.format(self.swift_container_name, 'grades-download'),
+            },
 
             "XQUEUE_AWS_ACCESS_KEY_ID": self.s3_access_key,
             "XQUEUE_AWS_SECRET_ACCESS_KEY": self.s3_secret_access_key,
             "XQUEUE_UPLOAD_BUCKET": self.s3_bucket_name,
             "XQUEUE_UPLOAD_PATH_PREFIX": '{}/{}'.format(self.swift_container_name, 'xqueue'),
-
-            "EDXAPP_GRADE_STORAGE_TYPE": 's3',
-            "EDXAPP_GRADE_BUCKET": self.s3_bucket_name,
-            "EDXAPP_GRADE_ROOT_PATH": '{}/{}'.format(self.swift_container_name, 'grades-download'),
 
             # Tracking logs
             "COMMON_OBJECT_STORE_LOG_SYNC": True,

--- a/instance/models/mixins/openedx_storage.py
+++ b/instance/models/mixins/openedx_storage.py
@@ -66,9 +66,7 @@ class OpenEdXStorageMixin(SwiftContainerInstanceMixin):
 
             # Required when s3 storage is the default for all Ocim beta instances,
             # using shared s3 buckets
-            "AWS_S3_KEY_PREFIX": self.swift_container_name,
-            "EDXAPP_AWS_LOCATION": '{{ AWS_S3_KEY_PREFIX }}',
-
+            "EDXAPP_AWS_LOCATION": self.swift_container_name,
             "EDXAPP_DEFAULT_FILE_STORAGE": 'storages.backends.s3boto.S3BotoStorage',
             "EDXAPP_AWS_ACCESS_KEY_ID": self.s3_access_key,
             "EDXAPP_AWS_SECRET_ACCESS_KEY": self.s3_secret_access_key,
@@ -77,6 +75,9 @@ class OpenEdXStorageMixin(SwiftContainerInstanceMixin):
             },
             "EDXAPP_AWS_S3_CUSTOM_DOMAIN": "{}.s3.amazonaws.com".format(self.s3_bucket_name),
             "EDXAPP_IMPORT_EXPORT_BUCKET": self.s3_bucket_name,
+            "EDXAPP_FILE_UPLOAD_BUCKET_NAME": self.s3_bucket_name,
+            "EDXAPP_FILE_UPLOAD_STORAGE_PREFIX": '{}/{}'.format(self.swift_container_name, 'submissions_attachments'),
+
 
             "XQUEUE_AWS_ACCESS_KEY_ID": self.s3_access_key,
             "XQUEUE_AWS_SECRET_ACCESS_KEY": self.s3_secret_access_key,

--- a/instance/models/mixins/openedx_storage.py
+++ b/instance/models/mixins/openedx_storage.py
@@ -70,6 +70,8 @@ class OpenEdXStorageMixin(SwiftContainerInstanceMixin):
             "EDXAPP_AUTH_EXTRA": {
                 "AWS_STORAGE_BUCKET_NAME": self.s3_bucket_name,
             },
+            "EDXAPP_AWS_S3_CUSTOM_DOMAIN": "{}.s3.amazonaws.com".format(self.s3_bucket_name),
+            "EDXAPP_IMPORT_EXPORT_BUCKET": self.s3_bucket_name,
 
             "XQUEUE_AWS_ACCESS_KEY_ID": self.s3_access_key,
             "XQUEUE_AWS_SECRET_ACCESS_KEY": self.s3_secret_access_key,
@@ -84,6 +86,7 @@ class OpenEdXStorageMixin(SwiftContainerInstanceMixin):
             "COMMON_OBJECT_STORE_LOG_SYNC": True,
             "COMMON_OBJECT_STORE_LOG_SYNC_BUCKET": self.s3_bucket_name,
             "COMMON_OBJECT_STORE_LOG_SYNC_PREFIX": 'logs/tracking/',
+            "AWS_S3_LOGS": True,
             "AWS_S3_LOGS_ACCESS_KEY_ID": self.s3_access_key,
             "AWS_S3_LOGS_SECRET_KEY": self.s3_secret_access_key,
         }

--- a/instance/models/mixins/openedx_storage.py
+++ b/instance/models/mixins/openedx_storage.py
@@ -24,12 +24,12 @@ import yaml
 from django.conf import settings
 from django.db import models
 
-from .storage import SwiftContainerInstanceMixin
+from .storage import SwiftContainerInstanceMixin, S3BucketInstanceMixin
 
 
 # Classes #####################################################################
 
-class OpenEdXStorageMixin(SwiftContainerInstanceMixin):
+class OpenEdXStorageMixin(SwiftContainerInstanceMixin, S3BucketInstanceMixin):
     """
     Mixin that provides functionality required for the storage backends that an OpenEdX
     Instance uses (when not using ephemeral databases)
@@ -70,6 +70,7 @@ class OpenEdXStorageMixin(SwiftContainerInstanceMixin):
             "EDXAPP_DEFAULT_FILE_STORAGE": 'storages.backends.s3boto.S3BotoStorage',
             "EDXAPP_AWS_ACCESS_KEY_ID": self.s3_access_key,
             "EDXAPP_AWS_SECRET_ACCESS_KEY": self.s3_secret_access_key,
+            "EDXAPP_AWS_STORAGE_BUCKET_NAME": self.s3_bucket_name,
             "EDXAPP_AUTH_EXTRA": {
                 "AWS_STORAGE_BUCKET_NAME": self.s3_bucket_name,
             },

--- a/instance/models/mixins/openedx_storage.py
+++ b/instance/models/mixins/openedx_storage.py
@@ -64,6 +64,10 @@ class OpenEdXStorageMixin(SwiftContainerInstanceMixin):
             "AWS_ACCESS_KEY_ID": self.s3_access_key,
             "AWS_SECRET_ACCESS_KEY": self.s3_secret_access_key,
 
+            # Required when s3 storage is the default for all Ocim beta instances,
+            # using shared s3 buckets
+            "AWS_S3_KEY_PREFIX": self.swift_container_name,
+
             "EDXAPP_DEFAULT_FILE_STORAGE": 'storages.backends.s3boto3.S3Boto3Storage',
             "EDXAPP_AWS_ACCESS_KEY_ID": self.s3_access_key,
             "EDXAPP_AWS_SECRET_ACCESS_KEY": self.s3_secret_access_key,

--- a/instance/models/mixins/storage.py
+++ b/instance/models/mixins/storage.py
@@ -21,13 +21,36 @@ Instance app model mixins - Database
 """
 
 # Imports #####################################################################
+import json
 
+import boto
+
+from django.db.backends.utils import truncate_name
 from django.conf import settings
 from django.db import models
 from swiftclient.exceptions import ClientException as SwiftClientException
 
 from instance import openstack_utils
 from instance.models.utils import default_setting
+
+
+def get_master_iam_connection():
+    """
+    Create connection to IAM service
+    """
+    return boto.connect_iam(
+        settings.AWS_ACCESS_KEY_ID,
+        settings.AWS_SECRET_ACCESS_KEY
+    )
+
+
+def get_s3_cors_config():
+    """
+    Create CORS config needed for ORA2 File uploads
+    """
+    cors_config = boto.s3.cors.CORSConfiguration()
+    cors_config.add_rule(allowed_method=['GET', 'PUT'], allowed_header=["*"], allowed_origin=["*"])
+    return cors_config
 
 
 # Classes #####################################################################
@@ -109,3 +132,125 @@ class SwiftContainerInstanceMixin(models.Model):
                     self.logger.exception('Could not delete Swift container "%s".', container_name)
             self.swift_provisioned = False
             self.save()
+
+
+class S3BucketInstanceMixin(models.Model):
+    """
+    Mixin to provision S3 bucket for an instance.
+    """
+    class Meta:
+        abstract = True
+
+    def get_s3_policy(self):
+        """
+        Return s3 policy with access to create and update bucket
+        """
+        policy = {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "Action": ["s3:ListBucket", "s3:CreateBucket", "s3:DeleteBucket", "s3:PutBucketCORS"],
+                    "Resource": ["arn:aws:s3:::{}".format(self.s3_bucket_name)]
+                },
+                {
+                    "Effect": "Allow",
+                    "Action": [
+                        "s3:*Object*"
+                    ],
+                    "Resource": ["arn:aws:s3:::{}/*".format(self.s3_bucket_name)]
+                }
+            ]
+        }
+        return json.dumps(policy, indent=2)
+
+    @property
+    def bucket_name(self):
+        """
+        Return bucket name truncated to 50 characters
+        """
+        return truncate_name(
+            '{}-{}'.format(settings.AWS_S3_BUCKET_PREFIX, self.database_name.replace('_', '-')),
+            length=50
+        )
+
+    @property
+    def iam_username(self):
+        """
+        Return IAM username truncated to 50 characters
+        """
+        return truncate_name(
+            '{}-{}'.format(settings.AWS_IAM_USER_PREFIX, self.database_name),
+            length=50
+        )
+
+    def create_iam_user(self):
+        """
+        Create IAM user with access only to the s3 bucket set in s3_bucket_name
+        """
+        if not(settings.AWS_ACCESS_KEY_ID or settings.AWS_SECRET_ACCESS_KEY):
+            return
+        iam = get_master_iam_connection()
+        iam.create_user(self.iam_username)
+        iam.put_user_policy(
+            self.iam_username,
+            'allow_access_s3_bucket',
+            self.get_s3_policy()
+        )
+        key_response = iam.create_access_key(self.iam_username)
+        keys = key_response['create_access_key_response']['create_access_key_result']['access_key']
+        self.s3_access_key = keys['access_key_id']
+        self.s3_secret_access_key = keys['secret_access_key']
+
+    def get_s3_connection(self):
+        """
+        Create connection to S3 service
+        """
+        return boto.connect_s3(
+            self.s3_access_key,
+            self.s3_secret_access_key
+        )
+
+    def provision_s3(self):
+        """
+        Create S3 Bucket if it doesn't exist
+        """
+        if self.s3_access_key and self.s3_secret_access_key:
+            s3 = self.get_s3_connection()
+            bucket = s3.create_bucket(self.s3_bucket_name)
+            bucket.set_cors(get_s3_cors_config())
+
+    def deprovision_s3(self):
+        """
+        Deprovision S3 by deleting S3 bucket and IAM user
+        """
+        if not(self.s3_access_key or self.s3_secret_access_key):
+            return
+        if self.s3_bucket_name:
+            try:
+                s3 = self.get_s3_connection()
+                bucket = s3.get_bucket(self.s3_bucket_name)
+                for key in bucket:
+                    key.delete()
+                s3.delete_bucket(self.s3_bucket_name)
+                self.s3_bucket_name = ""
+                self.save()
+            except boto.exception.S3ResponseError:
+                self.logger.exception(
+                    'There was an error trying to remove S3 bucket "%s".',
+                    self.s3_bucket_name
+                )
+        try:
+            iam = get_master_iam_connection()
+            # Access keys and policies need to be deleted before removing the user
+            iam.delete_access_key(self.s3_access_key, user_name=self.iam_username)
+            iam.delete_user_policy(self.iam_username, 'allow_access_s3_bucket')
+            iam.delete_user(self.iam_username)
+            self.s3_access_key = ""
+            self.s3_secret_access_key = ""
+            self.save()
+        except boto.exception.BotoServerError:
+            self.logger.exception(
+                'There was an error trying to remove IAM user "%s".',
+                self.iam_username
+            )

--- a/instance/tests/models/factories/openedx_appserver.py
+++ b/instance/tests/models/factories/openedx_appserver.py
@@ -28,7 +28,7 @@ from instance.tests.models.factories.openedx_instance import OpenEdXInstanceFact
 # Functions ###################################################################
 
 
-def make_test_appserver(instance=None, server=None):
+def make_test_appserver(instance=None, s3=False, server=None):
     """
     Factory method to create an OpenEdXAppServer (and OpenStackServer).
     """
@@ -36,6 +36,11 @@ def make_test_appserver(instance=None, server=None):
         instance = OpenEdXInstanceFactory()
     if not instance.load_balancing_server:
         instance.load_balancing_server = LoadBalancingServer.objects.select_random()
+        instance.save()
+    if s3:
+        instance.s3_access_key = 'test'
+        instance.s3_secret_access_key = 'test'
+        instance.s3_bucket_name = 'test'
         instance.save()
     appserver = instance._create_owned_appserver()
 

--- a/instance/tests/test_factories.py
+++ b/instance/tests/test_factories.py
@@ -43,7 +43,7 @@ class FactoriesTestCase(TestCase):
     CONFIGURATION_EXTRA_SETTINGS = (
         "{"
         "'demo_test_users': [],"
-        "'DEMO_CREATE_STAFF_USER': False"
+        "'DEMO_CREATE_STAFF_USER': False,"
         "'SANDBOX_ENABLE_CERTIFICATES': False"
         "}"
     )
@@ -125,6 +125,7 @@ class FactoriesTestCase(TestCase):
         configuration_extra_settings = """
         DEMO_CREATE_STAFF_USER: false
         demo_test_users: []
+        SANDBOX_ENABLE_CERTIFICATES: false
         EXTRA_SETTINGS: false
         ADDITIONAL_SETTINGS: true
         """
@@ -146,30 +147,30 @@ class FactoriesTestCase(TestCase):
         MySQLServer.objects.all().delete()
         MongoDBServer.objects.all().delete()
 
-        for setting, value, warning in (
+        for custom_settings, warning in (
                 (
-                    'SWIFT_ENABLE',
-                    False,
-                    'Swift support is currently disabled. Adjust SWIFT_ENABLE setting.',
+                    {'SWIFT_ENABLE': False, 'AWS_ACCESS_KEY': None, 'AWS_SECRET_ACCESS_KEY': None},
+                    (
+                        "Swift and AWS support is currently disabled. Add AWS_ACCESS_KEY_ID and "
+                        "AWS_SECRET_ACCESS_KEY settings or adjust SWIFT_ENABLE setting."
+                    ),
                 ),
                 (
-                    'DEFAULT_INSTANCE_MYSQL_URL',
-                    None,
+                    {'DEFAULT_INSTANCE_MYSQL_URL': None},
                     (
                         "No MySQL servers configured, and default URL for external MySQL database is missing."
                         "Create at least one MySQLServer, or set DEFAULT_INSTANCE_MYSQL_URL in your .env."
                     ),
                 ),
                 (
-                    'DEFAULT_INSTANCE_MONGO_URL',
-                    None,
+                    {'DEFAULT_INSTANCE_MONGO_URL': None},
                     (
                         "No MongoDB servers configured, and default URL for external MongoDB database is missing."
                         "Create at least one MongoDBServer, or set DEFAULT_INSTANCE_MONGO_URL in your .env."
                     ),
                 ),
         ):
-            with override_settings(**{setting: value}):
+            with override_settings(**custom_settings):
                 sub_domain = "production-instance-doomed"
                 production_instance_factory(sub_domain=sub_domain)
                 log_entries = LogEntry.objects.filter(level="WARNING")

--- a/instance/tests/test_factories.py
+++ b/instance/tests/test_factories.py
@@ -44,6 +44,7 @@ class FactoriesTestCase(TestCase):
         "{"
         "'demo_test_users': [],"
         "'DEMO_CREATE_STAFF_USER': False"
+        "'SANDBOX_ENABLE_CERTIFICATES': False"
         "}"
     )
     SANDBOX_DEFAULTS = {

--- a/opencraft/settings.py
+++ b/opencraft/settings.py
@@ -581,3 +581,18 @@ DEFAULT_LOAD_BALANCING_SERVER = env('DEFAULT_LOAD_BALANCING_SERVER', default=Non
 
 LOAD_BALANCER_FRAGMENT_NAME_PREFIX = env('LOAD_BALANCER_FRAGMENT_NAME_PREFIX', default='opencraft-')
 PRELIMINARY_PAGE_SERVER_IP = env('PRELIMINARY_PAGE_SERVER_IP', default=None)
+
+# AWS. Must be set if SWIFT_ENABLE = False"
+
+# Permissions required for this account are:
+# iam:PutUserPolicy
+# iam:CreateUser
+# iam:CreateAccessKey
+# iam:DeleteUser
+# iam:DeleteAccessKey
+# iam:DeleteUserPolicy
+
+AWS_SECRET_ACCESS_KEY = env('AWS_SECRET_ACCESS_KEY', default=None)
+AWS_ACCESS_KEY_ID = env('AWS_ACCESS_KEY_ID', default=None)
+AWS_S3_BUCKET_PREFIX = env('S3_BUCKET_PREFIX', default='ocim')
+AWS_IAM_USER_PREFIX = env('IAM_USER_PREFIX', default='ocim')

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ astroid==1.4.8
 Babel==2.3.4
 backports.shutil-get-terminal-size==1.0.0
 beautifulsoup4==4.5.1
+boto==2.48.0
 chardet==2.3.0
 CherryPy==3.8.2
 click==6.6


### PR DESCRIPTION
Adds s3 as default storage for new instances.

JIRA Ticket: OC-3841

Testing instructions:

- Add AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY global credentials to your .env file, this credentials should have permission to create other IAM users.
- Setup an instance on the admin (fill all the required values). When saving the instance the system will use your global credentials to create an IAM user with permissions to create and update the bucket. Verify that the fields "s3_bucket_name", "s3_access_key" and "s3_secret_access_key" have been populated.
- Launch a new appserver from the interface. Check that a bucket was created with the instance domain name.

Permissions needed for the AWS Global account are:

iam:PutUserPolicy
iam:CreateUser
iam:CreateAccessKey
iam:DeleteUser
iam:DeleteAccessKey
iam:DeleteUserPolicy