### PR TITLE
Remove the geerlingguy.nginx role.

### DIFF
--- a/deploy/opencraft.yml
+++ b/deploy/opencraft.yml
@@ -3,7 +3,7 @@
   become: true
   gather_facts: false
   tasks:
-    - raw: sudo apt-get update -qq && sudo apt-get install -qq python
+    - raw: "[ -x /usr/bin/python ] || sudo apt-get update -qq && sudo apt-get install -qq python"
 
 - name: Deploy the OpenCraft Instance Manager
   hosts: all
@@ -15,9 +15,5 @@
     - name: forward-server-mail
       FORWARD_MAIL_MYDOMAIN: "{{ inventory_hostname }}"
       when: vagrant_mode is undefined or not vagrant_mode
-    - name: geerlingguy.nginx
-      nginx_remove_default_vhost: true
-      when: vagrant_mode is undefined or not vagrant_mode
     - opencraft
-    - pmbauer.tarsnap
     - consul

--- a/deploy/requirements.yml
+++ b/deploy/requirements.yml
@@ -1,23 +1,17 @@
-# Note: due to security concerns we prefer using git hashes than ansible versions.
+# Note: due to security concerns we prefer using git hashes than ansible versions for
+# roles not managed by OpenCraft.
 
-- name: geerlingguy.nginx
-  src: https://github.com/geerlingguy/ansible-role-nginx
-  version: e81825546577cfb300efbcaec32aae4716561385
-
-# Our fork of security, can be synced when this is merged: https://github.com/geerlingguy/ansible-role-security/pull/16
 - name: geerlingguy.security
-  src: https://github.com/open-craft/ansible-role-security
-  version: origin/jbzdak/notify-mail
+  src: https://github.com/geerlingguy/ansible-role-security
+  version: af8b13833290ccae2ce1d2c9cce78862ddd3666c
 
 - name: kamaln7.swapfile
   src: https://github.com/kamaln7/ansible-swapfile
   version: 8eb0e18d90a7f25b6658fbf56bcba01b84a664fc
 
-# Our fork of pmbauer tarsnap.
-# Can be cleared when this is closed: https://github.com/pmbauer/ansible-tarsnap/pull/3
 - name: pmbauer.tarsnap
-  src: https://github.com/open-craft/ansible-tarsnap
-  version: d96b1e69ae6b930e0841d7b025a3070c408a23f4
+  src: https://github.com/pmbauer/ansible-tarsnap
+  version: 7a625912409a0be2a3bf48967c60c5328ae2f3b2
 
 - name: backup-to-tarsnap
   src: https://github.com/open-craft/ansible-backup-to-tarsnap

--- a/deploy/vagrant_vars.yml
+++ b/deploy/vagrant_vars.yml
@@ -24,6 +24,9 @@ security_sudoers_passwordless: [ 'vagrant' ]
 # Disable reporting to New Relic
 COMMON_SERVER_ENABLE_NEWRELIC: false
 
+# Do not install Certbot
+COMMON_SERVER_INSTALL_CERTBOT: false
+
 # The default .env file configuration for Vagrant. These settings can be
 # overridden in the private.yml file.
 OPENCRAFT_ENV_TOKENS:


### PR DESCRIPTION
Since we install nginx in the common-server role now, the geerlingguy.nginx role is no longer needed.

Further changes in this PR:
* Only install Python 2 if it's not already installed.
* Remove `pmbauer.tarsnap` from the playbook, since the role is a dependency of the `opencraft` role anyway.
* Consolidate role versions with the version in ansible-playbooks.
* Do not install Certbot on the Vagrant installation.

I tested these change on Vagrant only, by building a new Vagrant VM from scratch.