### PR TITLE
WIP: Link to instance page from admin

### DIFF
--- a/instance/models/openedx_instance.py
+++ b/instance/models/openedx_instance.py
@@ -26,6 +26,7 @@ from django.db import models, transaction
 from django.db.backends.utils import truncate_name
 from django.db.models import F
 from django.template import loader
+from django.urls import reverse
 from django.utils import timezone
 
 from instance import gandi
@@ -74,6 +75,13 @@ class OpenEdXInstance(
 
     def __str__(self):
         return "{} ({})".format(self.name, self.domain)
+
+    def get_absolute_url(self):
+        """
+        Return link to the instance admin page, e.g. /instance/210/
+        This link is shown in Django's admin.
+        """
+        return reverse('instance:index') + str(self.ref.id) + "/"
 
     def get_active_appservers(self):
         """


### PR DESCRIPTION
This adds a „View on site“ button to the openedx_instance admin page, to be able to move from Django's admin to Ocim's admin.

![view-on-site](https://user-images.githubusercontent.com/132703/39317745-06e2e122-4985-11e8-8b22-aad5eb3ef87f.png)

Tested in local.

This PR was created to test CircleCI's cleanup process. **WIP** because I might still use it to trigger some builds.