### PR TITLE
Disable SSH host key checking for Ansible.

### DIFF
--- a/instance/ansible.py
+++ b/instance/ansible.py
@@ -166,6 +166,10 @@ def run_playbook(requirements_path, inventory_str, vars_str, playbook_path, play
         env = dict(os.environ)
         env['TMPDIR'] = ansible_tmp_dir
 
+        # Disable SSH host key checking by Ansible – since IP addresses are constantly reused,
+        # changing host keys are expected.
+        env['ANSIBLE_HOST_KEY_CHECKING'] = 'false'
+
         yield subprocess.Popen(
             cmd,
             stdout=subprocess.PIPE,


### PR DESCRIPTION
Follow-up to #300.

The [Ansible configuration in edx/configuration disables SSH host key checking](https://github.com/edx/configuration/blob/837308626ff278a39303f8b987313d7e38c36ef3/playbooks/ansible.cfg#L8).  The first time a playbook runs for a given IP, SSH will accept the host key unconditionally 
and add it to `~/.ssh/known_hosts`.  The `ansible.cfg` in ansible-playbooks, by contrast, does not disable host key checking.  Most of the time this isn't a problem, since by the time the playbook runs the host key is already in `known_hosts`.  If we by chance get assigned an IP that we already had for an earlier app server, we will have a different host key in `known_hosts`.  Ansible will ignore the discrepancy for the upstream playbook, since host key checking is disabled, but SSH won't add the key to `known_hosts`, because there already is a different key for the same IP.  In this case, our playbook will fail.

This PR disables host key checking for all Ansible runs.