### PR TITLE
Get only archived and successfully deployed instances for redeploy.

### DIFF
--- a/instance/management/commands/instance_redeploy.py
+++ b/instance/management/commands/instance_redeploy.py
@@ -216,8 +216,9 @@ class Command(BaseCommand):
             **instance_filter
         ).exclude(
             **instance_exclusion
-        ).exclude(
-            ref_set__is_archived=True
+        ).filter(
+            ref_set__is_archived=False,
+            successfully_provisioned=True,
         ).exclude(
             tags__in=[
                 self.ongoing_tag,

--- a/instance/tests/management/test_instance_redeploy.py
+++ b/instance/tests/management/test_instance_redeploy.py
@@ -112,10 +112,14 @@ class InstanceRedeployTestCase(TestCase):
         """
         # Create test instances with known attributes, and mock out the appserver_set
         instances = {}
-        for label in 'ABCDEFG':
+        for label in 'ABCDEFGH':
 
             # Create an instance, with an appserver
-            instance = OpenEdXInstance.objects.create(sub_domain=label, openedx_release='z.1')
+            instance = OpenEdXInstance.objects.create(
+                sub_domain=label,
+                openedx_release='z.1',
+                successfully_provisioned=True
+            )
             appserver = make_test_appserver(instance)
 
             if success:
@@ -137,6 +141,10 @@ class InstanceRedeployTestCase(TestCase):
         # Archive Instance B, so it too won't match the filter
         instances['B']['instance'].ref.is_archived = True
         instances['B']['instance'].save()
+
+        # Pretend Instance H was never successfully provisioned, so it also won't match the filter.
+        instances['H']['instance'].successfully_provisioned = False
+        instances['H']['instance'].save()
 
         def _tag_instance(instance, tag_name):
             """


### PR DESCRIPTION
We will be running a mass redeployment, and want to make sure to only include those successfully provisioned. This PR inverts the logic a bit to `filter` out those not archived rather than call `exclude` for those that are, and then also to filter those that are only successfully provisioned.

Testing not explicitly needed due to the simplicity of the change and because the tests should build plenty of confidence. And because we'll be running the command right now anyway.