### PR TITLE
Catch any exception if an appserver fails to spawn.

### DIFF
--- a/instance/tasks.py
+++ b/instance/tasks.py
@@ -67,7 +67,10 @@ def spawn_appserver(
         instance = OpenEdXInstance.objects.get(ref_set__pk=instance_ref_id)
 
         instance.logger.info('Spawning new AppServer, attempt %d of %d', i, num_attempts)
-        appserver_id = instance.spawn_appserver()
+        try:
+            appserver_id = instance.spawn_appserver()
+        except Exception:  # pylint: disable=broad-except
+            appserver_id = None
         if appserver_id:
             if failure_tag:
                 instance.tags.remove(failure_tag)


### PR DESCRIPTION
Otherwise workers will completely drop the task and the instance redeployment management command will not be able to recognize if an ongoing instance has actually failed, since the ongoing tag will remain.

Test instructions:

Bring this to prod where we're currently facing issues with provisioning S3 on the first try, run the instance redeployment command, and notice that now the low prio workers no longer completely drop all work after failing to provision S3.