### PR TITLE
Check that the heartbeat is functioning before activating.

### DIFF
--- a/instance/tests/integration/integration_instance.py
+++ b/instance/tests/integration/integration_instance.py
@@ -385,12 +385,13 @@ class InstanceIntegrationTestCase(IntegrationTestCase):
         self.assertEqual(appserver.server.status, ServerStatus.Ready)
 
     @patch_git_checkout
-    def test_ansible_failignore(self, git_checkout, git_working_dir):
+    @patch("instance.models.openedx_appserver.OpenEdXAppServer.heartbeat_active")
+    def test_ansible_failignore(self, heartbeat_active, git_checkout, git_working_dir):
         """
         Ensure failures that are ignored aren't reflected in the instance
         """
         git_working_dir.return_value = os.path.join(os.path.dirname(__file__), "ansible")
-
+        heartbeat_active.return_value = True
         instance = OpenEdXInstanceFactory(name='Integration - test_ansible_failignore')
         with patch.object(OpenEdXAppServer, 'CONFIGURATION_PLAYBOOK', new="playbooks/failignore.yml"), \
                 self.settings(ANSIBLE_APPSERVER_PLAYBOOK='playbooks/failignore.yml'):

--- a/instance/tests/utils.py
+++ b/instance/tests/utils.py
@@ -144,6 +144,7 @@ def patch_services(func):
                 mock_disable_monitoring=stack_patch(
                     'instance.models.mixins.openedx_monitoring.OpenEdXMonitoringMixin.disable_monitoring'
                 ),
+                mock_heartbeat_active=stack_patch('instance.models.openedx_appserver.OpenEdXAppServer.heartbeat_active')
             )
             stack.enter_context(patch_gandi())
             return func(self, mocks, *args, **kwargs)


### PR DESCRIPTION
There are issues where an appserver is very quickly made active behind the load balancer before it has a steady heartbeat. In that case, HAProxy takes it off the map because it assumes the server is down. Do not put a server in a healthy state on our side unless the heartbeat is functioning.