### PR TITLE
Disable New Relic and RabbitMQ by default

### DIFF
--- a/instance/models/mixins/openedx_config.py
+++ b/instance/models/mixins/openedx_config.py
@@ -234,7 +234,7 @@ class OpenEdXConfigMixin(ConfigMixinBase):
             "EDXAPP_WORKER_DEFAULT_STOPWAITSECS": 1200,
 
             # Monitoring
-            "COMMON_ENABLE_NEWRELIC": bool(settings.NEWRELIC_LICENSE_KEY),
+            "COMMON_ENABLE_NEWRELIC": False,
             "COMMON_ENABLE_NEWRELIC_APP": bool(settings.NEWRELIC_LICENSE_KEY),
             "NEWRELIC_LICENSE_KEY": settings.NEWRELIC_LICENSE_KEY or "",
 
@@ -245,6 +245,9 @@ class OpenEdXConfigMixin(ConfigMixinBase):
             "DISCOVERY_HOSTNAME": '~{}'.format(self.instance.discovery_domain_nginx_regex),
             "DISCOVERY_NGINX_PORT": 80,
             "DISCOVERY_SSL_NGINX_PORT": 443,
+
+            # RabbitMQ disabled locally
+            "SANBOX_ENABLE_RABBITMQ": False,
 
             # Ecommerce
             "SANDBOX_ENABLE_ECOMMERCE": False,  # set to true to enable ecommerce

--- a/instance/tests/models/test_openedx_instance.py
+++ b/instance/tests/models/test_openedx_instance.py
@@ -262,7 +262,7 @@ class OpenEdXInstanceTestCase(TestCase):
         appserver_id = instance.spawn_appserver()
         appserver = instance.appserver_set.get(pk=appserver_id)
         configuration_vars = yaml.load(appserver.configuration_settings)
-        self.assertIs(configuration_vars['COMMON_ENABLE_NEWRELIC'], True)
+        self.assertIs(configuration_vars['COMMON_ENABLE_NEWRELIC'], False)
         self.assertIs(configuration_vars['COMMON_ENABLE_NEWRELIC_APP'], True)
         self.assertEqual(configuration_vars['COMMON_ENVIRONMENT'], 'opencraft')
         self.assertEqual(configuration_vars['COMMON_DEPLOYMENT'], instance.internal_lms_domain)


### PR DESCRIPTION
Disables New relic and RabbitMQ depends on: https://github.com/open-craft/configuration/pull/43/