### PR TITLE
Fixed the logic to prevent multiple instances from being spawned

### DIFF
--- a/instance/tasks.py
+++ b/instance/tasks.py
@@ -76,12 +76,13 @@ def spawn_appserver(
                 instance.tags.remove(failure_tag)
             if success_tag:
                 instance.tags.add(success_tag)
-            if mark_active_on_success and make_appserver_active(
+            if mark_active_on_success:
+                make_appserver_active(
                     appserver_id,
                     active=mark_active_on_success,
                     deactivate_others=deactivate_old_appservers
-            ):
-                break
+                )
+            break
     else:
         if failure_tag:
             instance.tags.add(failure_tag)


### PR DESCRIPTION
This PR addresses a bug pointed out in [OC-4205's comment](https://tasks.opencraft.com/browse/OC-4205?focusedCommentId=70999&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-70999)

JIRA tickets: OC-4205

Testing instructions:

Since the API call [/api/v1/openedx_appserver/] does not call the spawn_appserver without num_count, the way to test it is  probably via the management command instance_redeploy.py It should break on success even if num_attempts >1.



Reviewers

@UmanShahzad
@xitij2000 