### PR TITLE
Disable by default provisioning analytics_api and insights.

### DIFF
--- a/instance/models/mixins/openedx_config.py
+++ b/instance/models/mixins/openedx_config.py
@@ -282,6 +282,10 @@ class OpenEdXConfigMixin(ConfigMixinBase):
             # The certificate agent poll xqueue way too frequently for what we need by default (5 seconds).
             # Make it poll less.
             "CERTS_QUEUE_POLL_FREQUENCY": 60,
+
+            # Insights and analytics_api
+            "SANDBOX_ENABLE_ANALYTICS_API": False, # set to true to enable analytics_api
+            "SANDBOX_ENABLE_INSIGHTS": False # set to true to enable insights
         }
 
         if self.smtp_relay_settings:


### PR DESCRIPTION
This PR adds:

```
"SANDBOX_ENABLE_ANALYTICS_API": False
"SANDBOX_ENABLE_INSIGHTS": False
```

to default Open edX settings to disable provisioning of the `analytics_api` and `insights` in sandboxes.
Both of these flags have been just added to [edx/configuration](https://github.com/edx/configuration) repo via https://github.com/edx/configuration/pull/4563.

https://hawthorn-beta.sandbox.opencraft.hosting/ have been spawned with both flags set to False manually.

**Reviewers:**
- [ ] @pomegranited 

Signed-off-by: Tomasz Gargas <tomasz@opencraft.com>