### PR TITLE
Revert "Check that the heartbeat is functioning before activating."

### DIFF
--- a/instance/tests/integration/integration_instance.py
+++ b/instance/tests/integration/integration_instance.py
@@ -385,13 +385,12 @@ class InstanceIntegrationTestCase(IntegrationTestCase):
         self.assertEqual(appserver.server.status, ServerStatus.Ready)
 
     @patch_git_checkout
-    @patch("instance.models.openedx_appserver.OpenEdXAppServer.heartbeat_active")
-    def test_ansible_failignore(self, heartbeat_active, git_checkout, git_working_dir):
+    def test_ansible_failignore(self, git_checkout, git_working_dir):
         """
         Ensure failures that are ignored aren't reflected in the instance
         """
         git_working_dir.return_value = os.path.join(os.path.dirname(__file__), "ansible")
-        heartbeat_active.return_value = True
+
         instance = OpenEdXInstanceFactory(name='Integration - test_ansible_failignore')
         with patch.object(OpenEdXAppServer, 'CONFIGURATION_PLAYBOOK', new="playbooks/failignore.yml"), \
                 self.settings(ANSIBLE_APPSERVER_PLAYBOOK='playbooks/failignore.yml'):

--- a/instance/tests/utils.py
+++ b/instance/tests/utils.py
@@ -144,7 +144,6 @@ def patch_services(func):
                 mock_disable_monitoring=stack_patch(
                     'instance.models.mixins.openedx_monitoring.OpenEdXMonitoringMixin.disable_monitoring'
                 ),
-                mock_heartbeat_active=stack_patch('instance.models.openedx_appserver.OpenEdXAppServer.heartbeat_active')
             )
             stack.enter_context(patch_gandi())
             return func(self, mocks, *args, **kwargs)


### PR DESCRIPTION
Reverts open-craft/opencraft#316

I too quickly merged this before testing it on stage. After testing it with https://stage.console.opencraft.com/instance/2110/edx-appserver/611/, the server failed to configure for seemingly a related reason, so I've made this revert PR. Will merge as soon as tests pass and we can try again.