### PR TITLE
Mark an instance as 'terminated' only on successful deletion

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -10,7 +10,7 @@ jobs:
           LOAD_BALANCER_FRAGMENT_NAME_PREFIX: 'integration-'
           TEST_RUNNER: 'opencraft.tests.utils.CircleCIParallelTestRunner'
       - image: redis
-      - image: mongo
+      - image: mongo:3.2-jessie
       - image: "circleci/mysql:5"
         environment:
           MYSQL_ALLOW_EMPTY_PASSWORD: True


### PR DESCRIPTION
## Short description of the changes

If there are errors while making the OpenStack delete API call,
mark the instance as 'unknown'. In case the server is not found,
mark it as 'terminated'.

## Steps to test:
### Server not found scenario
* Launch an AppServer instance and wait till the OpenStack VM is up and running.
* Delete the VM from the OpenStack console bypassing OCIM.
* Try to terminate the VM from OCIM (I called the `terminate()` method on the instance from the shell)
* The OpenStack API should return a 'not found' status and the status of the AppServer should change to `terminated`.

### OpenStack API issues scenario
* Launch an AppServer and wait till the OpenStack VM is up and running.
* Change the OpenStack API endpoint to gibberish. (I tested by disconnecting the network on my computer).
* Try to terminate the VM.
* Since the OpenStack API is unreachable, there will be a `NewConnectionError` exception thrown (caught by `requests.RequestException`).
* The status of the server should now change to `unknown`.