### PR TITLE
Set DISCOVERY_VERSION to a correct default value

### DIFF
--- a/instance/models/mixins/openedx_config.py
+++ b/instance/models/mixins/openedx_config.py
@@ -245,6 +245,7 @@ class OpenEdXConfigMixin(ConfigMixinBase):
             "DISCOVERY_HOSTNAME": '~{}'.format(self.instance.discovery_domain_nginx_regex),
             "DISCOVERY_NGINX_PORT": 80,
             "DISCOVERY_SSL_NGINX_PORT": 443,
+            "DISCOVERY_VERSION": self.openedx_release,
 
             # RabbitMQ disabled locally
             "SANBOX_ENABLE_RABBITMQ": False,

--- a/instance/tests/models/test_openedx_appserver.py
+++ b/instance/tests/models/test_openedx_appserver.py
@@ -47,6 +47,8 @@ from instance.tests.utils import patch_services
 
 
 # Tests #######################################################################
+
+@ddt  # pylint: disable=too-many-public-methods
 class OpenEdXAppServerTestCase(TestCase):
     """
     Test cases for OpenEdXAppServer objects
@@ -200,6 +202,52 @@ class OpenEdXAppServerTestCase(TestCase):
         instance = OpenEdXInstanceFactory(openstack_region="elsewhere")
         make_test_appserver(instance)
         mock_get_nova_client.assert_called_once_with("elsewhere")
+
+    @data(
+        'ANALYTICS_API_VERSION',
+        'DISCOVERY_VERSION',
+        'ECOMMERCE_VERSION',
+        'INSIGHTS_VERSION',
+        'NOTIFIER_VERSION',
+    )
+    def test_default_component_versions(self, component_version):
+        """
+        Test the default value of components' version
+        """
+        instance = OpenEdXInstanceFactory(
+            name='Vars Instance',
+            email='vars@example.com',
+            openedx_release='dummy-release'
+        )
+        appserver = make_test_appserver(instance)
+        self.assertIn(
+            '{}: dummy-release'.format(component_version), appserver.configuration_settings
+        )
+
+    @data(
+        'ANALYTICS_API_VERSION',
+        'DISCOVERY_VERSION',
+        'ECOMMERCE_VERSION',
+        'INSIGHTS_VERSION',
+        'NOTIFIER_VERSION',
+    )
+    def test_component_versions_on_override(self, component_version):
+        """
+        Test the components' version values on override
+        """
+        extra_configuration = """
+        {}: dummy-release
+        """.format(component_version)
+        instance = OpenEdXInstanceFactory(
+            name='Vars Instance',
+            email='vars@example.com',
+            openedx_release='open-release/ginkgo.2',
+            configuration_extra_settings=extra_configuration,
+        )
+        appserver = make_test_appserver(instance)
+        self.assertIn(
+            '{}: dummy-release'.format(component_version), appserver.configuration_settings
+        )
 
     def test_configuration_extra_settings(self):
         """


### PR DESCRIPTION
## Short Description

Set the default value of `DISCOVERY_VERSION` to the openedx release
being installed to avoid the master branch of discovery
being used as the default value. The master version of discovery
doesn't work well with other `gingko`-based services.

## Steps to test
### Normal Scenario:
1. Create an instance with a specific openedx release (for example, `open-release/ginkgo.2`)
1. Spawn an AppServer.
1. Once the AppServer has started spawning, check the configuration value used for `DISCOVERY_VERSION`. This can be checked from the `Configuration` section of the AppServer in the web UI from the value of `DISCOVERY_VERSION` in `Combined ansible vars:`
1. The value should match the openedx release with which the instance was created.

### With configuration override:
1. Create an instance with a specific openedx release and extra configuration overriding `DISCOVERY_VERSION` to `master`.
1. Repeat steps 2, 3 from the previous scenario.
1. The value of `DISCOVERY_VERSION` should be set to `master` and not the openedx release with which the instance was created.



