### PR TITLE
Don't merge: Add a Nomad jobspec for memcached jobs.

### DIFF
--- a/instance/templates/instance/memcached/memcached.nomad
+++ b/instance/templates/instance/memcached/memcached.nomad
@@ -1,0 +1,53 @@
+# Jobs need a globally consistent name, so we need to include the instance id.
+job "memcached-1234" {
+  datacenters = ["dc1"]
+  type = "service"
+  constraint {
+    distinct_hosts = true
+  }
+  update {
+    max_parallel = 1
+  }
+  migrate {
+    max_parallel = 1
+  }
+  group "memcached" {
+    count = 3    # Only 1 for stage
+    task "memcached" {
+      driver = "exec"
+      config {
+        command = "/usr/bin/memcached"
+        args    = [
+          # TCP port
+          "-p", "${NOMAD_PORT_cache}",
+          # Memory limit.  The daemon won't use more than the limit, but may use significantly less.
+          "-m", "64", # MB
+        ]
+      }
+      resources {
+        cpu    = 25 # MHz
+        # The daemon may grow bigger for some instances, capped at 64 MB, but will probably remain
+        # smaller for most sandboxes and instances, so we don't want to make excessive allocations.
+        memory = 32 # MB
+        network {
+          # Should be easily enough on average.  We don't want this to become a limiting factor for
+          # scheduling.
+          mbits = 1
+          port "cache" {}
+        }
+      }
+      # Register with Consul.
+      service {
+        name = "memcached-1234"
+        tags = ["memcached"]
+        port = "cache"
+        check {
+          name     = "alive"
+          type     = "tcp"
+          interval = "10s"
+          timeout  = "1s"
+        }
+      }
+    }
+  }
+}

--- a/instance/templates/instance/redis/redis.nomad
+++ b/instance/templates/instance/redis/redis.nomad
@@ -1,0 +1,66 @@
+# Jobs need a globally consistent name, so we need to include the instance id.
+job "redis-1234" {
+  datacenters = ["dc1"]
+  type = "service"
+  constraint {
+    distinct_hosts = true
+  }
+  update {
+    max_parallel = 1
+  }
+  migrate {
+    max_parallel = 1
+  }
+  group "redis" {
+    count = 1
+    task "server" {
+      driver = "exec"
+      config {
+        command = "/usr/bin/redis-server"
+        args    = [
+          # Listen only on localhost
+          "--bind", "127.0.0.1",
+          # TCP port
+          "--port", "${NOMAD_PORT_redis}",
+        ]
+      }
+      resources {
+        cpu    = 20 # MHz
+        # The daemon may in theory grow bigger than this, but given that it only stores the Celery
+        # queue it will in general be much smaller.
+        memory = 32 # MB
+        disk = 0
+        network {
+          # Should be easily enough on average.  We don't want this to become a limiting factor for
+          # scheduling.
+          mbits = 1
+          port "redis" {}
+        }
+      }
+    }
+    task "connect-proxy" {
+      driver = "exec"
+      config {
+        command = "/usr/local/bin/consul"
+        args    = [
+          "connect", "proxy",
+          "-service", "redis-1234",
+          "-service-addr", "127.0.0.1:${NOMAD_PORT_server_redis}",
+          "-listen", ":${NOMAD_PORT_redis}",
+          "-register",
+        ]
+      }
+      resources {
+        cpu = 20 # MHz
+        memory = 20 # MB
+        disk = 0
+        network {
+          # Should be easily enough on average.  We don't want this to become a limiting factor for
+          # scheduling.
+          mbits = 1
+          port "redis" {}
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
We probably won't need the spec in its current form, since we will create the jobs via the Nomad API.  I'm just adding it to the repo so it can be reviewed and used as a basis for the API call.