### PR TITLE
Support mongo replicasets backported into OpenCraft Ginkgo

### DIFF
--- a/instance/models/mixins/openedx_database.py
+++ b/instance/models/mixins/openedx_database.py
@@ -355,11 +355,14 @@ class OpenEdXDatabaseMixin(MySQLInstanceMixin, MongoDBInstanceMixin, RabbitMQIns
         primary_mongodb_server = self.primary_mongodb_server
         edxapp_mongo_hosts = ''
 
-        # Ginkgo (and previous) releases do not support replicasets, and require a list of hostnames.
-        if "ginkgo" in self.openedx_release or "ficus" in self.openedx_release:
+        # Upstream Ginkgo (and previous) releases do not support replicasets, and require a list of hostnames.
+        # OpenCraft backported replicaset support into Ginkgo release branches.
+        if (("ginkgo" in self.openedx_release and "opencraft" not in self.configuration_version) or
+                "ficus" in self.openedx_release):
             edxapp_mongo_hosts = [primary_mongodb_server.hostname]  # pylint: disable=redefined-variable-type
 
-        # Replicasets are supported by post-Ginkgo releases, and require a comma-separated string of hostnames.
+        # Replicasets are supported by OpenCraft's ginkgo, and upstream post-Ginkgo releases, and require a
+        # comma-separated string of hostnames.
         elif self.mongodb_replica_set:
             edxapp_mongo_hosts = ",".join(self.mongodb_servers.values_list('hostname', flat=True))
             extra_settings = {

--- a/instance/tests/models/test_openedx_database_mixins.py
+++ b/instance/tests/models/test_openedx_database_mixins.py
@@ -501,7 +501,6 @@ class MongoDBInstanceTestCase(TestCase):
         ('open-release/ficus', 'open-release/ficus'),
         ('open-release/ficus', 'opencraft-release/ficus'),
         ('open-release/ginkgo', 'open-release/ginkgo'),
-        ('open-release/ginkgo', 'opencraft-release/ginkgo'),
         (settings.OPENEDX_RELEASE_STABLE_REF, settings.STABLE_CONFIGURATION_VERSION),
     )
     @ddt.unpack
@@ -528,6 +527,7 @@ class MongoDBInstanceTestCase(TestCase):
         DEFAULT_MONGO_REPLICA_SET_HOSTS="test.opencraft.hosting,test1.opencraft.hosting,test2.opencraft.hosting"
     )
     @ddt.data(
+        ('open-release/ginkgo', 'opencraft-release/ginkgo'),
         (settings.DEFAULT_OPENEDX_RELEASE, settings.DEFAULT_CONFIGURATION_VERSION),
     )
     @ddt.unpack

--- a/instance/tests/models/test_openedx_database_mixins.py
+++ b/instance/tests/models/test_openedx_database_mixins.py
@@ -501,7 +501,7 @@ class MongoDBInstanceTestCase(TestCase):
         ('open-release/ficus', 'open-release/ficus'),
         ('open-release/ficus', 'opencraft-release/ficus'),
         ('open-release/ginkgo', 'open-release/ginkgo'),
-        (settings.OPENEDX_RELEASE_STABLE_REF, settings.STABLE_CONFIGURATION_VERSION),
+        (settings.OPENEDX_RELEASE_STABLE_REF, 'open-release/ginkgo'),
     )
     @ddt.unpack
     def test_ansible_settings_no_replica_set(self, openedx_release, configuration_version):
@@ -528,6 +528,7 @@ class MongoDBInstanceTestCase(TestCase):
     )
     @ddt.data(
         ('open-release/ginkgo', 'opencraft-release/ginkgo'),
+        (settings.OPENEDX_RELEASE_STABLE_REF, settings.STABLE_CONFIGURATION_VERSION),
         (settings.DEFAULT_OPENEDX_RELEASE, settings.DEFAULT_CONFIGURATION_VERSION),
     )
     @ddt.unpack

--- a/instance/tests/test_factories.py
+++ b/instance/tests/test_factories.py
@@ -56,7 +56,7 @@ class FactoriesTestCase(TestCase):
     }
     PRODUCTION_DEFAULTS = {
         "use_ephemeral_databases": False,
-        "configuration_version": settings.OPENEDX_RELEASE_STABLE_REF,
+        "configuration_version": settings.STABLE_CONFIGURATION_VERSION,
         "openedx_release": settings.OPENEDX_RELEASE_STABLE_REF,
         "configuration_extra_settings": CONFIGURATION_EXTRA_SETTINGS,
     }

--- a/opencraft/settings.py
+++ b/opencraft/settings.py
@@ -355,7 +355,9 @@ STABLE_EDX_PLATFORM_COMMIT = env('STABLE_EDX_PLATFORM_COMMIT', default=OPENEDX_R
 STABLE_CONFIGURATION_REPO_URL = env(
     'STABLE_CONFIGURATION_REPO_URL', default=DEFAULT_CONFIGURATION_REPO_URL
 )
-STABLE_CONFIGURATION_VERSION = env('STABLE_CONFIGURATION_VERSION', default=OPENEDX_RELEASE_STABLE_REF)
+# Note: until Hawthorn is released, OpenCraft uses their own ginkgo.1 configuration branch,
+# which includes backported replicaset support.
+STABLE_CONFIGURATION_VERSION = env('STABLE_CONFIGURATION_VERSION', default='opencraft-release/ginkgo.1')
 
 # The name of the security group to use for edxapp App servers.
 # This is used to set appropriate firewall rules to prevent external access to


### PR DESCRIPTION
Allow our production Ginkgo instances to use the performance benefits of mongo replica sets.

**JIRA tickets**: OC-4868

**Dependencies**: https://github.com/open-craft/configuration/pull/51

**Sandbox URL**:
* LMS: https://oc4868.sandbox.stage.opencraft.hosting/
* Studio: https://studio-oc4868.sandbox.stage.opencraft.hosting/

**Testing instructions**:

Steps used to create the above sandbox:
1. Configure an MongoDB primary server, with one or more secondaries, and replica set in the Ocim Admin.
1. Use the Ocim shell to create a Ginkgo instance attached to that replicaset, using the configuration version from https://github.com/open-craft/configuration/pull/51.
   ```python
   from instance.factories import production_instance_factory
   oc4868 = production_instance_factory(sub_domain='oc4868.sandbox', name='OC-4868 ginkgo replicaset (pomegranited)')
   oc4868.configuration_version = 'opencraft-release/ginkgo.1-replicaset'
   oc4868.configuration_extra_settings = ''
   oc4868.mongodb_server_id = # primary MongoDB server
   oc4868.mongodb_replicaset_id = # MongoDB ReplicaSet
   oc4868.save()
   ```
1. Spawn an appserver.
1. Check the appserver LMS/Studio to ensure they're running as expected.
1. From the LMS shell, run these commands to verify the replica set is enabled and read preference:
   ```python
   from xmodule.modulestore.django import modulestore

   # Check replica set enabled
   assert(modulestore().default_modulestore.db_connection.database.client._rs_client)
   assert(modulestore().contentstore.fs_files.database.client._rs_client)
   
   # LMS mongo reads from the secondaries
   from pymongo import ReadPreference
   assert(modulestore().default_modulestore.db_connection.database.client._read_pref == ReadPreference.SECONDARY_PREFERRED)
   assert(modulestore().contentstore.fs_files.database.client._read_pref == ReadPreference.SECONDARY_PREFERRED)
   ```
1. From the CMS shell, run the same commands as above, only the read preference here should be Primary:
   ```python
   ...
   # Studio mongo reads from the primary
   assert(modulestore().default_modulestore.db_connection.database.client._read_pref == ReadPreference.PRIMARY)
   assert(modulestore().contentstore.fs_files.database.client._read_pref == ReadPreference.PRIMARY)
   ```

**Reviewers**
- [ ] @mtyaka  