### PR TITLE
Store instance information in Consul

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -58,6 +58,14 @@ jobs:
             sudo apt-get install mysql-client
             pip install -r requirements.txt
             sudo apt-get install postgresql-client
+            sudo apt-get install unzip
+            sudo wget -P /tmp https://releases.hashicorp.com/consul/1.2.1/consul_1.2.1_linux_amd64.zip
+      - run:
+          name: Run Consul
+          command: |
+            sudo unzip /tmp/consul_1.2.1_linux_amd64.zip -d /usr/local/bin
+            consul agent -dev
+          background: true
       - save_cache:
           key: dependencies-{{ checksum "requirements.txt" }}
           paths:

--- a/instance/management/commands/update_metadata.py
+++ b/instance/management/commands/update_metadata.py
@@ -1,0 +1,138 @@
+# -*- coding: utf-8 -*-
+#
+# OpenCraft -- tools to aid developing and hosting free software projects
+# Copyright (C) 2015-2018 OpenCraft <contact@opencraft.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+"""
+Instance app - instances' metadata update management command
+"""
+
+# Imports #####################################################################
+
+import sys
+
+from django.conf import settings
+from django.core.management.base import BaseCommand
+
+import consul
+
+from instance.models.openedx_instance import OpenEdXInstance
+
+
+# Classes #####################################################################
+
+
+class Command(BaseCommand):
+    """
+    management command class for updating instances metadata
+    """
+    help = 'Updates the Consul metadata for all instances or just a single instance.'
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--skip-clean',
+            action='store_true',
+            help='Will skip cleaning metadata for archived instances.'
+        )
+        parser.add_argument(
+            '--skip-update',
+            action='store_true',
+            help='Will skip updating metadata for instances.'
+        )
+
+    def handle(self, *args, **options):
+        if not settings.CONSUL_ENABLED:
+            self.stdout.write(self.style.WARNING(
+                'This command does nothing unless you enable Consul in the configuration. Exiting...'
+            ))
+            sys.exit(0)
+
+        if not options.get('skip_update'):
+            self.update_all_instances_metadata()
+
+        if not options.get('skip_clean'):
+            self.clean_consul_metadata()
+
+    def update_all_instances_metadata(self):
+        """
+        This method will iterate over all non-archived instances to update
+        their metadata in Consul.
+        """
+        instances = self.get_running_instances()
+
+        self.stdout.write('Updating {} instances\' metadata...'.format(instances.count()))
+        for instance in instances:
+            instance.update_consul_metadata()
+
+        self.stdout.write(self.style.SUCCESS('Successfully updated instances\' metadata'))
+
+    def clean_consul_metadata(self):
+        """
+        This method will iterate over all archived instances and clean their
+        metadata from Consul.
+        """
+        client = consul.Consul()
+        instances_ids = self.get_archived_instances()
+        self.stdout.write('Cleaning metadata for {} archived instances...'.format(len(instances_ids)))
+
+        for instances_id in instances_ids:
+            prefix = settings.CONSUL_PREFIX.format(ocim=settings.OCIM_ID, instance=instances_id)
+            client.kv.delete(prefix, recurse=True)
+        self.stdout.write(self.style.SUCCESS('Successfully cleaned archived instances\' metadata'))
+
+    @staticmethod
+    def get_running_instances():
+        """
+        Generates a queryset of the active instances. Didn't put it as a
+        class variable to avoid multiple processes mutations.
+
+        :return: A Queryset of all active OpenEdXInstances
+        """
+        return OpenEdXInstance.objects.filter(ref_set__is_archived=False)
+
+    def get_archived_instances(self):
+        """
+        This management command gets the list of instance ids in Consul and the
+        non-archived instance ids from the database. Each instance only occurring
+        in Consul, but has been archived since should be considered archived.
+
+        :return: A set of all archived OpenEdXInstances
+        """
+        agent = consul.Consul()
+        archived_instances_ids = set()
+
+        instances_prefix = '{ocim}/instances/'.format(ocim=settings.OCIM_ID)
+        _, consul_instances_keys = agent.kv.get(instances_prefix, recurse=True, keys=True)
+
+        if not consul_instances_keys:
+            self.stdout.write('Consul does not contain data yet')
+            return archived_instances_ids
+
+        running_instances = self.get_running_instances()
+        running_instances_ids = running_instances.values_list('id', flat=True)
+
+        for key in consul_instances_keys:
+            id_elements = key.split('/')
+            try:
+                instance_id = int(id_elements[2])
+            except (IndexError, ValueError):
+                self.stdout.write(self.style.WARNING('A Consul key found with an unknown structure: {}'.format(key)))
+                continue
+
+            if instance_id not in running_instances_ids:
+                archived_instances_ids.add(instance_id)
+
+        return archived_instances_ids

--- a/instance/models/openedx_appserver.py
+++ b/instance/models/openedx_appserver.py
@@ -254,6 +254,7 @@ class OpenEdXAppServer(AppServer, OpenEdXAppConfiguration, AnsibleAppServerMixin
         if active:
             self.instance.enable_monitoring()
         self.instance.set_active_vm_dns_records()
+        self.instance.update_consul_metadata()
 
     @AppServer.status.only_for(AppServer.Status.New)
     def add_lms_users(self, lms_users):

--- a/instance/models/openedx_instance.py
+++ b/instance/models/openedx_instance.py
@@ -24,6 +24,7 @@ import string
 from django.conf import settings
 from django.db import models, transaction
 from django.db.backends.utils import truncate_name
+from django.db.models import F
 from django.template import loader
 from django.utils import timezone
 
@@ -41,7 +42,7 @@ from instance.models.mixins.openedx_storage import OpenEdXStorageMixin
 from instance.models.mixins.openedx_theme import OpenEdXThemeMixin
 from instance.models.mixins.secret_keys import SecretKeyInstanceMixin
 from instance.models.openedx_appserver import OpenEdXAppConfiguration
-from instance.models.utils import WrongStateException
+from instance.models.utils import WrongStateException, ConsulAgent
 from instance.utils import sufficient_time_passed
 
 
@@ -101,7 +102,9 @@ class OpenEdXInstance(DomainNameInstance, LoadBalancedInstance, OpenEdXAppConfig
             self.edx_platform_commit = self.openedx_release
         if self.storage_type is None:
             self.storage_type = settings.INSTANCE_STORAGE_TYPE
+
         super().save(**kwargs)
+        self.update_consul_metadata()
 
     def get_load_balancer_configuration(self, triggered_by_instance=False):
         """
@@ -354,7 +357,8 @@ class OpenEdXInstance(DomainNameInstance, LoadBalancedInstance, OpenEdXAppConfig
 
     def archive(self):
         """
-        Shut down this instance's app servers and mark it as archived.
+        Shut down this instance's app servers, mark it as archived and
+        remove its metadata from Consul.
         """
         self.disable_monitoring()
         self.remove_dns_records()
@@ -365,6 +369,7 @@ class OpenEdXInstance(DomainNameInstance, LoadBalancedInstance, OpenEdXAppConfig
             self.reconfigure_load_balancer(load_balancer)
         for appserver in self.appserver_set.iterator():
             appserver.terminate_vm()
+        self.purge_consul_metadata()
         super().archive()
 
     @staticmethod
@@ -389,3 +394,97 @@ class OpenEdXInstance(DomainNameInstance, LoadBalancedInstance, OpenEdXAppConfig
         self.deprovision_s3()
         self.deprovision_rabbitmq()
         super().delete(*args, **kwargs)
+
+    @property
+    def consul_prefix(self):
+        """
+        This is a property that helps determining a specific instance's rpefix in
+        Consul. The prefix helps in keeping different instances' configurations
+        separate from overridings and modifications.
+
+        :return: A unique Key-Value prefix for this instance in Consul.
+        """
+        return settings.CONSUL_PREFIX.format(ocim=settings.OCIM_ID, instance=self.id)
+
+    def _generate_consul_metadata(self):
+        """
+        Collects required configurations for this instance to reflect on Consul.
+        You can add, delete or alter configurations keys and values here which are
+        going to ve reflected in Consul immediately.
+
+        :return: A dict of the configurations.
+        """
+        active_servers = self.get_active_appservers()
+        basic_auth = self.http_auth_info_base64()
+        enable_health_checks = active_servers.count() > 1
+        active_servers_data = list(active_servers.annotate(public_ip=F('server___public_ip')).values('id', 'public_ip'))
+
+        configurations = {
+            'name': self.name,
+            'domains': self.get_load_balanced_domains(),
+            'health_checks_enabled': enable_health_checks,
+            'basic_auth': basic_auth.decode(),
+            'active_app_servers': active_servers_data,
+        }
+
+        return configurations
+
+    def _write_metadata_to_consul(self, configurations):
+        """
+        Reflect passed configurations to Consul. Values on consul
+        will be updated only if they changed in this version of the
+        model using agent's `cas` parameter (Check-And-Set).
+
+        If we successfully updated at least one field in Consul
+        then the configurations' version number is gonna be incremented.
+
+        :note: This still doesn't apply removed-configurations case.
+        :param configurations: A dict object contains the configurations
+                               to be written on Consul.
+        :return: A pair (version, changed) with the current version number and
+                 a bool to indicate whether the information was updated.
+        """
+        agent = ConsulAgent(prefix=self.consul_prefix)
+        version_updated = False
+
+        version_number = agent.get('version') or 0
+        for key, value in configurations.items():
+            index, stored_value = agent.get(key, index=True)
+            cas = index if stored_value else 0
+            agent.put(key, value, cas=cas)
+
+            if not version_updated and value != stored_value:
+                version_updated = True
+                version_number += 1
+                agent.put('version', version_number)
+
+        return version_number, version_updated
+
+    def update_consul_metadata(self):
+        """
+        This method is going over some pre-defined configurations fields
+        in this model to reflect their values on Consul.
+        If we successfully updated at least one field in Consul
+        then the configurations' version number is gonna be incremented.
+
+        :return: A pair (version, changed) with the current version number and
+                 a bool to indicate whether the information was updated.
+        """
+        if not settings.CONSUL_ENABLED:
+            return 0, False
+
+        new_configurations = self._generate_consul_metadata()
+        version, updated = self._write_metadata_to_consul(new_configurations)
+
+        return version, updated
+
+    def purge_consul_metadata(self):
+        """
+        This method is responsible for purging all instances' metadata from
+        Consul if they exist.
+        """
+        if not settings.CONSUL_ENABLED:
+            return
+
+        agent = ConsulAgent(prefix=self.consul_prefix)
+        agent.purge()

--- a/instance/models/utils.py
+++ b/instance/models/utils.py
@@ -21,9 +21,13 @@ Models Utils
 """
 import functools
 import inspect
+import json
+from json import JSONDecodeError
 from weakref import WeakKeyDictionary
 
 from django.conf import settings
+
+import consul
 
 # Exceptions ##################################################################
 
@@ -410,3 +414,112 @@ class ModelResourceStateDescriptor(ResourceStateDescriptor):
         # Save changes to this one field only
         resource.save(update_fields=[self.model_field_name])
         return new_state
+
+
+class ConsulAgent(object):
+    """
+    This class acts as a helper that simplifies the operations of getting, putting,
+    and deleting keys from Consul. These operations are mainly dealing with data-types,
+    managing prefixes, and reduces the call size to the main needed things with a
+    possibility to expand it for more advanced queries.
+    """
+    def __init__(self, prefix=''):
+        self._client = consul.Consul()
+        self.prefix = prefix
+
+    def get(self, key, index=False, **kwargs):
+        """
+        Get's a key value from Consul's Key-Value store after casting it to
+        the proper identified data-type.
+
+        :param key: The key its value to be fetched
+        :param index: If True then the return value will be a tuple of (index, value)
+                      where index is the current Consul index, suitable for making subsequent
+                      calls to wait for changes since this query was last run.
+        :param kwargs: Consul.kv.delete specific options
+        :return: The value or the the tuple of (index, value) of the specified key.
+        """
+        key = self.prefix + key
+        data_index, data = self._client.kv.get(key, **kwargs)
+
+        stored_value = data['Value'] if data else None
+        value = self._cast_value(stored_value)
+
+        if index:
+            return data_index, value
+
+        return value
+
+    def put(self, key, value, **kwargs):
+        """
+        Will put the given value of the key/prefixed-key in Consul's Key-Value
+        store. It'll dump lists and dictionaries first before storing them
+        :param key: The key its value to be updated.
+        :param value: The value given to the specified key.
+        :param kwargs: Consul.kv.put specific options
+        :return: Either True or False. If False is returned, then the update has not taken place.
+        """
+        consul_key = self.prefix + key
+        value = json.dumps(value) if self._is_json_serializable(value) else str(value)
+
+        return self._client.kv.put(consul_key, value, **kwargs)
+
+    def delete(self, key, **kwargs):
+        """
+        Will delete the given key/prefixed-key value from Consul's Key-Value store.
+
+        :param key: The key we want to delete.
+        :param kwargs: Consul.kv.delete specific options
+        :return: True if the operation succeeded, False otherwise.
+        """
+        key = self.prefix + key
+        self._client.kv.delete(key, **kwargs)
+
+    def purge(self):
+        """
+        Will simply removes all keys/prefixed-keys from Key-Value store.
+        :return: True if the operation succeeded, False otherwise.
+        """
+        return self._client.kv.delete(self.prefix, recurse=True)
+
+    @staticmethod
+    def _cast_value(value):
+        """
+        Will decode the value to make it a string object, then tries to cast it
+        the proper data-type as we're expecting.
+        Currently supporting the following data-types:
+            * int
+            * float
+            * list
+            * dict
+            * string
+        :param value: The fetched value from Consul to be checked.
+        :return: The casted value if the data-type identified, an str object of
+                 the value if not
+        """
+        value = value.decode() if value else None
+
+        try:
+            return int(value)
+        except (ValueError, TypeError):
+            pass
+
+        try:
+            return float(value)
+        except (ValueError, TypeError):
+            pass
+
+        try:
+            return json.loads(value)
+        except (JSONDecodeError, TypeError):
+            pass
+
+        return value
+
+    @staticmethod
+    def _is_json_serializable(obj):
+        """
+        :param obj: Object to check
+        :return: Boolean True if object is list or dictionary, False otherwise.
+        """
+        return isinstance(obj, dict) or isinstance(obj, list) or isinstance(obj, bool)

--- a/instance/tests/management/test_update_metadata.py
+++ b/instance/tests/management/test_update_metadata.py
@@ -1,0 +1,145 @@
+# -*- coding: utf-8 -*-
+#
+# OpenCraft -- tools to aid developing and hosting free software projects
+# Copyright (C) 2015-2016 OpenCraft <contact@opencraft.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+"""
+Instance app - instances' metadata update management command
+"""
+# Imports #####################################################################
+from unittest.mock import patch
+
+from django.conf import settings
+from django.core.management import call_command
+from django.utils.six import StringIO
+from django.test import TestCase, override_settings
+
+import consul
+
+
+# Tests #######################################################################
+from instance.models.openedx_instance import OpenEdXInstance
+from instance.tests.models.factories.openedx_instance import OpenEdXInstanceFactory
+
+
+class UpdateMetadataTestCase(TestCase):
+    """
+    Test cases for the `update_metadata` management command.
+    """
+    def setUp(self):
+        self.client = consul.Consul()
+        if self.client.kv.get('', recurse=True)[1]:
+            self.skipTest('Consul contains unknown values!')
+
+    @override_settings(CONSUL_ENABLED=False)
+    def test_consul_not_enabled(self):
+        """
+        Verify that the command exits if Consul is not enabled from the
+        settings file.
+        """
+        out = StringIO()
+        with self.assertRaises(SystemExit):
+            call_command('update_metadata', stdout=out)
+
+        self.assertIn(
+            'This command does nothing unless you enable Consul in the configuration. Exiting..',
+            out.getvalue()
+        )
+
+    @override_settings(CONSUL_ENABLED=True)
+    @patch('instance.management.commands.update_metadata.OpenEdXInstance.update_consul_metadata')
+    def test_consul_skip_clean(self, update_consul_metadata):
+        """
+        Tests the management command with skipping metadata clean option.
+
+        :param update_consul_metadata: update_consul_metadata method mock
+        """
+
+        update_consul_metadata.return_value = 1, True
+        out = StringIO()
+
+        total_instances = 0
+        call_command('update_metadata', skip_clean=True, stdout=out)
+
+        self.assertIn('Updating {} instances\' metadata'.format(total_instances), out.getvalue())
+        self.assertIn('Successfully updated instances\' metadata', out.getvalue())
+        self.assertNotIn('Cleaning metadata for {} archived instances...'.format(total_instances), out.getvalue())
+
+    @override_settings(CONSUL_ENABLED=True)
+    def test_consul_skip_update(self):
+        """
+        Tests the management command with skipping metadata update option.
+
+        :param purge_consul_metadata: purge_consul_metadata method mock
+        """
+        out = StringIO()
+
+        # Archive the instances
+        instances = [OpenEdXInstanceFactory.create() for _ in range(10)]
+        for instance in instances:
+            instance.ref.is_archived = True
+            instance.ref.save()
+
+        # Add some garbage data to consul
+        bad_prefix = settings.CONSUL_PREFIX.format(ocim=settings.OCIM_ID, instance=333)
+        self.client.kv.put(bad_prefix + 'key1', 'value1')
+        self.client.kv.put(bad_prefix + 'key2', 'value2')
+
+        call_command('update_metadata', skip_update=True, stdout=out)
+        objects_count = OpenEdXInstance.objects.count()
+
+        self.assertIn('Cleaning metadata for {} archived instances...'.format(objects_count + 1), out.getvalue())
+        self.assertIn('Successfully cleaned archived instances\' metadata', out.getvalue())
+        self.assertNotIn('Updating {} instances\' metadata'.format(objects_count + 1), out.getvalue())
+
+    @override_settings(CONSUL_ENABLED=True)
+    def test_consul_no_skip(self):
+        """
+        Tests the management command without skipping metadata update or clean options.
+
+        :param purge_consul_metadata: purge_consul_metadata method mock
+        :param update_consul_metadata: update_consul_metadata method mock
+        """
+        out = StringIO()
+
+        # Archive the instances
+        total_archived_instances = 10
+        archived_instances = [OpenEdXInstanceFactory.create() for _ in range(total_archived_instances)]
+        for instance in archived_instances:
+            instance.ref.is_archived = True
+            instance.ref.save()
+
+        # Add some garbage data to consul
+        bad_prefix = settings.CONSUL_PREFIX.format(ocim=settings.OCIM_ID, instance=333)
+        self.client.kv.put(bad_prefix + 'key1', 'value1')
+        self.client.kv.put(bad_prefix + 'key2', 'value2')
+
+        # Create an active instance
+        active_instances_total = 20
+        _ = [OpenEdXInstanceFactory.create() for _ in range(active_instances_total)]
+
+        call_command('update_metadata', stdout=out)
+
+        self.assertIn('Updating {} instances\' metadata'.format(active_instances_total), out.getvalue())
+        self.assertIn('Successfully updated instances\' metadata', out.getvalue())
+        self.assertIn(
+            'Cleaning metadata for {} archived instances...'.format(total_archived_instances + 1),
+            out.getvalue()
+        )
+        self.assertIn('Successfully cleaned archived instances\' metadata', out.getvalue())
+
+    def tearDown(self):
+        self.client.kv.delete('', recurse=True)

--- a/instance/tests/models/test_openedx_storage_mixins.py
+++ b/instance/tests/models/test_openedx_storage_mixins.py
@@ -323,13 +323,12 @@ class SwiftContainerInstanceTestCase(TestCase):
             with self.assertLogs('instance.models.instance', level='INFO') as cm:
                 instance._create_bucket(attempts=attempts)
         base_log_text = (
-            'INFO:instance.models.instance:instance=%s (Test Instance 1) | Retrying bucket creation.'
-            ' IAM keys are not propagated yet, attempt {} of %s.' %
-            (instance.ref.pk, attempts)
+            'INFO:instance.models.instance:instance={} ({!s:.15}) | Retrying bucket creation.'
+            ' IAM keys are not propagated yet, attempt %s of {}.'.format(instance.ref.pk, instance.ref.name, attempts)
         )
         self.assertEqual(
             cm.output,
-            [base_log_text.format(i) for i in range(1, attempts + 1)]
+            [base_log_text % i for i in range(1, attempts + 1)]
         )
 
     @patch('boto.connect_iam')

--- a/instance/tests/models/test_utils.py
+++ b/instance/tests/models/test_utils.py
@@ -21,20 +21,24 @@ model utils - Tests, mostly for state machine
 """
 
 # Imports #####################################################################
-
+import json
 from unittest import TestCase
 from unittest.mock import Mock
 
 from django.db import models
+
+import consul
 
 from instance.models.utils import (
     ResourceState,
     ResourceStateDescriptor,
     ModelResourceStateDescriptor,
     WrongStateException,
+    ConsulAgent,
 )
 
 # Tests #######################################################################
+from instance.tests.utils import skip_unless_consul_running
 
 
 class ResourceStateTests(TestCase):
@@ -518,3 +522,378 @@ class DjangoResourceTest(SimpleResourceTestCase):
         self.assertEqual(res.state, State3)
         self.assertEqual(self.make_resource.save.call_count, 3)
         self.make_resource.save.assert_called_with(update_fields=['backing_field'])
+
+
+@skip_unless_consul_running()
+class ConsulAgentTest(TestCase):
+    """
+    A Test Case for ConsulAgent class that acts as a helper between this
+    code base and consul client'
+    """
+    def setUp(self):
+        self.prefix = 'this/dummy/prefix/'
+        self.client = consul.Consul()
+        self.agent = ConsulAgent()
+        self.prefixed_agent = ConsulAgent(prefix=self.prefix)
+
+        if self.client.kv.get('', recurse=True)[1]:
+            self.skipTest('Consul contains unknown values!')
+
+    def test_init(self):
+        """
+        Tests ConsulAgent's init method and the data it's expected to receive and set.
+        """
+        agent = ConsulAgent()
+        self.assertEqual(agent.prefix, '')
+        self.assertIsInstance(agent._client, consul.Consul)
+
+        # With custom parameters
+        prefix = 'custom_prefix'
+        agent = ConsulAgent(prefix=prefix)
+        self.assertEqual(agent.prefix, prefix)
+        self.assertIsInstance(agent._client, consul.Consul)
+
+    def test_get_no_prefix(self):
+        """
+        Tests getting bare keys of different data types from Consul's Key-Value store.
+        """
+        agent = ConsulAgent()
+
+        # Test string values
+        key = 'string_key'
+        stored_value = 'String Value'
+        self.client.kv.put(key, stored_value)
+
+        fetched_value = agent.get(key)
+        self.assertIsInstance(fetched_value, str)
+        self.assertEqual(fetched_value, stored_value)
+
+        # Test integer values
+        key = 'int_key'
+        stored_value = 23  # pylint: disable=redefined-variable-type
+        self.client.kv.put(key, str(stored_value))
+
+        fetched_value = agent.get(key)
+        self.assertIsInstance(fetched_value, int)
+        self.assertEqual(fetched_value, stored_value)
+
+        # Test float values
+        key = 'float_key'
+        stored_value = 23.23
+        self.client.kv.put(key, str(stored_value))
+
+        fetched_value = agent.get(key)
+        self.assertIsInstance(fetched_value, float)
+        self.assertEqual(fetched_value, stored_value)
+
+        # Test list values
+        key = 'list_key'
+        stored_value = [{'nice': 'good'}, {'awesome': 'things'}]
+        self.client.kv.put(key, json.dumps(stored_value))
+
+        fetched_value = agent.get(key)
+        self.assertIsInstance(fetched_value, list)
+        self.assertEqual(fetched_value, stored_value)
+
+        # Test dict values
+        key = 'dict_key'
+        stored_value = {'nice': 'good', 'awesome': 'things'}
+        self.client.kv.put(key, json.dumps(stored_value))
+
+        fetched_value = agent.get(key)
+        self.assertIsInstance(fetched_value, dict)
+        self.assertEqual(fetched_value, stored_value)
+
+        # Test other (boolean) objects
+        key = 'random_key'
+        stored_value = True
+        self.client.kv.put(key, str(stored_value))
+
+        fetched_value = agent.get(key)
+        self.assertIsInstance(fetched_value, str)
+        self.assertEqual(fetched_value, str(stored_value))
+
+    def test_get_with_prefix(self):
+        """
+        Tests getting a prefixed key of different data types from Consul's KEy-Value store.
+        """
+        prefix = 'some-dummy/prefix/'
+        agent = ConsulAgent(prefix=prefix)
+
+        # Test string values
+        key = 'string_key'
+        stored_value = 'String Value'
+        self.client.kv.put(prefix + key, stored_value)
+
+        fetched_value = agent.get(key)
+        self.assertIsInstance(fetched_value, str)
+        self.assertEqual(fetched_value, stored_value)
+
+        # Test integer values
+        key = 'int_key'
+        stored_value = 23  # pylint: disable=redefined-variable-type
+        self.client.kv.put(prefix + key, str(stored_value))
+
+        fetched_value = agent.get(key)
+        self.assertIsInstance(fetched_value, int)
+        self.assertEqual(fetched_value, stored_value)
+
+        # Test float values
+        key = 'float_key'
+        stored_value = 23.23
+        self.client.kv.put(prefix + key, str(stored_value))
+
+        fetched_value = agent.get(key)
+        self.assertIsInstance(fetched_value, float)
+        self.assertEqual(fetched_value, stored_value)
+
+        # Test list values
+        key = 'list_key'
+        stored_value = [{'nice': 'good'}, {'awesome': 'things'}]
+        self.client.kv.put(prefix + key, json.dumps(stored_value))
+
+        fetched_value = agent.get(key)
+        self.assertIsInstance(fetched_value, list)
+        self.assertEqual(fetched_value, stored_value)
+
+        # Test dict values
+        key = 'dict_key'
+        stored_value = {'nice': 'good', 'awesome': 'things'}
+        self.client.kv.put(prefix + key, json.dumps(stored_value))
+
+        fetched_value = agent.get(key)
+        self.assertIsInstance(fetched_value, dict)
+        self.assertEqual(fetched_value, stored_value)
+
+        # Test other (boolean) objects
+        key = 'random_key'
+        stored_value = True
+        self.client.kv.put(prefix + key, str(stored_value))
+
+        fetched_value = agent.get(key)
+        self.assertIsInstance(fetched_value, str)
+        self.assertEqual(fetched_value, str(stored_value))
+
+    def test_put_no_prefix(self):
+        """
+        Will test the put functionality on Consul with different data types with no prefix on keys.
+        """
+        agent = ConsulAgent()
+
+        # Put string values
+        key = 'key'
+        value = 'value'
+        agent.put(key, value)
+
+        _, data = self.client.kv.get(key)
+        fetched_value = data['Value'].decode()
+        self.assertEqual(fetched_value, value)
+
+        # Put int values
+        key = 'key'
+        value = 1  # pylint: disable=redefined-variable-type
+        agent.put(key, value)
+
+        _, data = self.client.kv.get(key)
+        fetched_value = data['Value'].decode()
+        self.assertEqual(fetched_value, str(value))
+
+        # Put float values
+        key = 'key'
+        value = 1.1
+        agent.put(key, value)
+
+        _, data = self.client.kv.get(key)
+        fetched_value = data['Value'].decode()
+        self.assertEqual(fetched_value, str(value))
+
+        # Put list values
+        key = 'key'
+        value = [1, 2, 3, 5]
+        agent.put(key, value)
+
+        _, data = self.client.kv.get(key)
+        fetched_value = data['Value'].decode()
+        self.assertEqual(fetched_value, json.dumps(value))
+
+        # Put dict values
+        key = 'key'
+        value = {'key': 'value', 'another_key': 12}
+        agent.put(key, value)
+
+        _, data = self.client.kv.get(key)
+        fetched_value = data['Value'].decode()
+        self.assertEqual(fetched_value, json.dumps(value))
+
+        # Put other values
+        key = 'key'
+        value = False
+        agent.put(key, value)
+
+        _, data = self.client.kv.get(key)
+        fetched_value = data['Value'].decode()
+        self.assertEqual(fetched_value, json.dumps(value))
+
+    def test_put_with_prefix(self):
+        """
+        Will test the put functionality on Consul with different data types after prefixing the keys.
+        """
+        prefix = 'some/testing-prefix'
+        agent = ConsulAgent(prefix=prefix)
+        # Put string values
+        key = 'key'
+        value = 'value'
+        agent.put(key, value)
+
+        _, data = self.client.kv.get(prefix + key)
+        fetched_value = data['Value'].decode()
+        self.assertEqual(fetched_value, value)
+
+        # Put int values
+        key = 'key'
+        value = 1  # pylint: disable=redefined-variable-type
+        agent.put(key, value)
+
+        _, data = self.client.kv.get(prefix + key)
+        fetched_value = data['Value'].decode()
+        self.assertEqual(fetched_value, str(value))
+
+        # Put float values
+        key = 'key'
+        value = 1.1
+        agent.put(key, value)
+
+        _, data = self.client.kv.get(prefix + key)
+        fetched_value = data['Value'].decode()
+        self.assertEqual(fetched_value, str(value))
+
+        # Put list values
+        key = 'key'
+        value = [1, 2, 3, 5]
+        agent.put(key, value)
+
+        _, data = self.client.kv.get(prefix + key)
+        fetched_value = data['Value'].decode()
+        self.assertEqual(fetched_value, json.dumps(value))
+
+        # Put dict values
+        key = 'key'
+        value = {'key': 'value', 'another_key': 12}
+        agent.put(key, value)
+
+        _, data = self.client.kv.get(prefix + key)
+        fetched_value = data['Value'].decode()
+        self.assertEqual(fetched_value, json.dumps(value))
+
+        # Put other values
+        key = 'key'
+        value = False
+        agent.put(key, value)
+
+        _, data = self.client.kv.get(prefix + key)
+        fetched_value = data['Value'].decode()
+        self.assertEqual(fetched_value, json.dumps(value))
+
+    def test_delete_no_prefix(self):
+        """
+        Will test whether a key is gonna be deleted or not from the Key-Value store.
+        """
+        agent = ConsulAgent()
+        self.client.kv.put('key', 'value')
+        self.client.kv.put('another_key', 'another value')
+        self.client.kv.put('dummy_key', '1')
+
+        _, values = self.client.kv.get('', recurse=True)
+        self.assertEqual(len(values), 3)
+
+        agent.delete('key')
+        _, values = self.client.kv.get('', recurse=True)
+        self.assertEqual(len(values), 2)
+
+    def test_delete_with_prefix(self):
+        """
+        Delete with prefix will delete the given key from a prefixed agent.
+        """
+        prefix = 'nice-prefix'
+        agent = ConsulAgent(prefix=prefix)
+        self.client.kv.put(prefix + 'key', 'value')
+        self.client.kv.put(prefix + 'another_key', 'another value')
+        self.client.kv.put('dummy_key', '1')
+
+        _, values = self.client.kv.get('', recurse=True)
+        self.assertEqual(len(values), 3)
+
+        agent.delete('key')
+        _, values = self.client.kv.get('', recurse=True)
+        self.assertEqual(len(values), 2)
+
+        agent.delete('dummy_key')
+        _, values = self.client.kv.get('', recurse=True)
+        self.assertEqual(len(values), 2)
+
+    def test_purge_no_prefix(self):
+        """
+        Purging with no prefix will remove all of the keys from Consul's Key-Value store
+        """
+        agent = ConsulAgent()
+        self.client.kv.put('key', 'value')
+        self.client.kv.put('another_key', 'another value')
+        self.client.kv.put('dummy_key', '1')
+
+        _, values = self.client.kv.get('', recurse=True)
+        self.assertEqual(len(values), 3)
+
+        agent.purge()
+        _, values = self.client.kv.get('', recurse=True)
+        self.assertIsNone(values)
+
+    def test_purge_with_prefix(self):
+        """
+        Purging with prefix should only remove the prefixed keys with the given prefix.
+        All other values must not be touched.
+        """
+        prefix = 'nice-prefix'
+        agent = ConsulAgent(prefix=prefix)
+        self.client.kv.put(prefix + 'key', 'value')
+        self.client.kv.put(prefix + 'another_key', 'another value')
+        self.client.kv.put('dummy_key', '1')
+
+        _, values = self.client.kv.get('', recurse=True)
+        self.assertEqual(len(values), 3)
+
+        agent.purge()
+        _, values = self.client.kv.get('', recurse=True)
+        self.assertEqual(len(values), 1)
+
+    def test_cast_value(self):
+        """
+        Test the supported casted values in our Consul agent. Currently supporting integers,
+        floats, lists, dictionaries and strings
+        """
+        self.assertEqual(self.agent._cast_value(b'string'), 'string')
+        self.assertEqual(self.agent._cast_value(b'1'), 1)
+        self.assertEqual(self.agent._cast_value(b'1.3'), 1.3)
+
+        list_value = [{'test': 'value'}, {'another': 'test'}]
+        fetched_value = json.dumps(list_value).encode()
+        self.assertEqual(self.agent._cast_value(fetched_value), list_value)
+
+        dict_value = {'test': 'value', 'another': 'test'}
+        fetched_value = json.dumps(dict_value).encode()
+        self.assertEqual(self.agent._cast_value(fetched_value), dict_value)
+        self.assertIsNone(self.agent._cast_value(None))
+
+    def test_is_json_serializable(self):
+        """
+        Tests that lists and dicts are identified as json objects or not.
+        """
+        self.assertTrue(self.agent._is_json_serializable([1, 2, 3, 4, 5]))
+        self.assertTrue(self.agent._is_json_serializable({'key': 'value'}))
+        self.assertTrue(self.agent._is_json_serializable(False))
+
+        self.assertFalse(self.agent._is_json_serializable('nope'))
+        self.assertFalse(self.agent._is_json_serializable(1))
+        self.assertFalse(self.agent._is_json_serializable(1.1))
+
+    def tearDown(self):
+        self.client.kv.delete('', recurse=True)

--- a/opencraft/settings.py
+++ b/opencraft/settings.py
@@ -52,6 +52,11 @@ DEBUG = env.bool('DEBUG', default=False)
 ENABLE_DEBUG_TOOLBAR = env.bool('ENABLE_DEBUG_TOOLBAR', default=False)
 
 
+# Consul #########################################################################
+CONSUL_ENABLED = env.bool('CONSUL_ENABLED', default=False)
+OCIM_ID = env('OCIM_ID', default='ocim')
+CONSUL_PREFIX = env('CONSUL_PREFIX', default='{ocim}/instances/{instance}/')
+
 # Auth ########################################################################
 
 AUTHENTICATION_BACKENDS = (

--- a/requirements.txt
+++ b/requirements.txt
@@ -106,6 +106,7 @@ pylint-plugin-utils==0.2.4
 pymongo==3.3.1
 pyparsing==2.1.10
 python-cinderclient==1.9.0
+python-consul==1.1.0
 python-dateutil==2.6.0
 python-glanceclient==2.5.0
 python-keystoneclient==3.8.0


### PR DESCRIPTION
This change will help us store and update instance information in Consul. It introduces a mixin that can be used in any model we desire to add this feature to.

### WIP
- [x] Management Commands.
- [x] Tests.
