### PR TITLE
Add example Nomad jobspec for a Redis process.

### DIFF
--- a/instance/templates/instance/redis/redis.nomad
+++ b/instance/templates/instance/redis/redis.nomad
@@ -1,0 +1,66 @@
+# Jobs need a globally consistent name, so we need to include the instance id.
+job "redis-1234" {
+  datacenters = ["dc1"]
+  type = "service"
+  constraint {
+    distinct_hosts = true
+  }
+  update {
+    max_parallel = 1
+  }
+  migrate {
+    max_parallel = 1
+  }
+  group "redis" {
+    count = 1
+    task "server" {
+      driver = "exec"
+      config {
+        command = "/usr/bin/redis-server"
+        args    = [
+          # Listen only on localhost
+          "--bind", "127.0.0.1",
+          # TCP port
+          "--port", "${NOMAD_PORT_redis}",
+        ]
+      }
+      resources {
+        cpu    = 20 # MHz
+        # The daemon may in theory grow bigger than this, but given that it only stores the Celery
+        # queue it will in general be much smaller.
+        memory = 32 # MB
+        disk = 0
+        network {
+          # Should be easily enough on average.  We don't want this to become a limiting factor for
+          # scheduling.
+          mbits = 1
+          port "redis" {}
+        }
+      }
+    }
+    task "connect-proxy" {
+      driver = "exec"
+      config {
+        command = "/usr/local/bin/consul"
+        args    = [
+          "connect", "proxy",
+          "-service", "redis-1234",
+          "-service-addr", "127.0.0.1:${NOMAD_PORT_server_redis}",
+          "-listen", ":${NOMAD_PORT_redis}",
+          "-register",
+        ]
+      }
+      resources {
+        cpu = 20 # MHz
+        memory = 20 # MB
+        disk = 0
+        network {
+          # Should be easily enough on average.  We don't want this to become a limiting factor for
+          # scheduling.
+          mbits = 1
+          port "redis" {}
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This adds a simple Redis jobspec, which is virtually identical to the Memcache jobspec.  The main differences are naming and a count of 1 instead of 3 – as discussed on the ticket, we won't be able to use a highly available Redis deployment in this iteration.

This PR is not meant to be merged.  We will add the ability to automatically launch the jobs to Ocim in a future PR, which will likely build on this jobspec, but put it in a Python dictionary rather than a separate file.

I started a job using this spec on the production Nomad cluster to verify the spec.  Given that it is virtually identical to the Memcache spec, I don't think this needs separate end-to-end testing – simply sanity-checking the jobspec should be enough for review.