### PR TITLE
Disables RabbitMQ on Ocim instances

### DIFF
--- a/instance/models/mixins/openedx_config.py
+++ b/instance/models/mixins/openedx_config.py
@@ -248,7 +248,7 @@ class OpenEdXConfigMixin(ConfigMixinBase):
             "DISCOVERY_VERSION": self.openedx_release,
 
             # RabbitMQ disabled locally
-            "SANBOX_ENABLE_RABBITMQ": False,
+            "SANDBOX_ENABLE_RABBITMQ": False,
 
             # Ecommerce
             "SANDBOX_ENABLE_ECOMMERCE": False,  # set to true to enable ecommerce

--- a/instance/tests/models/test_openedx_instance.py
+++ b/instance/tests/models/test_openedx_instance.py
@@ -265,6 +265,22 @@ class OpenEdXInstanceTestCase(TestCase):
 
     @patch_services
     @patch('instance.models.openedx_appserver.OpenEdXAppServer.provision', return_value=True)
+    def test_sandbox_services_disabled(self, mocks, mock_provision):
+        """
+        Check that sandboxes are deployed with only the minimum services by default
+        """
+        instance = OpenEdXInstanceFactory(sub_domain='test.sandbox_services')
+        appserver_id = instance.spawn_appserver()
+        appserver = instance.appserver_set.get(pk=appserver_id)
+        configuration_vars = yaml.load(appserver.configuration_settings)
+        self.assertIs(configuration_vars['SANDBOX_ENABLE_RABBITMQ'], False)
+        self.assertIs(configuration_vars['SANDBOX_ENABLE_DISCOVERY'], False)
+        self.assertIs(configuration_vars['SANDBOX_ENABLE_ECOMMERCE'], False)
+        self.assertIs(configuration_vars['SANDBOX_ENABLE_ANALYTICS_API'], False)
+        self.assertIs(configuration_vars['SANDBOX_ENABLE_INSIGHTS'], False)
+
+    @patch_services
+    @patch('instance.models.openedx_appserver.OpenEdXAppServer.provision', return_value=True)
     def test_spawn_appserver_with_external_domains(self, mocks, mock_provision):
         """
         Test that relevant configuration variables use external domains when provisioning a new app server.

--- a/instance/tests/models/test_openedx_instance.py
+++ b/instance/tests/models/test_openedx_instance.py
@@ -265,11 +265,11 @@ class OpenEdXInstanceTestCase(TestCase):
 
     @patch_services
     @patch('instance.models.openedx_appserver.OpenEdXAppServer.provision', return_value=True)
-    def test_sandbox_services_disabled(self, mocks, mock_provision):
+    def test_appserver_services_disabled(self, mocks, mock_provision):
         """
-        Check that sandboxes are deployed with only the minimum services by default
+        Check that appservers are deployed with only the minimum services by default
         """
-        instance = OpenEdXInstanceFactory(sub_domain='test.sandbox_services')
+        instance = OpenEdXInstanceFactory(sub_domain='test.appserver_services')
         appserver_id = instance.spawn_appserver()
         appserver = instance.appserver_set.get(pk=appserver_id)
         configuration_vars = yaml.load(appserver.configuration_settings)


### PR DESCRIPTION
* Fixes typo from https://github.com/open-craft/opencraft/pull/317
* Adds tests to check for other disabled service settings

**JIRA tickets**: OC-5149

**Merge deadline**: ASAP

**Testing instructions**:

Simulating the effect of this change using this [hawthorn test instance](https://console.opencraft.com/instance/11250/edx-appserver/8178/).

1. Deploy a new appserver using this branch.
1. Ensure that the rabbitmq role is not run.

**Reviewers**
- [x] @itsjeyd 
- [x] @smarnach 