### PR TITLE
Add the missing Consul decorator to UpdateMetadataTestCase

### DIFF
--- a/instance/tests/management/test_update_metadata.py
+++ b/instance/tests/management/test_update_metadata.py
@@ -33,8 +33,10 @@ import consul
 # Tests #######################################################################
 from instance.models.openedx_instance import OpenEdXInstance
 from instance.tests.models.factories.openedx_instance import OpenEdXInstanceFactory
+from instance.tests.utils import skip_unless_consul_running
 
 
+@skip_unless_consul_running()
 class UpdateMetadataTestCase(TestCase):
     """
     Test cases for the `update_metadata` management command.


### PR DESCRIPTION
JIRA: [OC-4288](https://o/OC-4288)

This is to add the missing `skip_unless_consul_running` that makes the tests fail if the devstack doesn't contain Consul. This is not the ideal solution to continue with, but it's a work around until we have Consul up and running in the devstack.

Thanks @lgp171188 for pointing this out.