### PR TITLE
[OC-5149] Adjust max requests handled by LMS/CMS gunicorn workers 

### DIFF
--- a/instance/models/mixins/openedx_config.py
+++ b/instance/models/mixins/openedx_config.py
@@ -223,12 +223,17 @@ class OpenEdXConfigMixin(ConfigMixinBase):
                 "cms": 2,
             },
 
-            # Restart workers regularly to work around a memory leak
+            # Restart workers regularly to work around a memory leaks.
+            #
             # Tailor the max_requests number to suit the average request load on the server.
             # e.g if the instance receives an average of around 42000 requests per day,
             # with 10% for static assets, restarting after 20000 requests means
-            # restarting each of the 4 LMS workers about every 2-3 days.
+            # restarting each of the 3 LMS workers about every 1-2 days.
             "EDXAPP_LMS_MAX_REQ": 20000,
+
+            # Studio/CMS handles ~5% of the LMS requests with only 2 workers.
+            # Restart them every 1-2 days too.
+            "EDXAPP_CMS_MAX_REQ": 1000,
 
             # Celery workers
             "EDXAPP_WORKER_DEFAULT_STOPWAITSECS": 1200,

--- a/instance/models/mixins/openedx_config.py
+++ b/instance/models/mixins/openedx_config.py
@@ -226,13 +226,13 @@ class OpenEdXConfigMixin(ConfigMixinBase):
             # Restart workers regularly to work around a memory leaks.
             #
             # Tailor the max_requests number to suit the average request load on the server.
-            # e.g if the instance receives an average of around 42000 requests per day,
-            # with 10% for static assets, restarting after 20000 requests means
-            # restarting each of the 3 LMS workers about every 1-2 days.
-            "EDXAPP_LMS_MAX_REQ": 20000,
+            # e.g if the instance receives an average of around 20000 requests per day,
+            # with 10% for static assets, restarting after 10000 requests means
+            # restarting each of the 3 LMS workers about every .8 days.
+            "EDXAPP_LMS_MAX_REQ": 5000,
 
             # Studio/CMS handles ~5% of the LMS requests with only 2 workers.
-            # Restart them every 1-2 days too.
+            # Restart them every 1-2 days.
             "EDXAPP_CMS_MAX_REQ": 1000,
 
             # Celery workers


### PR DESCRIPTION
Sets a `max_requests` limit for the CMS celery workers, which should result in a worker restart frequency of 1-2 days for an average instance.

This change was made in an attempt to relieve memory pressure on existing Ginkgo instances, and to anticipate the CMS worker memory leaks reported for Hawthorn.  cf [openedx-ops post](https://groups.google.com/d/msg/openedx-ops/q-9lZwy-_GM/8X3PIED1AwAJ).

**Testing instructions**

1. Spawn a new appserver using this branch.
1. Note that `EDXAPP_CMS_MAX_REQ: 1000` is present in the configuration, which propagates to the `max_requests` value in `/edx/app/edxapp/cms_gunicorn.py`.

See [hawthorn-beta.opencraft.hosting](https://console.opencraft.com/instance/7850/) for an example.

**Reviewer**
- [x] @itsjeyd 