### PR TITLE
Add domain and domain slug to Consul Configurations

### DIFF
--- a/instance/models/openedx_instance.py
+++ b/instance/models/openedx_instance.py
@@ -420,6 +420,8 @@ class OpenEdXInstance(DomainNameInstance, LoadBalancedInstance, OpenEdXAppConfig
         active_servers_data = list(active_servers.annotate(public_ip=F('server___public_ip')).values('id', 'public_ip'))
 
         configurations = {
+            'domain_slug': self.domain_slug,
+            'domain': self.domain,
             'name': self.name,
             'domains': self.get_load_balanced_domains(),
             'health_checks_enabled': enable_health_checks,

--- a/instance/tests/models/test_openedx_instance.py
+++ b/instance/tests/models/test_openedx_instance.py
@@ -964,6 +964,8 @@ class OpenEdXInstanceConsulTestCase(TestCase):
         active_servers_data = list(active_servers.annotate(public_ip=F('server___public_ip')).values('id', 'public_ip'))
 
         expected_metadata = {
+            'domain_slug': instance.domain_slug,
+            'domain': instance.domain,
             'name': instance.name,
             'domains': instance.get_load_balanced_domains(),
             'health_checks_enabled': enable_health_checks,


### PR DESCRIPTION
This change helps in creating a `/etc/haproxy/backend.map` and a `etc/haproxy/haproxy.cfg`. Both fields are missing and required in the templates we're generating for these files.