### PR TITLE
[OC-5177] Add a new configuration setting OPENSTACK_PRODUCTION_INSTANCE_FLAVOR

### DIFF
--- a/instance/factories.py
+++ b/instance/factories.py
@@ -145,6 +145,9 @@ def production_instance_factory(**kwargs):
         configuration_version=settings.STABLE_CONFIGURATION_VERSION,
         openedx_release=settings.OPENEDX_RELEASE_STABLE_REF,
         configuration_extra_settings=extra_settings,
+        # Allow production instances to use a different OpenStack instance flavor by default.
+        # This allows using a larger instance flavor for production instances.
+        openstack_server_flavor=settings.OPENSTACK_PRODUCTION_INSTANCE_FLAVOR,
     )
     instance_kwargs.update(kwargs)
 

--- a/instance/tests/test_factories.py
+++ b/instance/tests/test_factories.py
@@ -52,11 +52,13 @@ class FactoriesTestCase(TestCase):
         "configuration_version": settings.DEFAULT_CONFIGURATION_VERSION,
         "openedx_release": settings.DEFAULT_OPENEDX_RELEASE,
         "configuration_extra_settings": "",
+        "openstack_server_flavor": settings.OPENSTACK_SANDBOX_FLAVOR,
     }
     PRODUCTION_DEFAULTS = {
         "configuration_version": settings.STABLE_CONFIGURATION_VERSION,
         "openedx_release": settings.OPENEDX_RELEASE_STABLE_REF,
         "configuration_extra_settings": CONFIGURATION_EXTRA_SETTINGS,
+        "openstack_server_flavor": settings.OPENSTACK_PRODUCTION_INSTANCE_FLAVOR,
     }
 
     def _assert_field_values(
@@ -65,7 +67,8 @@ class FactoriesTestCase(TestCase):
             sub_domain,
             configuration_version=SANDBOX_DEFAULTS["configuration_version"],
             openedx_release=SANDBOX_DEFAULTS["openedx_release"],
-            configuration_extra_settings=SANDBOX_DEFAULTS["configuration_extra_settings"]
+            configuration_extra_settings=SANDBOX_DEFAULTS["configuration_extra_settings"],
+            openstack_server_flavor=SANDBOX_DEFAULTS["openstack_server_flavor"],
     ):
         """
         Assert that field values of `instance` match expected values

--- a/opencraft/settings.py
+++ b/opencraft/settings.py
@@ -260,6 +260,10 @@ OPENSTACK_SANDBOX_FLAVOR = env.json('OPENSTACK_SANDBOX_FLAVOR', default={"ram": 
 OPENSTACK_SANDBOX_BASE_IMAGE = env.json('OPENSTACK_SANDBOX_BASE_IMAGE', default={"name": "Ubuntu 16.04"})
 OPENSTACK_SANDBOX_SSH_KEYNAME = env('OPENSTACK_SANDBOX_SSH_KEYNAME', default='opencraft')
 OPENSTACK_SANDBOX_SSH_USERNAME = env('OPENSTACK_SANDBOX_SSH_USERNAME', default='ubuntu')
+OPENSTACK_PRODUCTION_INSTANCE_FLAVOR = env.json(
+    'OPENSTACK_PRODUCTION_INSTANCE_FLAVOR',
+    default={"ram": 8192, "disk": 80}
+)
 
 # Separate credentials for Swift.  These credentials are currently passed on to each instance
 # when Swift is enabled.


### PR DESCRIPTION
Add a new configuration setting `OPENSTACK_PRODUCTION_FLAVOR`. Use it in the `production_instance_factory()` method to specify the
flavor to use for the production instances. Currently, all the
instances use the value of the `OPENSTACK_SANDBOX_FLAVOR` variable
by default. This change will facilitate using different flavors
for production and sandbox instances.

**Testing instructions**
* Deploy the changes in the source branch of this PR.
* Deploy the updated `.env` file from https://github.com/open-craft/ansible-secrets/pull/80 and restart OCIM.
* Create a new production instance and verify that it uses the flavor specified in `OPENSTACK_PRODUCTION_FLAVOR`.
* Create a non-production instance and verify that it uses the flavor specified in `OPENSTACK_SANDBOX_FLAVOR`.

**Reviewer**
- [ ] @itsjeyd 