### PR TITLE
(DON'T MERGE) [OC-5408] Add support for agent cluster leave

### DIFF
--- a/instance/models/openedx_instance.py
+++ b/instance/models/openedx_instance.py
@@ -362,6 +362,7 @@ class OpenEdXInstance(DomainNameInstance, LoadBalancedInstance, OpenEdXAppConfig
         """
         self.disable_monitoring()
         self.remove_dns_records()
+        self.leave_consul_cluster()
         if self.load_balancing_server is not None:
             load_balancer = self.load_balancing_server
             self.load_balancing_server = None
@@ -490,3 +491,15 @@ class OpenEdXInstance(DomainNameInstance, LoadBalancedInstance, OpenEdXAppConfig
 
         agent = ConsulAgent(prefix=self.consul_prefix)
         agent.purge()
+
+    def leave_consul_cluster(self):
+        """
+        Will instruct the client to leave and shutdown from the cluster
+        it's connected to
+        :return: True if the operation completed successfully, False otherwise.
+        """
+        if not settings.CONSUL_ENABLED:
+            return
+
+        agent = ConsulAgent(prefix=self.consul_prefix)
+        return agent.leave()

--- a/instance/models/utils.py
+++ b/instance/models/utils.py
@@ -28,7 +28,6 @@ from weakref import WeakKeyDictionary
 from django.conf import settings
 
 import requests
-from requests import exceptions as requests_exceptions
 
 import consul
 
@@ -526,7 +525,7 @@ class ConsulClient(object):
 
         try:
             response = requests.request(method, url)
-        except requests_exceptions.ConnectionError:
+        except requests.exceptions.ConnectionError:
             return False
 
         return 200 <= response.status_code < 300

--- a/instance/models/utils.py
+++ b/instance/models/utils.py
@@ -27,9 +27,10 @@ from weakref import WeakKeyDictionary
 
 from django.conf import settings
 
-import consul
 import requests
-from requests.exceptions import ConnectionError
+from requests import exceptions as requests_exceptions
+
+import consul
 
 # Exceptions ##################################################################
 
@@ -484,7 +485,7 @@ class ConsulAgent(object):
         """
         return self._client.kv.delete(self.prefix, recurse=True)
 
-    def leave(self, force=True):
+    def leave(self, force=False):
         """
         This method will request the agent to leave the cluster, if the
         operation wasn't completed successfully then it'll force nodes to
@@ -504,25 +505,24 @@ class ConsulAgent(object):
         """
         This method will force the agent nodes to leave the cluster.
         """
-        _, nodes = self._client.catalog.nodes()
-        for node in nodes:
-            self._client.agent.force_leave(node['Node'])
+        request_path = '/v1/agent/force-leave'
+        return self._api_request(request_path, method='put')
 
     def _api_request(self, path, method='get'):
         """
         This method serves a good need of making API requests to Consul
-        directly. This good in casae we need to make some advanced
+        directly. This good in case we need to make some advanced
         operations that are not supported from the library.
-        :param path:
-        :param method:
-        :return:
+        :param path: The API path you need to hit.
+        :param method: The HTTP request method this API should be listening to.
+        :return: True if the response is a 2XX status, False otherwise.
         """
         base_uri = self._client.http.base_uri
         url = '%s%s' % (base_uri, path)
 
         try:
             response = requests.request(method, url)
-        except ConnectionError:
+        except requests_exceptions.ConnectionError:
             return False
 
         return 200 <= response.status_code < 300

--- a/instance/models/utils.py
+++ b/instance/models/utils.py
@@ -501,6 +501,8 @@ class ConsulAgent(object):
         if not is_left and force:
             return self.force_leave()
 
+        return is_left
+
     def force_leave(self):
         """
         This method will force the agent nodes to leave the cluster.

--- a/instance/models/utils.py
+++ b/instance/models/utils.py
@@ -419,7 +419,7 @@ class ModelResourceStateDescriptor(ResourceStateDescriptor):
         return new_state
 
 
-class ConsulAgent(object):
+class ConsulClient(object):
     """
     This class acts as a helper that simplifies the operations of getting, putting,
     and deleting keys from Consul. These operations are mainly dealing with data-types,

--- a/instance/models/utils.py
+++ b/instance/models/utils.py
@@ -505,9 +505,11 @@ class ConsulAgent(object):
 
     def force_leave(self):
         """
-        This method will force the agent nodes to leave the cluster.
+        This method will force the agent node of the current OCIM
+        deployment to leave the cluster.
+        :return: True if the operation went successfully, False otherwise.
         """
-        request_path = '/v1/agent/force-leave'
+        request_path = '/v1/agent/force-leave/{node}'.format(node=settings.OCIM_ID)
         return self._api_request(request_path, method='put')
 
     def _api_request(self, path, method='get'):

--- a/instance/tests/models/test_openedx_instance.py
+++ b/instance/tests/models/test_openedx_instance.py
@@ -32,9 +32,10 @@ from django.db.models import F
 from django.test import override_settings
 from django.utils import timezone
 
-import consul
 from freezegun import freeze_time
 import yaml
+
+import consul
 
 from instance import gandi
 from instance.models.appserver import Status as AppServerStatus

--- a/instance/tests/models/test_utils.py
+++ b/instance/tests/models/test_utils.py
@@ -34,7 +34,7 @@ from instance.models.utils import (
     ResourceStateDescriptor,
     ModelResourceStateDescriptor,
     WrongStateException,
-    ConsulAgent,
+    ConsulClient,
 )
 
 # Tests #######################################################################
@@ -525,91 +525,91 @@ class DjangoResourceTest(SimpleResourceTestCase):
 
 
 @skip_unless_consul_running()
-class ConsulAgentTest(TestCase):
+class ConsulClientTest(TestCase):
     """
-    A Test Case for ConsulAgent class that acts as a helper between this
+    A Test Case for ConsulClient class that acts as a helper between this
     code base and consul client'
     """
     def setUp(self):
         self.prefix = 'this/dummy/prefix/'
-        self.client = consul.Consul()
-        self.agent = ConsulAgent()
-        self.prefixed_agent = ConsulAgent(prefix=self.prefix)
+        self.lib_client = consul.Consul()
+        self.client = ConsulClient()
+        self.prefixed_client = ConsulClient(prefix=self.prefix)
 
-        if self.client.kv.get('', recurse=True)[1]:
+        if self.lib_client.kv.get('', recurse=True)[1]:
             self.skipTest('Consul contains unknown values!')
 
     def test_init(self):
         """
-        Tests ConsulAgent's init method and the data it's expected to receive and set.
+        Tests ConsulClient's init method and the data it's expected to receive and set.
         """
-        agent = ConsulAgent()
-        self.assertEqual(agent.prefix, '')
-        self.assertIsInstance(agent._client, consul.Consul)
+        client = ConsulClient()
+        self.assertEqual(client.prefix, '')
+        self.assertIsInstance(client._client, consul.Consul)
 
         # With custom parameters
         prefix = 'custom_prefix'
-        agent = ConsulAgent(prefix=prefix)
-        self.assertEqual(agent.prefix, prefix)
-        self.assertIsInstance(agent._client, consul.Consul)
+        client = ConsulClient(prefix=prefix)
+        self.assertEqual(client.prefix, prefix)
+        self.assertIsInstance(client._client, consul.Consul)
 
     def test_get_no_prefix(self):
         """
         Tests getting bare keys of different data types from Consul's Key-Value store.
         """
-        agent = ConsulAgent()
+        client = ConsulClient()
 
         # Test string values
         key = 'string_key'
         stored_value = 'String Value'
-        self.client.kv.put(key, stored_value)
+        self.lib_client.kv.put(key, stored_value)
 
-        fetched_value = agent.get(key)
+        fetched_value = client.get(key)
         self.assertIsInstance(fetched_value, str)
         self.assertEqual(fetched_value, stored_value)
 
         # Test integer values
         key = 'int_key'
         stored_value = 23  # pylint: disable=redefined-variable-type
-        self.client.kv.put(key, str(stored_value))
+        self.lib_client.kv.put(key, str(stored_value))
 
-        fetched_value = agent.get(key)
+        fetched_value = client.get(key)
         self.assertIsInstance(fetched_value, int)
         self.assertEqual(fetched_value, stored_value)
 
         # Test float values
         key = 'float_key'
         stored_value = 23.23
-        self.client.kv.put(key, str(stored_value))
+        self.lib_client.kv.put(key, str(stored_value))
 
-        fetched_value = agent.get(key)
+        fetched_value = client.get(key)
         self.assertIsInstance(fetched_value, float)
         self.assertEqual(fetched_value, stored_value)
 
         # Test list values
         key = 'list_key'
         stored_value = [{'nice': 'good'}, {'awesome': 'things'}]
-        self.client.kv.put(key, json.dumps(stored_value))
+        self.lib_client.kv.put(key, json.dumps(stored_value))
 
-        fetched_value = agent.get(key)
+        fetched_value = client.get(key)
         self.assertIsInstance(fetched_value, list)
         self.assertEqual(fetched_value, stored_value)
 
         # Test dict values
         key = 'dict_key'
         stored_value = {'nice': 'good', 'awesome': 'things'}
-        self.client.kv.put(key, json.dumps(stored_value))
+        self.lib_client.kv.put(key, json.dumps(stored_value))
 
-        fetched_value = agent.get(key)
+        fetched_value = client.get(key)
         self.assertIsInstance(fetched_value, dict)
         self.assertEqual(fetched_value, stored_value)
 
         # Test other (boolean) objects
         key = 'random_key'
         stored_value = True
-        self.client.kv.put(key, str(stored_value))
+        self.lib_client.kv.put(key, str(stored_value))
 
-        fetched_value = agent.get(key)
+        fetched_value = client.get(key)
         self.assertIsInstance(fetched_value, str)
         self.assertEqual(fetched_value, str(stored_value))
 
@@ -618,59 +618,59 @@ class ConsulAgentTest(TestCase):
         Tests getting a prefixed key of different data types from Consul's KEy-Value store.
         """
         prefix = 'some-dummy/prefix/'
-        agent = ConsulAgent(prefix=prefix)
+        client = ConsulClient(prefix=prefix)
 
         # Test string values
         key = 'string_key'
         stored_value = 'String Value'
-        self.client.kv.put(prefix + key, stored_value)
+        self.lib_client.kv.put(prefix + key, stored_value)
 
-        fetched_value = agent.get(key)
+        fetched_value = client.get(key)
         self.assertIsInstance(fetched_value, str)
         self.assertEqual(fetched_value, stored_value)
 
         # Test integer values
         key = 'int_key'
         stored_value = 23  # pylint: disable=redefined-variable-type
-        self.client.kv.put(prefix + key, str(stored_value))
+        self.lib_client.kv.put(prefix + key, str(stored_value))
 
-        fetched_value = agent.get(key)
+        fetched_value = client.get(key)
         self.assertIsInstance(fetched_value, int)
         self.assertEqual(fetched_value, stored_value)
 
         # Test float values
         key = 'float_key'
         stored_value = 23.23
-        self.client.kv.put(prefix + key, str(stored_value))
+        self.lib_client.kv.put(prefix + key, str(stored_value))
 
-        fetched_value = agent.get(key)
+        fetched_value = client.get(key)
         self.assertIsInstance(fetched_value, float)
         self.assertEqual(fetched_value, stored_value)
 
         # Test list values
         key = 'list_key'
         stored_value = [{'nice': 'good'}, {'awesome': 'things'}]
-        self.client.kv.put(prefix + key, json.dumps(stored_value))
+        self.lib_client.kv.put(prefix + key, json.dumps(stored_value))
 
-        fetched_value = agent.get(key)
+        fetched_value = client.get(key)
         self.assertIsInstance(fetched_value, list)
         self.assertEqual(fetched_value, stored_value)
 
         # Test dict values
         key = 'dict_key'
         stored_value = {'nice': 'good', 'awesome': 'things'}
-        self.client.kv.put(prefix + key, json.dumps(stored_value))
+        self.lib_client.kv.put(prefix + key, json.dumps(stored_value))
 
-        fetched_value = agent.get(key)
+        fetched_value = client.get(key)
         self.assertIsInstance(fetched_value, dict)
         self.assertEqual(fetched_value, stored_value)
 
         # Test other (boolean) objects
         key = 'random_key'
         stored_value = True
-        self.client.kv.put(prefix + key, str(stored_value))
+        self.lib_client.kv.put(prefix + key, str(stored_value))
 
-        fetched_value = agent.get(key)
+        fetched_value = client.get(key)
         self.assertIsInstance(fetched_value, str)
         self.assertEqual(fetched_value, str(stored_value))
 
@@ -678,59 +678,59 @@ class ConsulAgentTest(TestCase):
         """
         Will test the put functionality on Consul with different data types with no prefix on keys.
         """
-        agent = ConsulAgent()
+        client = ConsulClient()
 
         # Put string values
         key = 'key'
         value = 'value'
-        agent.put(key, value)
+        client.put(key, value)
 
-        _, data = self.client.kv.get(key)
+        _, data = self.lib_client.kv.get(key)
         fetched_value = data['Value'].decode()
         self.assertEqual(fetched_value, value)
 
         # Put int values
         key = 'key'
         value = 1  # pylint: disable=redefined-variable-type
-        agent.put(key, value)
+        client.put(key, value)
 
-        _, data = self.client.kv.get(key)
+        _, data = self.lib_client.kv.get(key)
         fetched_value = data['Value'].decode()
         self.assertEqual(fetched_value, str(value))
 
         # Put float values
         key = 'key'
         value = 1.1
-        agent.put(key, value)
+        client.put(key, value)
 
-        _, data = self.client.kv.get(key)
+        _, data = self.lib_client.kv.get(key)
         fetched_value = data['Value'].decode()
         self.assertEqual(fetched_value, str(value))
 
         # Put list values
         key = 'key'
         value = [1, 2, 3, 5]
-        agent.put(key, value)
+        client.put(key, value)
 
-        _, data = self.client.kv.get(key)
+        _, data = self.lib_client.kv.get(key)
         fetched_value = data['Value'].decode()
         self.assertEqual(fetched_value, json.dumps(value))
 
         # Put dict values
         key = 'key'
         value = {'key': 'value', 'another_key': 12}
-        agent.put(key, value)
+        client.put(key, value)
 
-        _, data = self.client.kv.get(key)
+        _, data = self.lib_client.kv.get(key)
         fetched_value = data['Value'].decode()
         self.assertEqual(fetched_value, json.dumps(value))
 
         # Put other values
         key = 'key'
         value = False
-        agent.put(key, value)
+        client.put(key, value)
 
-        _, data = self.client.kv.get(key)
+        _, data = self.lib_client.kv.get(key)
         fetched_value = data['Value'].decode()
         self.assertEqual(fetched_value, json.dumps(value))
 
@@ -739,58 +739,58 @@ class ConsulAgentTest(TestCase):
         Will test the put functionality on Consul with different data types after prefixing the keys.
         """
         prefix = 'some/testing-prefix'
-        agent = ConsulAgent(prefix=prefix)
+        client = ConsulClient(prefix=prefix)
         # Put string values
         key = 'key'
         value = 'value'
-        agent.put(key, value)
+        client.put(key, value)
 
-        _, data = self.client.kv.get(prefix + key)
+        _, data = self.lib_client.kv.get(prefix + key)
         fetched_value = data['Value'].decode()
         self.assertEqual(fetched_value, value)
 
         # Put int values
         key = 'key'
         value = 1  # pylint: disable=redefined-variable-type
-        agent.put(key, value)
+        client.put(key, value)
 
-        _, data = self.client.kv.get(prefix + key)
+        _, data = self.lib_client.kv.get(prefix + key)
         fetched_value = data['Value'].decode()
         self.assertEqual(fetched_value, str(value))
 
         # Put float values
         key = 'key'
         value = 1.1
-        agent.put(key, value)
+        client.put(key, value)
 
-        _, data = self.client.kv.get(prefix + key)
+        _, data = self.lib_client.kv.get(prefix + key)
         fetched_value = data['Value'].decode()
         self.assertEqual(fetched_value, str(value))
 
         # Put list values
         key = 'key'
         value = [1, 2, 3, 5]
-        agent.put(key, value)
+        client.put(key, value)
 
-        _, data = self.client.kv.get(prefix + key)
+        _, data = self.lib_client.kv.get(prefix + key)
         fetched_value = data['Value'].decode()
         self.assertEqual(fetched_value, json.dumps(value))
 
         # Put dict values
         key = 'key'
         value = {'key': 'value', 'another_key': 12}
-        agent.put(key, value)
+        client.put(key, value)
 
-        _, data = self.client.kv.get(prefix + key)
+        _, data = self.lib_client.kv.get(prefix + key)
         fetched_value = data['Value'].decode()
         self.assertEqual(fetched_value, json.dumps(value))
 
         # Put other values
         key = 'key'
         value = False
-        agent.put(key, value)
+        client.put(key, value)
 
-        _, data = self.client.kv.get(prefix + key)
+        _, data = self.lib_client.kv.get(prefix + key)
         fetched_value = data['Value'].decode()
         self.assertEqual(fetched_value, json.dumps(value))
 
@@ -798,16 +798,16 @@ class ConsulAgentTest(TestCase):
         """
         Will test whether a key is gonna be deleted or not from the Key-Value store.
         """
-        agent = ConsulAgent()
-        self.client.kv.put('key', 'value')
-        self.client.kv.put('another_key', 'another value')
-        self.client.kv.put('dummy_key', '1')
+        client = ConsulClient()
+        self.lib_client.kv.put('key', 'value')
+        self.lib_client.kv.put('another_key', 'another value')
+        self.lib_client.kv.put('dummy_key', '1')
 
-        _, values = self.client.kv.get('', recurse=True)
+        _, values = self.lib_client.kv.get('', recurse=True)
         self.assertEqual(len(values), 3)
 
-        agent.delete('key')
-        _, values = self.client.kv.get('', recurse=True)
+        client.delete('key')
+        _, values = self.lib_client.kv.get('', recurse=True)
         self.assertEqual(len(values), 2)
 
     def test_delete_with_prefix(self):
@@ -815,36 +815,36 @@ class ConsulAgentTest(TestCase):
         Delete with prefix will delete the given key from a prefixed agent.
         """
         prefix = 'nice-prefix'
-        agent = ConsulAgent(prefix=prefix)
-        self.client.kv.put(prefix + 'key', 'value')
-        self.client.kv.put(prefix + 'another_key', 'another value')
-        self.client.kv.put('dummy_key', '1')
+        client = ConsulClient(prefix=prefix)
+        self.lib_client.kv.put(prefix + 'key', 'value')
+        self.lib_client.kv.put(prefix + 'another_key', 'another value')
+        self.lib_client.kv.put('dummy_key', '1')
 
-        _, values = self.client.kv.get('', recurse=True)
+        _, values = self.lib_client.kv.get('', recurse=True)
         self.assertEqual(len(values), 3)
 
-        agent.delete('key')
-        _, values = self.client.kv.get('', recurse=True)
+        client.delete('key')
+        _, values = self.lib_client.kv.get('', recurse=True)
         self.assertEqual(len(values), 2)
 
-        agent.delete('dummy_key')
-        _, values = self.client.kv.get('', recurse=True)
+        client.delete('dummy_key')
+        _, values = self.lib_client.kv.get('', recurse=True)
         self.assertEqual(len(values), 2)
 
     def test_purge_no_prefix(self):
         """
         Purging with no prefix will remove all of the keys from Consul's Key-Value store
         """
-        agent = ConsulAgent()
-        self.client.kv.put('key', 'value')
-        self.client.kv.put('another_key', 'another value')
-        self.client.kv.put('dummy_key', '1')
+        client = ConsulClient()
+        self.lib_client.kv.put('key', 'value')
+        self.lib_client.kv.put('another_key', 'another value')
+        self.lib_client.kv.put('dummy_key', '1')
 
-        _, values = self.client.kv.get('', recurse=True)
+        _, values = self.lib_client.kv.get('', recurse=True)
         self.assertEqual(len(values), 3)
 
-        agent.purge()
-        _, values = self.client.kv.get('', recurse=True)
+        client.purge()
+        _, values = self.lib_client.kv.get('', recurse=True)
         self.assertIsNone(values)
 
     def test_purge_with_prefix(self):
@@ -853,16 +853,16 @@ class ConsulAgentTest(TestCase):
         All other values must not be touched.
         """
         prefix = 'nice-prefix'
-        agent = ConsulAgent(prefix=prefix)
-        self.client.kv.put(prefix + 'key', 'value')
-        self.client.kv.put(prefix + 'another_key', 'another value')
-        self.client.kv.put('dummy_key', '1')
+        client = ConsulClient(prefix=prefix)
+        self.lib_client.kv.put(prefix + 'key', 'value')
+        self.lib_client.kv.put(prefix + 'another_key', 'another value')
+        self.lib_client.kv.put('dummy_key', '1')
 
-        _, values = self.client.kv.get('', recurse=True)
+        _, values = self.lib_client.kv.get('', recurse=True)
         self.assertEqual(len(values), 3)
 
-        agent.purge()
-        _, values = self.client.kv.get('', recurse=True)
+        client.purge()
+        _, values = self.lib_client.kv.get('', recurse=True)
         self.assertEqual(len(values), 1)
 
     def test_cast_value(self):
@@ -870,30 +870,30 @@ class ConsulAgentTest(TestCase):
         Test the supported casted values in our Consul agent. Currently supporting integers,
         floats, lists, dictionaries and strings
         """
-        self.assertEqual(self.agent._cast_value(b'string'), 'string')
-        self.assertEqual(self.agent._cast_value(b'1'), 1)
-        self.assertEqual(self.agent._cast_value(b'1.3'), 1.3)
+        self.assertEqual(self.client._cast_value(b'string'), 'string')
+        self.assertEqual(self.client._cast_value(b'1'), 1)
+        self.assertEqual(self.client._cast_value(b'1.3'), 1.3)
 
         list_value = [{'test': 'value'}, {'another': 'test'}]
         fetched_value = json.dumps(list_value).encode()
-        self.assertEqual(self.agent._cast_value(fetched_value), list_value)
+        self.assertEqual(self.client._cast_value(fetched_value), list_value)
 
         dict_value = {'test': 'value', 'another': 'test'}
         fetched_value = json.dumps(dict_value).encode()
-        self.assertEqual(self.agent._cast_value(fetched_value), dict_value)
-        self.assertIsNone(self.agent._cast_value(None))
+        self.assertEqual(self.client._cast_value(fetched_value), dict_value)
+        self.assertIsNone(self.client._cast_value(None))
 
     def test_is_json_serializable(self):
         """
         Tests that lists and dicts are identified as json objects or not.
         """
-        self.assertTrue(self.agent._is_json_serializable([1, 2, 3, 4, 5]))
-        self.assertTrue(self.agent._is_json_serializable({'key': 'value'}))
-        self.assertTrue(self.agent._is_json_serializable(False))
+        self.assertTrue(self.client._is_json_serializable([1, 2, 3, 4, 5]))
+        self.assertTrue(self.client._is_json_serializable({'key': 'value'}))
+        self.assertTrue(self.client._is_json_serializable(False))
 
-        self.assertFalse(self.agent._is_json_serializable('nope'))
-        self.assertFalse(self.agent._is_json_serializable(1))
-        self.assertFalse(self.agent._is_json_serializable(1.1))
+        self.assertFalse(self.client._is_json_serializable('nope'))
+        self.assertFalse(self.client._is_json_serializable(1))
+        self.assertFalse(self.client._is_json_serializable(1.1))
 
     def tearDown(self):
-        self.client.kv.delete('', recurse=True)
+        self.lib_client.kv.delete('', recurse=True)

--- a/opencraft/settings.py
+++ b/opencraft/settings.py
@@ -52,11 +52,6 @@ DEBUG = env.bool('DEBUG', default=False)
 ENABLE_DEBUG_TOOLBAR = env.bool('ENABLE_DEBUG_TOOLBAR', default=False)
 
 
-# Consul #########################################################################
-CONSUL_ENABLED = env.bool('CONSUL_ENABLED', default=False)
-OCIM_ID = env('OCIM_ID', default='ocim')
-CONSUL_PREFIX = env('CONSUL_PREFIX', default='{ocim}/instances/{instance}/')
-
 # Auth ########################################################################
 
 AUTHENTICATION_BACKENDS = (
@@ -687,6 +682,15 @@ AWS_S3_BUCKET_PREFIX = env('S3_BUCKET_PREFIX', default='ocim')
 AWS_IAM_USER_PREFIX = env('IAM_USER_PREFIX', default='ocim')
 
 # Consul ######################################################################
+
+# Determines whether Consul is enabled on this OCIM server or not.
+CONSUL_ENABLED = env.bool('CONSUL_ENABLED', default=False)
+
+# The machine ID that Consul is gonna use to identify this deployment.
+OCIM_ID = env('OCIM_ID', default='ocim')
+
+# The prefix we're gonna use to store key-value records. It must contain `ocim` and `instance` placeholders.
+CONSUL_PREFIX = env('CONSUL_PREFIX', default='{ocim}/instances/{instance}/')
 
 # The encryption key used to gossip in a Consul cluster.
 CONSUL_ENCRYPT = env('CONSUL_ENCRYPT', default='')


### PR DESCRIPTION
This change introduces two things:
1. The ability to communicate with Consul through APIs directly without a need for external library. This is useful when we run into advanced cases where the library we're using doesn't support them.
1. Consul leave functionality which asks the agent to leave the cluster gracefully, or to instruct the agent to force a node into the left state if the agent couldn't leave its cluster gracefully.

I wanted to implement a multi-(threading|processing) approach here since the operation takes about 5-8 seconds to complete, then I backed of when I saw there's no such usage in the whole project for any of the approaches.

- [x] Tests