### PR TITLE
Shutdown a server before termination.

### DIFF
--- a/instance/models/server.py
+++ b/instance/models/server.py
@@ -427,17 +427,25 @@ class OpenStackServer(Server):
 
     def terminate(self):
         """
-        Terminate the server
+        Stop and terminate the server.
+
+        We explicitly stop and wait for a graceful shutdown of the server before terminating it.
+        This ensures any daemons that need to perform cleanup tasks can do so, or that any
+        shutdown scripts/tasks get executed.
         """
-        self.logger.info('Terminating server (status=%s)...', self.status)
         if self.status == Status.Terminated:
             return
-        elif not self.vm_created:
+
+        self.logger.info('Terminating server (status=%s)...', self.status)
+        if not self.vm_created:
+            self.logger.info('Note: server was not created when terminated.')
             self._status_to_terminated()
             return
 
         try:
-            self.os_server.delete()
+            os_server = self.os_server
+            self._shutdown(os_server)
+            os_server.delete()
         except novaclient.exceptions.NotFound:
             self.logger.error('Error while attempting to terminate server: could not find OS server')
             self._status_to_terminated()
@@ -449,3 +457,17 @@ class OpenStackServer(Server):
                 self._status_to_unknown()
         else:
             self._status_to_terminated()
+
+    def _shutdown(self, os_server, poll_interval=10, max_wait=600):
+        """
+        Shutdown the server and wait to return until shutdown or wait threshold reached.
+
+        We don't have an explicit state for this and don't catch exceptions, which is why this is private.
+        The caller is expected to handle any exceptions and retry if necessary.
+        """
+        os_server.stop()
+        while max_wait and os_server.status != 'SHUTOFF':
+            time.sleep(poll_interval)
+            max_wait -= poll_interval
+            os_server = self.os_server
+        return os_server.status == 'SHUTOFF'

--- a/instance/models/server.py
+++ b/instance/models/server.py
@@ -458,14 +458,16 @@ class OpenStackServer(Server):
         else:
             self._status_to_terminated()
 
-    def _shutdown(self, os_server, poll_interval=10, max_wait=600):
+    def _shutdown(self, os_server, poll_interval=10):
         """
         Shutdown the server and wait to return until shutdown or wait threshold reached.
 
         We don't have an explicit state for this and don't catch exceptions, which is why this is private.
         The caller is expected to handle any exceptions and retry if necessary.
         """
+        max_wait = settings.SHUTDOWN_TIMEOUT
         os_server.stop()
+
         while max_wait and os_server.status != 'SHUTOFF':
             time.sleep(poll_interval)
             max_wait -= poll_interval

--- a/opencraft/settings.py
+++ b/opencraft/settings.py
@@ -327,6 +327,9 @@ DEFAULT_EDX_PLATFORM_REPO_URL = 'https://github.com/{}.git'.format(DEFAULT_FORK)
 
 # Open edX Instance and App Server Settings  ##################################
 
+# Time in seconds to wait before making a force termination for servers.
+SHUTDOWN_TIMEOUT = env.int('SHUTDOWN_TIMEOUT', default=600)  # 10 minutes
+
 # Instances will be created as subdomains of this domain by default
 DEFAULT_INSTANCE_BASE_DOMAIN = env('DEFAULT_INSTANCE_BASE_DOMAIN')
 DEFAULT_STUDIO_DOMAIN_PREFIX = env('DEFAULT_STUDIO_DOMAIN_PREFIX', default='studio-')


### PR DESCRIPTION
TASK: [OC-5408](https://tasks.opencraft.com/browse/OC-5408)

This PR is made in an effort to make OCIM AppServer closes gracefully which was not the case. The approach followed here is to shut the AppServer off and then terminating it rather than doing a hard termination.
