### PR TITLE
Minor fixes: organization regexp, documentation typo in "manage_own"

### DIFF
--- a/instance/models/instance.py
+++ b/instance/models/instance.py
@@ -111,7 +111,7 @@ class InstanceReference(TimeStampedModel):
 
         Instance managers are those users that can see a list of instances (at least their own).
         Superusers are automatically instance managers and will see all instances.
-        Normal users become instance managers when they're granted the "instance.manage_all" permission.
+        Normal users become instance managers when they're granted the "instance.manage_own" permission.
         """
         permission = '{}.{}'.format(cls._meta.app_label, "manage_own")
         return user.is_superuser or user.has_perm(permission)

--- a/reports/urls.py
+++ b/reports/urls.py
@@ -31,5 +31,5 @@ from reports import views
 
 app_name = 'reports'
 urlpatterns = [
-    url(r'^(?P<organization>\w+)/(?P<year>[0-9]{4})/(?P<month>[0-9]{1,2})/$', views.report, name='report'),
+    url(r'^(?P<organization>[-\w]+)/(?P<year>[0-9]{4})/(?P<month>[0-9]{1,2})/$', views.report, name='report'),
 ]


### PR DESCRIPTION
- accept dashes in organization slug in URL. The regexp comes from documentation like https://simpleisbetterthancomplex.com/references/2016/10/10/url-patterns.html
- fix typo (manage_all doesn't exist, now it's manage_own)