### PR TITLE
WIP: SE-331 Fix issues related to JOURNALS_API_URL

### DIFF
--- a/instance/models/mixins/openedx_config.py
+++ b/instance/models/mixins/openedx_config.py
@@ -288,7 +288,10 @@ class OpenEdXConfigMixin(ConfigMixinBase):
 
             # Insights and analytics_api
             "SANDBOX_ENABLE_ANALYTICS_API": False, # set to true to enable analytics_api
-            "SANDBOX_ENABLE_INSIGHTS": False # set to true to enable insights
+            "SANDBOX_ENABLE_INSIGHTS": False, # set to true to enable insights
+
+            # Journal dependency work-around
+            "JOURNALS_API_URL": '{{ EDXAPP_LMS_BASE_SCHEME }}://journals-{{ EDXAPP_LMS_BASE }}/api/v1/',
         }
 
         if self.smtp_relay_settings:


### PR DESCRIPTION
This has to do with the `./manage` command in [edx/configuration/playbooks/roles/ecommerce/defaults/main.yml](edx/configuration/playbooks/roles/ecommerce/defaults/main.yml) contianing `--journals_api_url={{ JOURNALS_API_URL }}` where JOURNALS_API_URL is defined in  [edx/configuration/playbooks/roles/edxapp/defaults/main.yml](edx/configuration/playbooks/roles/edxapp/defaults/main.yml). That role (edxapp) does not share variable scope with the ecommerce role, hence JOURNALS_API_URL is undefined in the ecommerce role. Ansible deployments using ecommerce fail.

**Jira** [SE-331](https://tasks.opencraft.com/browse/SE-331), relating to a previous issue cf [OC-4842](https://tasks.opencraft.com/browse/OC-4842)

**How to test**
Unsure, please help.

