### PR TITLE
[SE-370] Avoid logging every minute the PRs list from GitHub, to reduce log size in DB

### DIFF
--- a/pr_watch/github.py
+++ b/pr_watch/github.py
@@ -59,7 +59,7 @@ def get_object_from_url(url):
     """
     logger.info('GET URL %s', url)
     r = requests.get(url, headers=GH_HEADERS)
-    logger.info('Response body: %s', r.text)
+    logger.debug('Response body: %s', r.text)
     if r.status_code == 404:
         raise ObjectDoesNotExist('404 response from {0}'.format(url))
     if r.status_code == 403 and r.headers.get('X-RateLimit-Remaining', '') == '0':


### PR DESCRIPTION
INFO messages are being logged to DB, and because `pr_watch` runs every minute, the DB is getting filled with responses that come from GitHub, each one can be around 15 Kb; this is making the logs take a lot of space and thus the backups too. This PR makes the responses not be logged to DB.
We still log the queries we do to GitHub (small line).