### PR TITLE
Remove the redundant slash from heartbeat URL

### DIFF
--- a/instance/models/mixins/domain_names.py
+++ b/instance/models/mixins/domain_names.py
@@ -218,7 +218,7 @@ class DomainNameInstance(models.Model):
         """
         LMS extended heartbeat URL.
         """
-        return u'{}/heartbeat?extended'.format(self.url)
+        return u'{}heartbeat?extended'.format(self.url)
 
     def save(self, **kwargs):
         """


### PR DESCRIPTION
TASK: [SE-191](https://tasks.opencraft.com/browse/SE-191)

Removing the / from `lms_extended_heartbeat_url` to fix the NewRelic monitors.