### PR TITLE
[SE-461] Put the forum heartbeat checks in EDXAPP_ENV_EXTRA instead of EDXAPP_LMS_ENV_EXTRA

### DIFF
--- a/instance/models/mixins/openedx_config.py
+++ b/instance/models/mixins/openedx_config.py
@@ -50,14 +50,6 @@ class OpenEdXConfigMixin(ConfigMixinBase):
             # edxapp
             "EDXAPP_PLATFORM_NAME": self.instance.name,
             "EDXAPP_SITE_NAME": self.instance.domain,
-            "EDXAPP_LMS_ENV_EXTRA": {
-                "ADDL_INSTALLED_APPS": [
-                    "openedx.core.djangoapps.heartbeat",
-                ],
-                "HEARTBEAT_EXTENDED_CHECKS": [
-                    "lms.lib.comment_client.utils.check_forum_heartbeat",
-                ],
-            },
             "EDXAPP_LMS_NGINX_PORT": 80,
             "EDXAPP_LMS_SSL_NGINX_PORT": 443,
             "EDXAPP_LMS_BASE_SCHEME": 'https',
@@ -182,6 +174,12 @@ class OpenEdXConfigMixin(ConfigMixinBase):
             # Available as ENV_TOKENS in the django setting files.
             "EDXAPP_ENV_EXTRA": {
                 "LANGUAGE_CODE": 'en',
+                "ADDL_INSTALLED_APPS": [
+                    "openedx.core.djangoapps.heartbeat",
+                ],
+                "HEARTBEAT_EXTENDED_CHECKS": [
+                    "lms.lib.comment_client.utils.check_forum_heartbeat",
+                ],
             },
 
             # Features


### PR DESCRIPTION
With the current `edx_sandbox.yml` playbook, `EDXAPP_LMS_ENV_EXTRA` and `EDXAPP_ENV_EXTRA` don't merge their values when both are passed together. One overrides the other.

This PR is to avoid passing `EDXAPP_LMS_ENV_EXTRA` and using `EDXAPP_ENV_EXTRA` instead. The extended heartbeat will be available from LMS and CMS (I'm hoping the 2nd part works, since the forum heartbeat check is unrelated to LMS and CMS)

**JIRA tickets**: SE-461
**Discussions**: None
**Dependencies**: None
**Screenshots**: None
**Sandbox URL**: None yet
**Merge deadline**: None

**Testing instructions**:

1. Install in stage
2. Deploy a normal server
3. Check both https://xxxxxxxxxx.opencraft.hosting/heartbeat?extended and https://studio-xxxxxxxxxx.opencraft.hosting/heartbeat?extended, both should work and return the same
4. Deploy a server with a custom `EDXAPP_ENV_EXTRA` and check that the final server will have the custom settings plus our heartbeat settings, combined (you can check `lms.env.json`). And that the heartbeat still works in LMS and CMS.

**Reviewers**
- [ ] @pomegranited 

**Author concerns**: Will the forum heartbeat work in Studio even though some code lives in a `lms.…` package?
**Settings**: None