### PR TITLE
Fix the shutdown timeout infinite loop bug and also fix the unreliable ordering bug in the instance redeploy command

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -6,8 +6,7 @@ unless Vagrant.has_plugin?("vagrant-vbguest")
 end
 
 Vagrant.configure(2) do |config|
-  # TODO: Switch back to the official box once it is released
-  config.vm.box = 'opencraft/xenial64'
+  config.vm.box = 'ubuntu/xenial64'
   config.vm.synced_folder '.', '/vagrant', disabled: true
   config.vm.synced_folder '.', '/home/vagrant/opencraft'
 

--- a/instance/management/commands/instance_redeploy.py
+++ b/instance/management/commands/instance_redeploy.py
@@ -225,7 +225,7 @@ class Command(BaseCommand):
                 self.success_tag,
                 self.failure_tag,
             ]
-        )
+        ).order_by('id')
 
     def _failed_instances(self):
         """

--- a/instance/management/commands/instance_redeploy.py
+++ b/instance/management/commands/instance_redeploy.py
@@ -295,7 +295,7 @@ class Command(BaseCommand):
         # Loop termination is handled at the end.
         while True:
             # 1. Log instances that failed or succeeded.
-            for instance in self.ongoing_tag.openedxinstance_set.iterator():
+            for instance in self.ongoing_tag.openedxinstance_set.order_by('id').iterator():
                 instance_tags = instance.tags.all()
                 if self.success_tag in instance_tags:
                     LOG.info("SUCCESS: %s [%s]", instance, instance.id)

--- a/instance/models/server.py
+++ b/instance/models/server.py
@@ -468,6 +468,8 @@ class OpenStackServer(Server):
         We don't have an explicit state for this and don't catch exceptions, which is why this is private.
         The caller is expected to handle any exceptions and retry if necessary.
         """
+        # We purposely check for `None` rather than generically for falseness
+        # because it allows `max_wait = 0`.
         max_wait = max_wait if max_wait is not None else settings.SHUTDOWN_TIMEOUT
 
         os_server.stop()

--- a/instance/models/server.py
+++ b/instance/models/server.py
@@ -461,15 +461,17 @@ class OpenStackServer(Server):
         else:
             self._status_to_terminated()
 
-    def _shutdown(self, os_server, poll_interval=10, max_wait=settings.SHUTDOWN_TIMEOUT):
+    def _shutdown(self, os_server, poll_interval=10, max_wait=None):
         """
         Shutdown the server and wait to return until shutdown or wait threshold reached.
 
         We don't have an explicit state for this and don't catch exceptions, which is why this is private.
         The caller is expected to handle any exceptions and retry if necessary.
         """
+        max_wait = max_wait if max_wait is not None else settings.SHUTDOWN_TIMEOUT
+
         os_server.stop()
-        while max_wait and os_server.status != 'SHUTOFF':
+        while max_wait > 0 and os_server.status != 'SHUTOFF':
             time.sleep(poll_interval)
             max_wait -= poll_interval
             os_server = self.os_server

--- a/instance/tests/management/test_instance_redeploy.py
+++ b/instance/tests/management/test_instance_redeploy.py
@@ -204,8 +204,8 @@ class InstanceRedeployTestCase(TestCase):
             'Number of upgrade attempts per instance: 1',
 
             '** Starting redeployment **',
+            'SPAWNING: {0} [{0.id}]'.format(instances['E']['instance']),
             'SPAWNING: {0} [{0.id}]'.format(instances['F']['instance']),
-            'SPAWNING: {0} [{0.id}]'.format(instances['G']['instance']),
 
             '******* Status *******',
             'Instances pending redeployment: 1',
@@ -213,9 +213,9 @@ class InstanceRedeployTestCase(TestCase):
             'Failed to redeploy: 1',
             'Successfully redeployed (done): 3',
             'Sleeping for 0:00:01',
+            'SUCCESS: {0} [{0.id}]'.format(instances['E']['instance']),
             'SUCCESS: {0} [{0.id}]'.format(instances['F']['instance']),
-            'SUCCESS: {0} [{0.id}]'.format(instances['G']['instance']),
-            'SPAWNING: {0} [{0.id}]'.format(instances['E']['instance']),
+            'SPAWNING: {0} [{0.id}]'.format(instances['G']['instance']),
 
             '******* Status *******',
             'Instances pending redeployment: 0',
@@ -223,7 +223,7 @@ class InstanceRedeployTestCase(TestCase):
             'Failed to redeploy: 1',
             'Successfully redeployed (done): 4',
             'Sleeping for 0:00:01',
-            'SUCCESS: {0} [{0.id}]'.format(instances['E']['instance']),
+            'SUCCESS: {0} [{0.id}]'.format(instances['G']['instance']),
 
             '******* Status *******',
             'Instances pending redeployment: 0',
@@ -287,7 +287,7 @@ class InstanceRedeployTestCase(TestCase):
             'Number of upgrade attempts per instance: 1',
 
             '** Starting redeployment **',
-            'SPAWNING: {0} [{0.id}]'.format(instances['F']['instance']),
+            'SPAWNING: {0} [{0.id}]'.format(instances['E']['instance']),
 
             '******* Status *******',
             'Instances pending redeployment: 2',
@@ -295,8 +295,8 @@ class InstanceRedeployTestCase(TestCase):
             'Failed to redeploy: 2',
             'Successfully redeployed (done): 1',
             'Sleeping for 0:00:01',
-            'FAILED: {0} [{0.id}]'.format(instances['F']['instance']),
-            'SPAWNING: {0} [{0.id}]'.format(instances['G']['instance']),
+            'FAILED: {0} [{0.id}]'.format(instances['E']['instance']),
+            'SPAWNING: {0} [{0.id}]'.format(instances['F']['instance']),
 
             '******* Status *******',
             'Instances pending redeployment: 1',
@@ -304,8 +304,8 @@ class InstanceRedeployTestCase(TestCase):
             'Failed to redeploy: 3',
             'Successfully redeployed (done): 1',
             'Sleeping for 0:00:01',
-            'FAILED: {0} [{0.id}]'.format(instances['G']['instance']),
-            'SPAWNING: {0} [{0.id}]'.format(instances['E']['instance']),
+            'FAILED: {0} [{0.id}]'.format(instances['F']['instance']),
+            'SPAWNING: {0} [{0.id}]'.format(instances['G']['instance']),
 
             '******* Status *******',
             'Instances pending redeployment: 0',
@@ -313,7 +313,7 @@ class InstanceRedeployTestCase(TestCase):
             'Failed to redeploy: 4',
             'Successfully redeployed (done): 1',
             'Sleeping for 0:00:01',
-            'FAILED: {0} [{0.id}]'.format(instances['E']['instance']),
+            'FAILED: {0} [{0.id}]'.format(instances['G']['instance']),
 
             '******* Status *******',
             'Instances pending redeployment: 0',

--- a/instance/tests/models/test_server.py
+++ b/instance/tests/models/test_server.py
@@ -28,6 +28,7 @@ from unittest.mock import Mock, call, patch
 
 from ddt import ddt, data, unpack
 from django.conf import settings
+from django.test import override_settings
 import novaclient
 import requests
 
@@ -331,6 +332,7 @@ class OpenStackServerTestCase(TestCase):
         server = OpenStackServerFactory(status=server_status)
         self.assertFalse(server.vm_created)
 
+    @override_settings(SHUTDOWN_TIMEOUT=1)
     @data(
         ('building-server-id', ServerStatus.Building),
         ('booting-server-id', ServerStatus.Booting),
@@ -346,6 +348,7 @@ class OpenStackServerTestCase(TestCase):
         self.assertEqual(server.status, ServerStatus.Terminated)
         server.os_server.delete.assert_called_once_with()
 
+    @override_settings(SHUTDOWN_TIMEOUT=0)
     @data(
         ServerStatus.Pending,
         ServerStatus.Building,  # Edge case: Server has status 'building' but no OpenStack ID yet
@@ -364,6 +367,7 @@ class OpenStackServerTestCase(TestCase):
         else:
             self.assertEqual(server.status, ServerStatus.Terminated)
 
+    @override_settings(SHUTDOWN_TIMEOUT=0)
     @data(
         ('booting-server-id', ServerStatus.Booting),
         ('ready-server-id', ServerStatus.Ready),
@@ -386,6 +390,7 @@ class OpenStackServerTestCase(TestCase):
         server.os_server.delete.assert_called_once_with()
         mock_logger.error.assert_called_once_with(AnyStringMatching('Error while attempting to terminate server'))
 
+    @override_settings(SHUTDOWN_TIMEOUT=0)
     @data(
         requests.RequestException('Error'),
         novaclient.exceptions.ClientException('Error'),


### PR DESCRIPTION
This should also remove the unnecessary delays during the unit test runs.