### PR TITLE
[BB-635] Add archive_instances command to archive OpenEdXInstances.

### DIFF
--- a/instance/management/commands/archive_instances.py
+++ b/instance/management/commands/archive_instances.py
@@ -1,0 +1,87 @@
+# -*- coding: utf-8 -*-
+#
+# OpenCraft -- tools to aid developing and hosting free software projects
+# Copyright (C) 2015-2018 OpenCraft <contact@opencraft.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+"""
+Instance app - Archive one or more instances by their domains
+"""
+
+# Imports #####################################################################
+
+import logging
+
+from django.core.management.base import BaseCommand
+
+from instance.models.openedx_instance import OpenEdXInstance
+
+LOG = logging.getLogger(__name__)
+
+# Classes #####################################################################
+
+
+class Command(BaseCommand):
+    """
+    archive_instances management command class
+    """
+    help = 'Archive instances specified by their internal LMS domain.'
+
+    def add_arguments(self, parser):
+        parser.add_argument('domain', nargs='+', help='Instance domain')
+        parser.add_argument(
+            '--force',
+            action='store_true',
+            help='Pass --force to archive without confirming first.'
+        )
+
+    def handle(self, *args, **options):
+        domains = options['domain']
+        force = options['force']
+
+        instances = OpenEdXInstance.objects.filter(
+            internal_lms_domain__in=domains,
+            ref_set__is_archived=False
+        )
+        instance_count = instances.count()
+
+        self.stdout.write('Archiving %s instances...' % instance_count)
+        if self.confirm(force):
+            for instance in instances:
+                self.stdout.write('Archiving %s...' % instance.internal_lms_domain)
+                self.archive_instance(instance)
+            self.stdout.write(self.style.SUCCESS('Archived %s instances.' % instance_count))
+        else:
+            self.stdout.write('Cancelled')
+
+    @staticmethod
+    def archive_instance(instance):
+        """
+        Archive a single OpenEdXInstance.
+        """
+        instance.archive()
+        instance.deprovision_rabbitmq()
+
+    def confirm(self, force):
+        """
+        Confirm with the user that archiving should proceed, unless force is True.
+        """
+        if force:
+            answer = 'yes'
+        else:
+            self.stdout.write('Are you sure you want to continue? [yes/No]')
+            answer = input()
+
+        return answer.lower().startswith('y')

--- a/instance/management/commands/archive_instances.py
+++ b/instance/management/commands/archive_instances.py
@@ -71,12 +71,14 @@ class Command(BaseCommand):
         )
         instance_count = instances.count()
 
-        self.stdout.write('Archiving %s instances...' % instance_count)
+        self.stdout.write('Archiving %s instances (from %s domains) ...' % (instance_count, len(domains)))
         if self.confirm(force):
             for instance in instances:
                 self.stdout.write('Archiving %s...' % instance.internal_lms_domain)
                 self.archive_instance(instance)
-            self.stdout.write(self.style.SUCCESS('Archived %s instances.' % instance_count))
+            self.stdout.write(
+                self.style.SUCCESS('Archived %s instances (from %s domains).' % (instance_count, len(domains)))
+            )
         else:
             self.stdout.write('Cancelled')
 

--- a/instance/tests/fixtures/management/archive_instances.txt
+++ b/instance/tests/fixtures/management/archive_instances.txt
@@ -1,0 +1,3 @@
+E.example.com
+F.example.com
+G.example.com

--- a/instance/tests/fixtures/management/archive_instances2.txt
+++ b/instance/tests/fixtures/management/archive_instances2.txt
@@ -1,0 +1,1 @@
+H.example.com

--- a/instance/tests/management/test_archive_instances.py
+++ b/instance/tests/management/test_archive_instances.py
@@ -1,0 +1,139 @@
+# -*- coding: utf-8 -*-
+#
+# OpenCraft -- tools to aid developing and hosting free software projects
+# Copyright (C) 2015-2018 OpenCraft <contact@opencraft.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+"""
+Instance - Archive instances command unit tests
+"""
+# Imports #####################################################################
+
+from unittest.mock import patch, MagicMock
+
+from django.core.management import call_command, CommandError
+from django.utils.six import StringIO
+from django.test import TestCase
+
+from instance.models.openedx_instance import OpenEdXInstance
+from instance.tests.models.factories.openedx_appserver import make_test_appserver
+
+
+# Tests #######################################################################
+
+class ArchiveInstancesTestCase(TestCase):
+    """
+    Test cases for the `archive_instances` management command.
+    """
+    def setUp(self):
+        """
+        Set up properties used to verify captured logs
+        """
+        super().setUp()
+        self.cmd_module = 'instance.management.commands.archive_instances'
+        self.log_level = 'INFO'
+
+    def test_required_args(self):
+        """
+        Verify that the command correctly requires at least one domain parameter.
+        """
+        with self.assertRaisesRegex(CommandError, 'Error: the following arguments are required: domain'):
+            call_command('archive_instances')
+
+    @patch('instance.management.commands.archive_instances.input', MagicMock(return_value='no'))
+    def test_no_archive(self):
+        """
+        Verify that the user can cancel the archiving by answering "no"
+        """
+        out = StringIO()
+        call_command('archive_instances', 'foo.example.com', stdout=out)
+        self.assertTrue(out.getvalue().strip().endswith('Cancelled'))
+
+    @patch('instance.management.commands.archive_instances.input', MagicMock(return_value='yes'))
+    def test_yes_archive(self):
+        """
+        Verify that the user can continue with the archiving by answering "yes"
+        """
+        out = StringIO()
+        call_command('archive_instances', 'foo.example.com', stdout=out)
+        self.assertRegex(out.getvalue(), 'Archived 0 instances.')
+
+    def test_force_archive(self):
+        """
+        Verify that the user is not promped when --force is provided
+        """
+        out = StringIO()
+        call_command('archive_instances', 'foo.example.com', '--force', stdout=out)
+        self.assertRegex(out.getvalue(), 'Archived 0 instances.')
+
+    @patch('instance.models.mixins.load_balanced.LoadBalancedInstance.remove_dns_records')
+    @patch('instance.models.mixins.openedx_monitoring.OpenEdXMonitoringMixin.disable_monitoring')
+    @patch('instance.models.load_balancer.LoadBalancingServer.reconfigure')
+    @patch('instance.models.mixins.rabbitmq.RabbitMQInstanceMixin.deprovision_rabbitmq')
+    def test_archiving_instances(self, mock_reconfigure, mock_disable_monitoring,
+                                 mock_remove_dns_records, mock_deprovision_rabbitmq):
+        """
+        Test archiving single and multiple instances.
+        """
+        instances = self.create_test_instances()
+
+        out = StringIO()
+        call_command('archive_instances', 'A.example.com', '--force', stdout=out)
+        self.assertRegex(out.getvalue(), 'Archived 1 instances.')
+        instancea = instances['A']['instance']
+        instancea.refresh_from_db()
+        self.assertTrue(instancea.ref.is_archived)
+        self.assertEqual(mock_deprovision_rabbitmq.call_count, 1)
+
+        # archive multiple instances
+        # instance B is already archived, so should be ignored
+        out = StringIO()
+        call_command('archive_instances', 'B.example.com', 'C.example.com', 'D.example.com', '--force', stdout=out)
+        self.assertRegex(out.getvalue(), 'Archived 2 instances.')
+        for label in 'BCD':
+            instance = instances[label]['instance']
+            instance.refresh_from_db()
+            self.assertTrue(instance.ref.is_archived)
+        self.assertEqual(mock_deprovision_rabbitmq.call_count, 3)
+
+    @staticmethod
+    def create_test_instances():
+        """
+        Create instances to test archiving.
+        """
+        # Create test instances with known attributes, and mock out the appserver_set
+        instances = {}
+        for label in 'ABCDEFGH':
+
+            # Create an instance, with an appserver
+            instance = OpenEdXInstance.objects.create(
+                sub_domain=label,
+                openedx_release='z.1',
+                successfully_provisioned=True
+            )
+            appserver = make_test_appserver(instance)
+
+            # Transition the appserver through the various statuses to "running"
+            appserver._status_to_waiting_for_server()
+            appserver._status_to_configuring_server()
+            appserver._status_to_running()
+
+            instances[label] = dict(instance=instance, appserver=appserver)
+
+        # Archive Instance B, so it won't match the filter
+        instances['B']['instance'].ref.is_archived = True
+        instances['B']['instance'].save()
+
+        return instances

--- a/instance/tests/management/test_archive_instances.py
+++ b/instance/tests/management/test_archive_instances.py
@@ -114,8 +114,8 @@ class ArchiveInstancesTestCase(TestCase):
         self.assertRegex(out.getvalue(), r'.*Archived 1 instances \(from 1 domains\).*')
 
     @patch('instance.management.commands.archive_instances.input', MagicMock(return_value='yes'))
-    @ddt.data([['A.example.com'], 1])
-    @ddt.data([['B.example.com', 'C.example.com', 'D.example.com'], 2])
+    @ddt.data([['A.example.com'], 1],
+              [['B.example.com', 'C.example.com', 'D.example.com'], 2])
     @ddt.unpack
     @patch('instance.models.mixins.load_balanced.LoadBalancedInstance.remove_dns_records')
     @patch('instance.models.mixins.openedx_monitoring.OpenEdXMonitoringMixin.disable_monitoring')
@@ -127,7 +127,7 @@ class ArchiveInstancesTestCase(TestCase):
         """
         Test archiving single and multiple instances by passing invidividual domains.
         """
-        instances = self.create_test_instances('ABCDEFG')
+        instances = self.create_test_instances('ABCDEFGH')
         # Mark instance B as archived, so it won't match the filter
         instances['B.example.com']['instance'].ref.is_archived = True
         instances['B.example.com']['instance'].save()
@@ -148,8 +148,8 @@ class ArchiveInstancesTestCase(TestCase):
         self.assertEqual(mock_deprovision_rabbitmq.call_count, expected_archived_count)
 
     @patch('instance.management.commands.archive_instances.input', MagicMock(return_value='yes'))
-    @ddt.data(['archive_instances.txt', 3])
-    @ddt.data(['archive_instances2.txt', 1])
+    @ddt.data(['archive_instances.txt', 3],
+              ['archive_instances2.txt', 1])
     @ddt.unpack
     @patch('instance.models.mixins.load_balanced.LoadBalancedInstance.remove_dns_records')
     @patch('instance.models.mixins.openedx_monitoring.OpenEdXMonitoringMixin.disable_monitoring')
@@ -161,10 +161,7 @@ class ArchiveInstancesTestCase(TestCase):
         """
         Test archiving instances from domains listed in a file.
         """
-        instances = self.create_test_instances('ABCDEFG')
-        # Mark instance B as archived, so it won't match the filter
-        instances['B.example.com']['instance'].ref.is_archived = True
-        instances['B.example.com']['instance'].save()
+        instances = self.create_test_instances('ABCDEFGH')
 
         patch('instance.management.commands.archive_instances.input', MagicMock(return_value='yes'))
         out = StringIO()


### PR DESCRIPTION
See BB-635

  Added a new `archive_instances` management command to archive multiple instances by their Internal LMS domains.

  Example usage:
  ```
$ make manage 'archive_instances --domains=sandbox.example.com,test.example.com'
honcho run python3 manage.py archive_instances --domains=sandbox.example.com,test.example.com
Found 2 instances (from 2 domains) to be archived...
- sandbox.example.com
- test.example.com
Are you sure you want to continue? [yes/No]
yes
Archiving sandbox.example.com...
Archiving test.example.com...
Archived 2 instances (from 2 domains).
  ```
  Can also accept a file of newline-separated domains.
  ```
  $ make manage 'archive_instances --file=domains.txt'
  ```

  Includes unittests for the command. Tests were based on existing tests for similar commands like `instance_redeploy`.
