### PR TITLE
Set CONN_MAX_AGE default to 0

### DIFF
--- a/instance/models/mixins/openedx_database.py
+++ b/instance/models/mixins/openedx_database.py
@@ -250,7 +250,7 @@ class OpenEdXDatabaseMixin(MySQLInstanceMixin, MongoDBInstanceMixin, RabbitMQIns
                     "HOST": "{{ ECOMMERCE_DATABASE_HOST }}",
                     "PORT": self.mysql_server.port,
                     "ATOMIC_REQUESTS": True,
-                    "CONN_MAX_AGE": 60
+                    "CONN_MAX_AGE": 0
                 },
             },
 
@@ -306,7 +306,7 @@ class OpenEdXDatabaseMixin(MySQLInstanceMixin, MongoDBInstanceMixin, RabbitMQIns
                     "HOST": self.mysql_server.hostname,
                     "PORT": self.mysql_server.port,
                     "ATOMIC_REQUESTS": True,
-                    "CONN_MAX_AGE": 60
+                    "CONN_MAX_AGE": 0
                 },
             },
 
@@ -345,6 +345,9 @@ class OpenEdXDatabaseMixin(MySQLInstanceMixin, MongoDBInstanceMixin, RabbitMQIns
             "COMMON_MYSQL_READ_ONLY_PASS": self._get_mysql_pass(self.read_only_user),
             "COMMON_MYSQL_ADMIN_USER": self.admin_user,
             "COMMON_MYSQL_ADMIN_PASS": self._get_mysql_pass(self.admin_user),
+
+            # Common options to all django services
+            "edx_django_service_default_db_conn_max_age": 0,
         }
 
     def _get_mongo_settings(self):

--- a/instance/tests/models/test_openedx_database_mixins.py
+++ b/instance/tests/models/test_openedx_database_mixins.py
@@ -332,7 +332,7 @@ class MySQLInstanceTestCase(TestCase):
                         "HOST": "{{ ECOMMERCE_DATABASE_HOST }}",
                         "PORT": expected_port,
                         "ATOMIC_REQUESTS": True,
-                        "CONN_MAX_AGE": 60
+                        "CONN_MAX_AGE": 0
                     }
                 }]
             },
@@ -344,7 +344,7 @@ class MySQLInstanceTestCase(TestCase):
                 ["DEFAULT_DB_NAME", "DATABASES"],
                 [{"name": "programs", "user": "program", "additional_settings": {
                     "ATOMIC_REQUESTS": True,
-                    "CONN_MAX_AGE": 60,
+                    "CONN_MAX_AGE": 0,
                 }}]
             ),
             "INSIGHTS_": make_nested_group_info(


### PR DESCRIPTION
This sets both the CONN_MAX_AGE where manually specified  to 0,
and uses the `edx_django_service_default_db_conn_max_age` variable
to set the default CONN_MAX_AGE for all edx django services.