### PR TITLE
BB-692 Fix errors when deprovisioning resources that has been already deprovisioned.

### DIFF
--- a/README.md
+++ b/README.md
@@ -813,6 +813,18 @@ works just like `archive()` except that it also destroys all data (MySQL, mongo,
 instance.delete()
 ```
 
+Use `delete(ignore_errors=True)` in case some of the resources related
+to an instance were deleted or modified and "forcing" deletion is necessary.
+
+It is possible to ignore errors for specific resources when deleting an instance:
+
+- `delete(ignore_mysql_errors=True)` to ignore MySQL errors.
+- `delete(ignore_mongo_errors=True)` to ignore Mongo errors.
+- `delete(ignore_rabbitmq_errors=True)` to ignore RabbitMQ errors.
+
+> **Note:** Any errors raised and its stacktrace will be logged in case
+> there's need for more information.
+
 **Do not use delete() in production!**
 
 

--- a/instance/models/instance.py
+++ b/instance/models/instance.py
@@ -88,7 +88,7 @@ class InstanceReference(TimeStampedModel):
         Delete this InstanceReference and the associated Instance.
         """
         if not kwargs.pop('instance_already_deleted', False):
-            self.instance.delete(ref_already_deleted=True)
+            self.instance.delete(ref_already_deleted=True, **kwargs)
         super().delete(*args, **kwargs)
 
     def save(self, *args, **kwargs):
@@ -277,7 +277,7 @@ class Instance(ValidateModelMixin, models.Model):
         This will delete the InstanceReference at the same time.
         """
         if not kwargs.pop('ref_already_deleted', False):
-            self.ref.delete(instance_already_deleted=True)
+            self.ref.delete(instance_already_deleted=True, **kwargs)
         super().delete(*args, **kwargs)
 
 

--- a/instance/models/mixins/load_balanced.py
+++ b/instance/models/mixins/load_balanced.py
@@ -65,6 +65,7 @@ class LoadBalancedInstance(models.Model):
         Delete the DNS records for this instance.
         """
         for domain in self.get_managed_domains():
+            self.logger.info('Removing domain "%s" from DNS Records.', domain)
             gandi.api.remove_dns_record(domain)
 
     def reconfigure_load_balancer(self, load_balancing_server=None):

--- a/instance/tests/models/test_openedx_instance.py
+++ b/instance/tests/models/test_openedx_instance.py
@@ -52,7 +52,7 @@ from instance.tests.utils import patch_services, skip_unless_consul_running
 
 # Tests #######################################################################
 
-@ddt.ddt # pylint: disable=too-many-lines
+@ddt.ddt  # pylint: disable=too-many-lines
 class OpenEdXInstanceTestCase(TestCase):
     """
     Test cases for OpenEdXInstance models
@@ -500,6 +500,8 @@ class OpenEdXInstanceTestCase(TestCase):
     @patch('instance.models.mixins.database.MySQLInstanceMixin.deprovision_mysql')
     @patch('instance.models.mixins.database.MongoDBInstanceMixin.deprovision_mongo')
     @patch('instance.models.mixins.storage.SwiftContainerInstanceMixin.deprovision_swift')
+    @patch('instance.models.mixins.storage.S3BucketInstanceMixin.deprovision_s3')
+    @patch('instance.models.mixins.rabbitmq.RabbitMQInstanceMixin.deprovision_rabbitmq')
     def test_delete_instance(self, mocks, delete_by_ref, *mock_methods):
         """
         Test that an instance can be deleted directly or by its InstanceReference.

--- a/requirements.txt
+++ b/requirements.txt
@@ -124,7 +124,7 @@ requests-oauthlib==0.7.0
 requests-toolbelt==0.7.0
 requestsexceptions==1.1.3
 requirements-detector==0.5.2
-responses==0.5.1
+responses==0.10.4
 rfc3986==0.4.1
 rjsmin==1.0.12
 selenium==2.53.6


### PR DESCRIPTION
- Add flags to ignore errors when deleting an OpenEDX Instance.
- Add log messages to show what's going on when deleting an instance.
- Add unit test for deleting an instance ignoring errors.
- Fix some deprovision tests.
- Update responses library to mock response with 'reason' attribute.

When this task was created we thought the issue was that `OpenEDXInstance.delete()` was trying to deprovision resources that were already deprovisioned before.
This is partially true because the `delete()` method was trying to get rid of things that were not there anymore, but those resources were not "correctly" deprovisioned. Meaning, checking for `self.<resource>_provisioned` would not give us the correct state if the resource was deleted manually or using another method.
Also, the class methods implemented currently in the codebase they do check if the `<resouce>_provisioned` flag is `False` and if it so then the codebase do not try to delete that resource, e.g. [MySQL](https://github.com/open-craft/opencraft/blob/master/instance/models/mixins/database.py#L232), [Mongo](https://github.com/open-craft/opencraft/blob/master/instance/models/mixins/database.py#L343), [Swift](https://github.com/open-craft/opencraft/blob/master/instance/models/mixins/storage.py#L138), [RabbitMQ](https://github.com/open-craft/opencraft/blob/master/instance/models/mixins/rabbitmq.py#L164)

This PR implements a few flags to ignore errors raised when using `OpenEdxInstance.delete()`.
Errors will be logged but not raised.

**Test instructions:**

1. ssh to [ocim stage](https://github.com/open-craft/ansible-secrets/blob/master/host_vars/stage.console.opencraft.com.yml) and apply patch.
2. Create an instance using Django's shell:
```
from instance.models.openedx_instance import OpenEdXInstance

instance = OpenEdXInstance.objects.create(
    name='Dogwood sandbox',
    sub_domain='dogwood',
    # The rest of the parameters are all optional:
    email='myname@opencraft.com',
    openedx_release='named-release/dogwood',
    configuration_version='named-release/dogwood',
    configuration_source_repo_url='https://github.com/edx/configuration.git',
    configuration_extra_settings='',
)
```
3. Manually delete resources:
```
instance.deprovision_mysql()
instance.deprovision_mongo()
instance.deprovision_rabbitmq()
```
4. Set `<resource>_provisioned` flag to `True`.
```
instance.mysql_provisioned = True
instance.mongo_provisioned = True
instance.rabbitmq_provisioned = True
instance.save()
```
5. Delete instance:
```
instance.delete(ignore_errors=True)
```

**Expected behavior:**

Every other resource/config should be deleted correctly (e.g. DNS records) as well as database records. There should be a few MySQL, Mongo and RabbitMQ messages printed to the output since the code will try to delete databases and/or users that are no longer there but the `delete()` method should not exit with an error.