### PR TITLE
BB-756 - Improve fault tolerance of cleanup script and run it only after all tests are done

### DIFF
--- a/bin/run-circleci-tests
+++ b/bin/run-circleci-tests
@@ -2,13 +2,14 @@
 
 set -e
 
-make install_system_dependencies
-
-case $CIRCLE_NODE_INDEX in
-    0)
-        make test
-        ;;
-    *)
-        make test.integration
-        ;;
-esac
+echo "Hi"
+# make install_system_dependencies
+#
+# case $CIRCLE_NODE_INDEX in
+#     0)
+#         make test
+#         ;;
+#     *)
+#         make test.integration
+#         ;;
+# esac

--- a/bin/run-circleci-tests
+++ b/bin/run-circleci-tests
@@ -4,6 +4,8 @@ set -e
 
 make install_system_dependencies
 
+asdfasdf
+
 case $CIRCLE_NODE_INDEX in
     0)
         make test

--- a/bin/run-circleci-tests
+++ b/bin/run-circleci-tests
@@ -2,14 +2,13 @@
 
 set -e
 
-echo "Hi"
-# make install_system_dependencies
-#
-# case $CIRCLE_NODE_INDEX in
-#     0)
-#         make test
-#         ;;
-#     *)
-#         make test.integration
-#         ;;
-# esac
+make install_system_dependencies
+
+case $CIRCLE_NODE_INDEX in
+    0)
+        make test
+        ;;
+    *)
+        make test.integration
+        ;;
+esac

--- a/bin/run-circleci-tests
+++ b/bin/run-circleci-tests
@@ -4,8 +4,6 @@ set -e
 
 make install_system_dependencies
 
-asdfasdf
-
 case $CIRCLE_NODE_INDEX in
     0)
         make test

--- a/circle.yml
+++ b/circle.yml
@@ -114,8 +114,7 @@ workflows:
   version: 2
   build-test-and-deploy:
     jobs:
-      - cleanup
-      # - build
-      # - cleanup:
-      #     requires:
-      #       - build
+      - build
+      - cleanup:
+          requires:
+            - build

--- a/circle.yml
+++ b/circle.yml
@@ -100,9 +100,7 @@ jobs:
           command: |
             python3 -m venv venv
             . venv/bin/activate
-            pip install --upgrade pip
-            pip install --upgrade virtualenv
-            pip install -r requirements.txt
+            pip install -r cleanup_utils/requirements.txt
       - run:
           name: Cleanup
           command: |
@@ -115,6 +113,4 @@ workflows:
   build-test-and-deploy:
     jobs:
       - build
-      - cleanup:
-          requires:
-            - build
+      - cleanup

--- a/circle.yml
+++ b/circle.yml
@@ -90,9 +90,7 @@ jobs:
           when: always
   cleanup:
     docker:
-      - image: circleci/python:3.5.4-browsers
-        environment:
-          DEFAULT_FORK: 'open-craft/edx-platform'
+      - image: circleci/python:3.5.4
     steps:
       - checkout
       - restore_cache:

--- a/circle.yml
+++ b/circle.yml
@@ -116,8 +116,7 @@ workflows:
   version: 2
   build-test-and-deploy:
     jobs:
-      # - build
-      - cleanup
-      # - cleanup:
-      #     requires:
-      #       - build
+      - build
+      - cleanup:
+          requires:
+            - build

--- a/circle.yml
+++ b/circle.yml
@@ -88,3 +88,36 @@ jobs:
             make test.integration_cleanup
           no_output_timeout: 20m
           when: always
+  cleanup:
+    docker:
+      - image: circleci/python:3.5.4-browsers
+        environment:
+          DEFAULT_FORK: 'open-craft/edx-platform'
+    steps:
+      - checkout
+      - restore_cache:
+          key: dependencies-{{ checksum "requirements.txt" }}
+      - run:
+          name: Install Dependencies
+          command: |
+            python3 -m venv venv
+            . venv/bin/activate
+            pip install --upgrade pip
+            pip install --upgrade virtualenv
+            pip install -r requirements.txt
+      - run:
+          name: Cleanup
+          command: |
+            . venv/bin/activate
+            make test.integration_cleanup
+          no_output_timeout: 20m
+          when: always
+workflows:
+  version: 2
+  build-test-and-deploy:
+    jobs:
+      # - build
+      - cleanup
+      # - cleanup:
+      #     requires:
+      #       - build

--- a/circle.yml
+++ b/circle.yml
@@ -57,6 +57,7 @@ jobs:
             sudo apt-get update; sudo apt-get install python2.7-dev
             sudo apt-get install mysql-client
             pip install -r requirements.txt
+            pip install -r cleanup_utils/requirements.txt
             sudo apt-get install postgresql-client
             sudo apt-get install unzip
             sudo wget -P /tmp https://releases.hashicorp.com/consul/1.2.1/consul_1.2.1_linux_amd64.zip

--- a/circle.yml
+++ b/circle.yml
@@ -114,7 +114,8 @@ workflows:
   version: 2
   build-test-and-deploy:
     jobs:
-      - build
-      - cleanup:
-          requires:
-            - build
+      - cleanup
+      # - build
+      # - cleanup:
+      #     requires:
+      #       - build

--- a/circle.yml
+++ b/circle.yml
@@ -81,13 +81,6 @@ jobs:
           no_output_timeout: 47m
           environment:
             ANSIBLE_HOST_KEY_CHECKING: False
-      - run:
-          name: Cleanup
-          command: |
-            . venv/bin/activate
-            make test.integration_cleanup
-          no_output_timeout: 20m
-          when: always
   cleanup:
     docker:
       - image: circleci/python:3.5.4

--- a/cleanup_utils/aws_cleanup.py
+++ b/cleanup_utils/aws_cleanup.py
@@ -203,9 +203,8 @@ class AwsCleanupInstance:
                 # If user policy exists
                 if user_policy:
                     buckets_to_delete = self.get_bucket_names_from_policy(user_policy)
-
                     logger.info("  > Cleaning up stuff from user %s.", user['UserName'])
-
+                    
                     # Delete buckets, user policy, access keys and the iam user
                     for bucket_name in buckets_to_delete:
                         logger.info("    * Deleting bucket %s.", bucket_name)
@@ -217,23 +216,29 @@ class AwsCleanupInstance:
                         user['UserName']
                     )
                     self.delete_user_policy(user['UserName'], DEFAULT_POLICY_NAME)
-
-                    for access_key in old_keys:
-                        logger.info(
-                            "    * Deleting access key %s  from user %s.",
-                            access_key['AccessKeyId'],
-                            user['UserName']
-                        )
-                        self.delete_user_access_key(
-                            username=user['UserName'],
-                            access_key=access_key
-                        )
-
-                    logger.info("    * Deleting user %s.", user['UserName'])
-                    self.delete_user(username=user['UserName'])
-
-                    # Saves hashes from user name
-                    # ocim-HASH_integration_plebia_net.
-                    self.cleaned_up_hashes.append(
-                        user['UserName'].split('_')[0][5:]
+                else:
+                    logger.warning(
+                        "    * WARNING: The user %s doesn't have %s policy. Skipping bucket and policy deletion...",
+                        user['UserName'],
+                        DEFAULT_POLICY_NAME
                     )
+
+                for access_key in old_keys:
+                    logger.info(
+                        "    * Deleting access key %s  from user %s.",
+                        access_key['AccessKeyId'],
+                        user['UserName']
+                    )
+                    self.delete_user_access_key(
+                        username=user['UserName'],
+                        access_key=access_key
+                    )
+
+                logger.info("    * Deleting user %s.", user['UserName'])
+                self.delete_user(username=user['UserName'])
+
+                # Saves hashes from user name
+                # ocim-HASH_integration_plebia_net.
+                self.cleaned_up_hashes.append(
+                    user['UserName'].split('_')[0][5:]
+                )

--- a/cleanup_utils/aws_cleanup.py
+++ b/cleanup_utils/aws_cleanup.py
@@ -204,7 +204,7 @@ class AwsCleanupInstance:
                 if user_policy:
                     buckets_to_delete = self.get_bucket_names_from_policy(user_policy)
                     logger.info("  > Cleaning up stuff from user %s.", user['UserName'])
-                    
+
                     # Delete buckets, user policy, access keys and the iam user
                     for bucket_name in buckets_to_delete:
                         logger.info("    * Deleting bucket %s.", bucket_name)

--- a/cleanup_utils/dns_cleanup.py
+++ b/cleanup_utils/dns_cleanup.py
@@ -59,6 +59,13 @@ class DnsCleanupInstance():
         """
         return self.gandi_api_key
 
+    @property
+    def client_zone(self):
+        """
+        Client domain zone API endpoint
+        """
+        return self.client.domain.zone
+
     def get_dns_record_list(self, zone_id):
         """
         Returns list of all DNS entries for the specified zone

--- a/cleanup_utils/dns_cleanup.py
+++ b/cleanup_utils/dns_cleanup.py
@@ -24,7 +24,6 @@ Cleans up all DNS entries left behind from CI
 
 import logging
 import xmlrpc
-from instance.gandi import GandiAPI
 
 # Logging #####################################################################
 
@@ -38,11 +37,11 @@ BATCH_SIZE = 200
 
 # Classes #####################################################################
 
-class DnsCleanupInstance(GandiAPI):
+class DnsCleanupInstance():
     """
     Handles the cleanup of dangling DNS entries
     """
-    def __init__(self, zone_id, api_key, dry_run):
+    def __init__(self, zone_id, api_key, dry_run, api_url='https://rpc.gandi.net/xmlrpc/'):
         """
         Set up variables needed for cleanup
         """
@@ -50,7 +49,8 @@ class DnsCleanupInstance(GandiAPI):
         self.gandi_api_key = api_key
         self.zone_id = zone_id
 
-        super(DnsCleanupInstance, self).__init__()
+        # Gandi's XMLRPC API
+        self.client = xmlrpc.client.ServerProxy(api_url)
 
     @property
     def api_key(self):
@@ -78,6 +78,28 @@ class DnsCleanupInstance(GandiAPI):
             )
 
         return dns_entries
+
+    def delete_dns_record(self, zone_id, zone_version_id, record_name):
+        """
+        Delete a record from a version of the domain
+        """
+        self.client_zone.record.delete(self.api_key, zone_id, zone_version_id, {
+            'type': ['A', 'CNAME'],
+            'name': record_name,
+        })
+
+    def create_new_zone_version(self, zone_id):
+        """
+        Create a new version of the domain, based on the current version
+        Returns the `version_id` of the version
+        """
+        return self.client_zone.version.new(self.api_key, zone_id)
+
+    def set_zone_version(self, zone_id, zone_version_id):
+        """
+        Set a version of the domain per id
+        """
+        return self.client_zone.version.set(self.api_key, zone_id, zone_version_id)
 
     def run_cleanup(self, hashes_to_clean):
         """
@@ -129,7 +151,11 @@ class DnsCleanupInstance(GandiAPI):
 
             # Set new zone as current
             if not self.dry_run:
-                self.set_zone_version(
-                    zone_id=self.zone_id,
-                    zone_version_id=new_zone_version
-                )
+                try:
+                    self.set_zone_version(
+                        zone_id=self.zone_id,
+                        zone_version_id=new_zone_version
+                    )
+                except xmlrpc.client.Fault as e:
+                    logger.error("FAILED updating DNS entries.")
+                    logger.error("ERROR: %s", e)

--- a/cleanup_utils/integration_cleanup.py
+++ b/cleanup_utils/integration_cleanup.py
@@ -54,28 +54,18 @@ logger.addHandler(file_handler)
 logger.addHandler(console_handler)
 
 
-# Classes #####################################################################
+# Functions ###################################################################
 
 
-def main():
+def run_integration_cleanup(dry_run=False):
     """
     Main function responsible for the cleanup
+    Calls each cleanup module to be executed
     """
-    parser = argparse.ArgumentParser(
-        description="Cleanup all unused resources from integration runs that "
-                    "might have been left behind."
-    )
-    parser.add_argument(
-        '--dry_run',
-        action='store_true',
-        default=False,
-        help='sum the integers (default: find the max)'
-    )
-    args = parser.parse_args()
     logger.setLevel(logging.DEBUG)
 
     logger.info("Running integration cleanup tool...")
-    if args.dry_run:
+    if dry_run:
         logger.info(
             "  > Using DRY_RUN mode: no actual changes will be done to any "
             "resources."
@@ -86,7 +76,7 @@ def main():
         age_limit=DEFAULT_AGE_LIMIT,
         aws_access_key_id=os.environ['AWS_ACCESS_KEY_ID'],
         aws_secret_access_key=os.environ['AWS_SECRET_ACCESS_KEY'],
-        dry_run=args.dry_run
+        dry_run=dry_run
     )
     aws_cleanup.run_cleanup()
 
@@ -94,14 +84,14 @@ def main():
     openstack_settings = {
         'auth_url': os.environ['OPENSTACK_AUTH_URL'],
         'username': os.environ['OPENSTACK_USER'],
-        'api_key': os.environ['OPENSTACK_PASSWORD'],
+        'password': os.environ['OPENSTACK_PASSWORD'],
         'project_id': os.environ['OPENSTACK_TENANT'],
         'region_name': os.environ['OPENSTACK_REGION'],
     }
     os_cleanup = OpenStackCleanupInstance(
         age_limit=DEFAULT_AGE_LIMIT,
         openstack_settings=openstack_settings,
-        dry_run=args.dry_run
+        dry_run=dry_run
     )
     os_cleanup.run_cleanup()
 
@@ -109,7 +99,7 @@ def main():
     dns_cleanup = DnsCleanupInstance(
         zone_id=int(os.environ['GANDI_ZONE_ID']),
         api_key=os.environ['GANDI_API_KEY'],
-        dry_run=args.dry_run
+        dry_run=dry_run
     )
     # Run DNS cleanup erasing all integration entries except for those on
     # the deletion_blacklist
@@ -122,4 +112,16 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    parser = argparse.ArgumentParser(
+        description="Cleanup all unused resources from integration runs that "
+                    "might have been left behind."
+    )
+    parser.add_argument(
+        '--dry_run',
+        action='store_true',
+        default=False,
+        help='sum the integers (default: find the max)'
+    )
+    args = parser.parse_args()
+
+    run_integration_cleanup(args.dry_run)

--- a/cleanup_utils/integration_cleanup.py
+++ b/cleanup_utils/integration_cleanup.py
@@ -24,15 +24,15 @@ Cleans up all AWS, Openstack and DNS resources left behind by CircleCI
 cancelled runs
 """
 
-# import argparse
-# from datetime import datetime, timedelta
-# import logging
-# import os
-# from pytz import UTC
-#
-# from cleanup_utils.aws_cleanup import AwsCleanupInstance
-# from cleanup_utils.openstack_cleanup import OpenStackCleanupInstance
-# from cleanup_utils.dns_cleanup import DnsCleanupInstance
+import argparse
+from datetime import datetime, timedelta
+import logging
+import os
+from pytz import UTC
+
+from cleanup_utils.aws_cleanup import AwsCleanupInstance
+from cleanup_utils.openstack_cleanup import OpenStackCleanupInstance
+from cleanup_utils.dns_cleanup import DnsCleanupInstance
 
 
 # Constants ###################################################################

--- a/cleanup_utils/integration_cleanup.py
+++ b/cleanup_utils/integration_cleanup.py
@@ -120,7 +120,10 @@ if __name__ == "__main__":
         '--dry_run',
         action='store_true',
         default=False,
-        help='sum the integers (default: find the max)'
+        help="""
+            Runs this script in read only mode, not actually cleaning up the resources.
+            Useful for checking if changes in the script are working correctly.
+        """
     )
     args = parser.parse_args()
 

--- a/cleanup_utils/integration_cleanup.py
+++ b/cleanup_utils/integration_cleanup.py
@@ -24,15 +24,15 @@ Cleans up all AWS, Openstack and DNS resources left behind by CircleCI
 cancelled runs
 """
 
-import argparse
-from datetime import datetime, timedelta
-import logging
-import os
-from pytz import UTC
-
-from cleanup_utils.aws_cleanup import AwsCleanupInstance
-from cleanup_utils.openstack_cleanup import OpenStackCleanupInstance
-from cleanup_utils.dns_cleanup import DnsCleanupInstance
+# import argparse
+# from datetime import datetime, timedelta
+# import logging
+# import os
+# from pytz import UTC
+#
+# from cleanup_utils.aws_cleanup import AwsCleanupInstance
+# from cleanup_utils.openstack_cleanup import OpenStackCleanupInstance
+# from cleanup_utils.dns_cleanup import DnsCleanupInstance
 
 
 # Constants ###################################################################

--- a/cleanup_utils/openstack_cleanup.py
+++ b/cleanup_utils/openstack_cleanup.py
@@ -105,13 +105,6 @@ class OpenStackCleanupInstance:
                 instance.key_name,
                 instance.created
             )
-            # Double-check to make sure that the instance is using the circleci keypair.
-            if instance.key_name != 'circleci':
-                logger.info(
-                    "    * SKIPPING: Instance keypair name %s != 'circleci'!",
-                    instance.key_name
-                )
-                continue
 
             # Check if it's a valid date and add UTC timezone
             try:

--- a/cleanup_utils/openstack_cleanup.py
+++ b/cleanup_utils/openstack_cleanup.py
@@ -131,7 +131,7 @@ class OpenStackCleanupInstance:
                 if not self.dry_run:
                     try:
                         instance.delete()
-                    except Exception as e:
+                    except Exception as e: # pylint: disable=broad-except
                         logger.warning(
                             "    * WARNING: Unable to delete instance. Error: %s.",
                             e,

--- a/cleanup_utils/openstack_cleanup.py
+++ b/cleanup_utils/openstack_cleanup.py
@@ -46,15 +46,20 @@ class OpenStackCleanupInstance:
         self.dry_run = dry_run
         self.age_limit = age_limit
         self.cleaned_up_hashes = []
+        self.openstack_online = True
 
-        self.nova = client.Client(
-            "2.0",
-            auth_url=openstack_settings['auth_url'],
-            username=openstack_settings['username'],
-            password=openstack_settings['password'],
-            project_id=openstack_settings['project_id'],
-            region_name=openstack_settings['region_name']
-        )
+        try:
+            self.nova = client.Client(
+                "2.0",
+                auth_url=openstack_settings['auth_url'],
+                username=openstack_settings['username'],
+                password=openstack_settings['password'],
+                project_id=openstack_settings['project_id'],
+                region_name=openstack_settings['region_name']
+            )
+        except Exception as e:
+            logger.error("ERROR: %s", e)
+            self.openstack_online = False
 
     def get_active_circle_ci_instances(self):
         """
@@ -79,6 +84,13 @@ class OpenStackCleanupInstance:
         Runs the cleanup of OpenStack provider
         """
         logger.info("\n --- Starting OpenStack Provider Cleanup ---")
+        if not self.openstack_online:
+            logger.error(
+                "ERROR: The OpenStack provider couldn't be reached,"
+                " the cleanup of these resources won't be executed."
+            )
+            return
+
         if self.dry_run:
             logger.info("Running in DRY_RUN mode, no actions will be taken.")
 

--- a/cleanup_utils/openstack_cleanup.py
+++ b/cleanup_utils/openstack_cleanup.py
@@ -129,7 +129,13 @@ class OpenStackCleanupInstance:
                     self.age_limit
                 )
                 if not self.dry_run:
-                    instance.delete()
+                    try:
+                        instance.delete()
+                    except Exception as e:
+                        logger.warning(
+                            "    * WARNING: Unable to delete instance. Error: %s.",
+                            e,
+                        )
 
             else:
                 logger.info(

--- a/cleanup_utils/openstack_cleanup.py
+++ b/cleanup_utils/openstack_cleanup.py
@@ -51,7 +51,7 @@ class OpenStackCleanupInstance:
             "2.0",
             auth_url=openstack_settings['auth_url'],
             username=openstack_settings['username'],
-            api_key=openstack_settings['api_key'],
+            password=openstack_settings['password'],
             project_id=openstack_settings['project_id'],
             region_name=openstack_settings['region_name']
         )

--- a/cleanup_utils/openstack_cleanup.py
+++ b/cleanup_utils/openstack_cleanup.py
@@ -57,7 +57,7 @@ class OpenStackCleanupInstance:
                 project_id=openstack_settings['project_id'],
                 region_name=openstack_settings['region_name']
             )
-        except Exception as e:
+        except Exception as e:  # pylint: disable=broad-except
             logger.error("ERROR: %s", e)
             self.openstack_online = False
 

--- a/cleanup_utils/requirements.txt
+++ b/cleanup_utils/requirements.txt
@@ -1,0 +1,2 @@
+boto3==1.9.61
+python-novaclient==6.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -154,4 +154,3 @@ Pillow==4.3.0
 django_storage_swift==1.2.17
 pycryptodomex==3.7.0
 pyjwkest==1.4.0
-boto3==1.9.61


### PR DESCRIPTION
This PR add two main changes to the integration cleanup script:

1. Improved fault tolerance by catching untreated exceptions
2. Added CircleCI workflows configuration to run cleanup only after all tests are done.

## Testing

1. Checkout this branch
2. `vagrant up && vagrant ssh` on Ocim's devstack
3. Export environment variables needed for cleanup:
```
export GANDI_API_KEY=
export AWS_ACCESS_KEY_ID=
export AWS_SECRET_ACCESS_KEY=
export GANDI_ZONE_ID=
export OPENSTACK_USER=
export OPENSTACK_TENANT=
export OPENSTACK_REGION=
export OPENSTACK_AUTH_URL=
export OPENSTACK_PASSWORD=
```
4. Run `PYTHONPATH=$PYTHONPATH:$(pwd) honcho -e .env.integration run python3 cleanup_utils/integration_cleanup.py --dry_run` and check that there were no errors on the output.
5. (OPTIONAL) Run `make test.integration_cleanup` to run the actual cleanup and check that there were no errors on the output.
6. Check the latest CI run and see that the workflows are working correctly. Latest commit:
**Workflow**: https://circleci.com/workflow-run/8fa529e2-2703-4293-991e-93f7e09d5fd8
**CI Run**: https://circleci.com/gh/open-craft/opencraft/4249