### PR TITLE
Upgrade to boto3

### DIFF
--- a/instance/management/commands/reprovision_buckets.py
+++ b/instance/management/commands/reprovision_buckets.py
@@ -1,0 +1,66 @@
+# -*- coding: utf-8 -*-
+#
+# OpenCraft -- tools to aid developing and hosting free software projects
+# Copyright (C) 2015-2019 OpenCraft <contact@opencraft.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+"""
+This management command will reprovision the S3 bucket for each available
+instance to have its configuration updated on AWS.
+"""
+
+import logging
+
+from botocore.exceptions import ClientError
+from django.core.management.base import BaseCommand
+
+from instance.models.instance import InstanceReference
+
+LOG = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    """
+    This management command will reprovision the S3 bucket for each available
+    instance to have its configuration updated on AWS.
+    """
+    help = (
+        'Reprovision S3 buckets for all available instances'
+    )
+
+    def handle(self, *args, **options):
+        """
+        Reprovisions the S3 bucket for each available instance to have its
+        configuration updated on AWS.
+        """
+
+        # Identify instances that need updating
+        refs = InstanceReference.objects.filter(is_archived=False)
+        LOG.info('Found "%d" active instances', len(refs))
+
+        for ref in refs:
+            LOG.info('Reprovisioning %s S3 bucket to update bucket and iam configuration', ref.instance.name)
+
+            # Reprovisioning will update the necessary configuration
+            try:
+                ref.instance.provision_s3()
+            except ClientError as e:
+                LOG.error(
+                    'Failed to reprovision bucket for "%s" due to: %s',
+                    ref.instance.name,
+                    e
+                )
+            else:
+                LOG.info('Reprovisioned bucket for %s', ref.instance.name)

--- a/instance/tests/integration/integration_instance.py
+++ b/instance/tests/integration/integration_instance.py
@@ -253,7 +253,27 @@ class InstanceIntegrationTestCase(IntegrationTestCase):
 
         self._assert_theme_favicon_in_html(instance, application, favicon_url)
 
+    def assert_bucket_configured(self, instance):
+        """
+        Ensure bucket is configured with proper lifecycle and versioning
+        """
+        # Make sure versioning is enabled
+        response = instance.s3.get_bucket_versioning(Bucket=instance.s3_bucket_name)
+        self.assertEqual(response.get('Status'), 'Enabled')
+
+        # Make sure expiration lifecycle is enabled
+        response = instance.s3.get_bucket_lifecycle_configuration(Bucket=instance.s3_bucket_name)
+        self.assertIn('Rules', response)
+        days = None
+        for rule in response.get('Rules'):
+            if rule.get('Status') == 'Enabled' and 'NoncurrentVersionExpiration' in rule:
+                days = rule.get('NoncurrentVersionExpiration').get('NoncurrentDays')
+                break
+        self.assertEqual(settings.S3_VERSION_EXPIRATION, days)
+
+
     @override_settings(INSTANCE_STORAGE_TYPE='s3')
+    @shard(1)
     def test_spawn_appserver(self):
         """
         Provision an instance and spawn an AppServer, complete with custom theme (colors)
@@ -289,9 +309,10 @@ class InstanceIntegrationTestCase(IntegrationTestCase):
         # We don't want to simulate e-mail verification of the user who submitted the application,
         # because that would start provisioning. Instead, we provision ourselves here.
 
-        appserver = spawn_appserver(instance.ref.pk, mark_active_on_success=True, num_attempts=2)
+        spawn_appserver(instance.ref.pk, mark_active_on_success=True, num_attempts=2)
 
         self.assert_instance_up(instance)
+        self.assert_bucket_configured(instance)
         self.assert_appserver_firewalled(instance)
         self.assertTrue(instance.successfully_provisioned)
         for appserver in instance.appserver_set.all():
@@ -299,7 +320,6 @@ class InstanceIntegrationTestCase(IntegrationTestCase):
             self.assert_lms_users_provisioned(user, appserver)
             self.assert_theme_provisioned(instance, appserver, application)
 
-    @shard(1)
     @override_settings(INSTANCE_STORAGE_TYPE='s3')
     def test_betatest_accepted(self):
         """

--- a/instance/tests/integration/integration_instance.py
+++ b/instance/tests/integration/integration_instance.py
@@ -271,7 +271,6 @@ class InstanceIntegrationTestCase(IntegrationTestCase):
                 break
         self.assertEqual(settings.S3_VERSION_EXPIRATION, days)
 
-
     @override_settings(INSTANCE_STORAGE_TYPE='s3')
     @shard(1)
     def test_spawn_appserver(self):

--- a/instance/tests/management/test_reprovision_buckets.py
+++ b/instance/tests/management/test_reprovision_buckets.py
@@ -1,0 +1,82 @@
+# -*- coding: utf-8 -*-
+#
+# OpenCraft -- tools to aid developing and hosting free software projects
+# Copyright (C) 2015-2018 OpenCraft <contact@opencraft.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+"""
+Instance - reprovision_buckets unit tests
+"""
+from unittest.mock import patch
+
+from django.core.management import call_command
+from django.test import TestCase
+from django.utils.six import StringIO
+from testfixtures import LogCapture
+
+from instance.models.openedx_instance import OpenEdXInstance
+
+
+class ReprovisionBucketsTestCase(TestCase):
+    """
+    Test cases for the `reprovision_buckets` management command.
+    """
+
+    def test_no_instances(self):
+        """
+        Verify that the command correctly notifies the user that there are no instances for migration.
+        """
+        with LogCapture() as captured_logs:
+            call_command(
+                'reprovision_buckets',
+                stdout=StringIO(),
+            )
+        # Verify the logs
+        self.assertIn(
+            'Found "0" active instances',
+            [l[2] for l in captured_logs.actual()])
+
+    @patch('instance.models.mixins.storage.S3BucketInstanceMixin._enable_bucket_versioning')
+    @patch('instance.models.mixins.storage.S3BucketInstanceMixin._update_bucket_lifecycle')
+    @patch('instance.models.mixins.storage.S3BucketInstanceMixin._update_bucket_cors')
+    @patch('instance.models.mixins.storage.S3BucketInstanceMixin._perform_create_bucket')
+    @patch('instance.models.mixins.storage.S3BucketInstanceMixin._update_iam_policy')
+    @patch('instance.models.mixins.storage.S3BucketInstanceMixin.create_iam_user')
+    def test_migrate(self,
+                     mock_create_iam_user,
+                     mock_update_iam,
+                     mock_create_bucket,
+                     mock_update_cors,
+                     mock_update_lifecycle,
+                     mock_enable_versioning):
+        """
+        Verify that the command correctly reprovision the bucket for an instance.
+        """
+        OpenEdXInstance.objects.create(
+            sub_domain='test', name='test instance', storage_type=OpenEdXInstance.S3_STORAGE)
+        with LogCapture() as captured_logs:
+            call_command(
+                'reprovision_buckets',
+                stdout=StringIO(),
+            )
+            # Verify the logs
+        self.assertIn(
+            'Found "1" active instances',
+            set(l[2] for l in captured_logs.actual()))
+
+        mock_update_iam.assert_called_once_with()
+        mock_update_cors.assert_called_once_with()
+        mock_update_lifecycle.assert_called_once_with()
+        mock_enable_versioning.assert_called_once_with()

--- a/instance/tests/models/test_openedx_storage_mixins.py
+++ b/instance/tests/models/test_openedx_storage_mixins.py
@@ -23,19 +23,29 @@ OpenEdXInstance Storage Mixins - Tests
 # Imports #####################################################################
 from unittest.mock import call, patch
 
-import boto
+import boto3
 import ddt
 import yaml
+from botocore.exceptions import ClientError
+from botocore.session import get_session
+from botocore.stub import Stubber
 from django.conf import settings
 from django.test.utils import override_settings
 
-from instance.models.mixins.storage import StorageContainer, get_master_iam_connection, get_s3_cors_config
+from instance.models.mixins import storage
+from instance.models.mixins.storage import StorageContainer, S3_CORS
 from instance.tests.base import TestCase
 from instance.tests.models.factories.openedx_appserver import make_test_appserver
 from instance.tests.models.factories.openedx_instance import OpenEdXInstanceFactory
+from instance.tests.models.utils import S3Stubber, IAMStubber
 
+
+# Clients #####################################################################
+iam_client = get_session().create_client('iam')
+s3_client = get_session().create_client('s3')
 
 # Tests #######################################################################
+
 
 class OpenEdXStorageMixinTestCase(TestCase):
     """
@@ -183,9 +193,33 @@ def get_swift_settings(instance):
     }
 
 
-# pylint: disable=too-many-public-methods
+class ContainerTestCase(TestCase):
+    """
+    Tests for provisioning settings
+    """
+    def check_ansible_settings(self, appserver, expected=True, s3=False):
+        """
+        Verify the Ansible settings.
+        """
+        instance = appserver.instance
+        if s3:
+            expected_settings = get_s3_settings(instance)
+        else:
+            expected_settings = get_swift_settings(instance)
+
+        # Replace any \' occurrences because some settings may have it while we do a blanket assertion without it.
+        # For example: we assert "EDXAPP_SWIFT_TENANT_NAME: 9999999999" is in `ansible_vars`, which would have
+        # "EDXAPP_SWIFT_TENANT_NAME: \'9999999999\'", causing a mismatch unless we strip the \'.
+        ansible_vars = str(appserver.configuration_settings).replace("\'", '')
+        for ansible_var, value in expected_settings.items():
+            if expected:
+                self.assertRegex(ansible_vars, r'{}:\s*{}'.format(ansible_var, value))
+            else:
+                self.assertNotRegex(ansible_vars, r'{}:\s*{}'.format(ansible_var, value))
+
+
 @ddt.ddt
-class SwiftContainerInstanceTestCase(TestCase):
+class SwiftContainerInstanceTestCase(ContainerTestCase):
     """
     Tests for Swift container provisioning.
     """
@@ -255,26 +289,6 @@ class SwiftContainerInstanceTestCase(TestCase):
         self.assertIs(instance.swift_provisioned, False)
         self.assertFalse(create_swift_container.called)
 
-    def check_ansible_settings(self, appserver, expected=True, s3=False):
-        """
-        Verify the Ansible settings.
-        """
-        instance = appserver.instance
-        if s3:
-            expected_settings = get_s3_settings(instance)
-        else:
-            expected_settings = get_swift_settings(instance)
-
-        # Replace any \' occurrences because some settings may have it while we do a blanket assertion without it.
-        # For example: we assert "EDXAPP_SWIFT_TENANT_NAME: 9999999999" is in `ansible_vars`, which would have
-        # "EDXAPP_SWIFT_TENANT_NAME: \'9999999999\'", causing a mismatch unless we strip the \'.
-        ansible_vars = str(appserver.configuration_settings).replace("\'", '')
-        for ansible_var, value in expected_settings.items():
-            if expected:
-                self.assertRegex(ansible_vars, r'{}:\s*{}'.format(ansible_var, value))
-            else:
-                self.assertNotRegex(ansible_vars, r'{}:\s*{}'.format(ansible_var, value))
-
     def test_ansible_settings_swift(self):
         """
         Verify Swift Ansible configuration when Swift is enabled.
@@ -292,6 +306,19 @@ class SwiftContainerInstanceTestCase(TestCase):
         appserver = make_test_appserver(instance)
         self.check_ansible_settings(appserver, expected=False)
 
+
+@ddt.ddt
+@override_settings(
+    AWS_ACCESS_KEY='test',
+    AWS_SECRET_ACCESS_KEY_ID='test',
+    INSTANCE_STORAGE_TYPE=StorageContainer.S3_STORAGE,
+)
+class S3ContainerInstanceTestCase(ContainerTestCase):
+    """
+    Tests for S3 Storage
+    """
+    default_region = boto3.client('s3').meta.config.region_name
+
     @ddt.data(
         '',
         'eu-west-1',
@@ -305,103 +332,163 @@ class SwiftContainerInstanceTestCase(TestCase):
         appserver = make_test_appserver(instance, s3=True)
         self.check_ansible_settings(appserver, s3=True)
 
-    @override_settings(
-        AWS_ACCESS_KEY='test',
-        AWS_SECRET_ACCESS_KEY_ID='test',
-        AWS_S3_DEFAULT_HOSTNAME='s3.test.host',
-        AWS_S3_CUSTOM_REGION_HOSTNAME='s3.{region}.test.host',
-        INSTANCE_STORAGE_TYPE=StorageContainer.S3_STORAGE,
-    )
     @ddt.data(
-        ('', 's3.test.host'),
-        ('region', 's3.region.test.host'),
-        ('eu-central-1', 's3.eu-central-1.test.host'),
+        ('', default_region),
+        ('region', 'region'),
+        ('eu-central-1', 'eu-central-1'),
     )
     @ddt.unpack
-    def test_get_s3_connection(self, s3_region, expected_hostname):
+    def test_get_s3_connection(self, s3_region, expected_region):
         """
         Test get_s3 connection returns right instance
         """
         instance = OpenEdXInstanceFactory()
         instance.s3_region = s3_region
-        s3_connection = instance.get_s3_connection()
-        self.assertIsInstance(s3_connection, boto.s3.connection.S3Connection)
-        self.assertEqual(s3_connection.host, expected_hostname)
+        self.assertEqual(instance.s3.meta.region_name, expected_region)
 
     def test_get_s3_policy(self):
         """
         Verify S3 policy is set for correctly
         """
-        instance = OpenEdXInstanceFactory()
-        policies = [
-            (
-                '"Action": [\n        "s3:ListBucket",\n        "s3:CreateBucket"'
-                ',\n        "s3:DeleteBucket",\n        "s3:PutBucketCORS"\n      ]'
-            ),
-            '"Resource": [\n        "arn:aws:s3:::{}"\n      ]'.format(instance.s3_bucket_name),
-            '"Action": [\n        "s3:*Object*"\n      ]',
-            '"Resource": [\n        "arn:aws:s3:::{}/*"\n      ]'.format(instance.s3_bucket_name)
+        instance = OpenEdXInstanceFactory(s3_bucket_name='test_bucket')
+        actions = [
+            "s3:ListBucket",
+            "s3:CreateBucket",
+            "s3:DeleteBucket",
+            "s3:PutBucketCORS",
+            "s3:PutBucketVersioning",
+            "s3:PutLifecycleConfiguration",
         ]
-        policy = instance.get_s3_policy()
-        for line in policies:
-            self.assertIn(line, policy)
+        policy = instance.get_s3_policy()['Statement']
+        self.assertIn("arn:aws:s3:::{}".format(instance.s3_bucket_name), policy[0]['Resource'])
+        for action in actions:
+            self.assertIn(action, policy[0]['Action'])
 
-    @patch('boto.s3.connection.S3Connection.create_bucket')
-    @patch('boto.s3.bucket.Bucket.set_cors')
-    def test_provision_s3(self, set_cors, create_bucket):
+    @ddt.data(
+        (True, ), (False, )
+    )
+    @patch('instance.models.mixins.storage.S3BucketInstanceMixin.iam', iam_client)
+    @patch('instance.models.mixins.storage.S3BucketInstanceMixin.s3', s3_client)
+    # pylint: disable=no-self-use
+    def test_provision_s3(self, provision_iam):
         """
         Test s3 provisioning succeeds
         """
         instance = OpenEdXInstanceFactory()
         instance.storage_type = StorageContainer.S3_STORAGE
-        instance.s3_access_key = 'test'
-        instance.s3_secret_access_key = 'test'
         instance.s3_bucket_name = 'test'
         instance.s3_region = 'test'
-        instance.provision_s3()
-        create_bucket.assert_called_once_with(instance.s3_bucket_name, location=instance.s3_region)
-        self.assertEqual(
-            instance.s3_hostname,
-            settings.AWS_S3_CUSTOM_REGION_HOSTNAME.format(region=instance.s3_region)
-        )
+        if not provision_iam:
+            instance.s3_access_key = 'test'
+            instance.s3_secret_access_key = 'test'
 
-    @patch('boto.s3.connection.S3Connection.create_bucket')
-    def test__create_bucket_fails(self, create_bucket):
+        with S3Stubber(s3_client) as stubber, IAMStubber(iam_client) as iamstubber:
+            if provision_iam:
+                iamstubber.stub_create_user(instance.iam_username)
+                iamstubber.stub_create_access_key(instance.iam_username)
+                iamstubber.stub_put_user_policy(
+                    instance.iam_username,
+                    storage.USER_POLICY_NAME,
+                    instance.get_s3_policy()
+                )
+                stubber.stub_create_bucket()
+                stubber.stub_put_cors()
+                stubber.stub_set_expiration()
+                stubber.stub_versioning()
+                instance.provision_s3()
+
+    @patch('instance.models.mixins.storage.S3BucketInstanceMixin.s3', s3_client)
+    def test__create_bucket_fails(self):
         """
         Test s3 provisioning fails on bucket creation, and retries up to 4 times
         """
-        create_bucket.side_effect = boto.exception.S3ResponseError(403, "Forbidden")
         instance = OpenEdXInstanceFactory()
         instance.s3_access_key = 'test'
         instance.s3_secret_access_key = 'test'
         instance.s3_bucket_name = 'test'
-        attempts = 4
-        with self.assertRaises(boto.exception.S3ResponseError):
-            with self.assertLogs('instance.models.instance', level='INFO') as cm:
-                instance._create_bucket(attempts=attempts)
-        base_log_text = (
-            'INFO:instance.models.instance:instance={} ({!s:.15}) | Retrying bucket creation.'
-            ' IAM keys are not propagated yet, attempt %s of {}.'.format(instance.ref.pk, instance.ref.name, attempts)
-        )
-        self.assertEqual(
-            cm.output,
-            [base_log_text % i for i in range(1, attempts + 1)]
-        )
+        max_tries = 4
+        stubber = Stubber(s3_client)
+        for _ in range(max_tries):
+            stubber.add_client_error('create_bucket')
+        with self.assertLogs('instance.models.instance', level='INFO') as cm:
+            with stubber:
+                with self.assertRaises(ClientError):
+                    instance._create_bucket(max_tries=max_tries)
 
-    @patch('boto.connect_iam')
-    @patch('boto.s3.connection.S3Connection')
-    def test_deprovision_s3(self, s3_connection, iam_connection):
+            base_log_text = (
+                'INFO:instance.models.instance:instance={} ({!s:.15}) | Retrying bucket creation.'
+                ' IAM keys are not propagated yet, attempt %s of {}.'.format(instance.ref.pk, instance.ref.name,
+                                                                             max_tries)
+            )
+            self.assertEqual(
+                cm.output,
+                [base_log_text % i for i in range(1, max_tries + 1)]
+            )
+
+    @patch('instance.models.mixins.storage.S3BucketInstanceMixin.iam', iam_client)
+    @patch('instance.models.mixins.storage.S3BucketInstanceMixin.s3', s3_client)
+    def test_deprovision_s3(self):
         """
         Test s3 deprovisioning succeeds
         """
+
         instance = OpenEdXInstanceFactory()
         instance.storage_type = StorageContainer.S3_STORAGE
-        instance.s3_access_key = 'test'
+        instance.s3_access_key = 'test_0123456789a'
         instance.s3_secret_access_key = 'test'
         instance.s3_bucket_name = 'test'
         instance.s3_region = 'test'
-        instance.provision_s3()
-        instance.deprovision_s3()
+
+        with S3Stubber(s3_client) as stubber, IAMStubber(iam_client) as iamstubber:
+            iamstubber.stub_put_user_policy(
+                instance.iam_username,
+                storage.USER_POLICY_NAME,
+                instance.get_s3_policy()
+            )
+            stubber.stub_create_bucket()
+            stubber.stub_put_cors()
+            stubber.stub_set_expiration()
+            stubber.stub_versioning()
+            instance.provision_s3()
+            # Put an object
+            stubber.stub_put_object(b'test', 'test')
+            s3_client.put_object(Body=b'test', Bucket='test', Key='test')
+            # Overwrite object
+            stubber.stub_put_object(b'another_test', 'test')
+            s3_client.put_object(Body=b'another_test', Bucket='test', Key='test')
+            # Put another object
+            stubber.stub_put_object(b'another_test', 'another_test')
+            s3_client.put_object(Body=b'another_test', Bucket='test', Key='another_test')
+            # Delete object
+            stubber.stub_delete_object(key='another_test')
+            s3_client.delete_object(Bucket='test', Key='another_test')
+            # Make sure three versions and a delete marker are removed
+            items = {
+                'Versions': [
+                    {'Key': 'test', 'VersionId': '1a'},
+                    {'Key': 'test', 'VersionId': '2b'},
+                    {'Key': 'another_test', 'VersionId': '3c'}
+                ],
+                'DeleteMarkers': [
+                    {'Key': 'another_test', 'VersionId': '4d'}
+                ]
+            }
+            stubber.stub_list_object_versions(result=items)
+            stubber.add_response('delete_objects', {}, {
+                'Bucket': 'test',
+                'Delete': {
+                    'Objects': [{'Key': d['Key'], 'VersionId': d['VersionId']}
+                                for d in items['Versions'] + items['DeleteMarkers']]
+                }
+            })
+            stubber.stub_list_object_versions(result={})
+            stubber.stub_delete_bucket()
+
+            iamstubber.stub_delete_access_key(instance.iam_username, instance.s3_access_key)
+            iamstubber.stub_delete_user_policy(instance.iam_username)
+            iamstubber.stub_delete_user(instance.iam_username)
+            instance.deprovision_s3()
+
         instance.refresh_from_db()
         self.assertEqual(instance.s3_bucket_name, "")
         self.assertEqual(instance.s3_access_key, "")
@@ -409,41 +496,74 @@ class SwiftContainerInstanceTestCase(TestCase):
         # We always want to preserve information about a client's preferred region, so s3_region should not be empty.
         self.assertEqual(instance.s3_region, "test")
 
-    @patch('boto.connect_iam')
-    @patch('boto.s3.connection.S3Connection')
-    def test_deprovision_s3_delete_user_fails(self, s3_connection, connect_iam):
+    @patch('instance.models.mixins.storage.S3BucketInstanceMixin.s3', s3_client)
+    @patch('instance.models.mixins.storage.S3BucketInstanceMixin.iam', iam_client)
+    def test_deprovision_s3_delete_user_fails(self):
         """
         Test s3 deprovisioning fails on delete_user
         """
-        iam_connection = connect_iam()
-        iam_connection.delete_access_key.side_effect = boto.exception.BotoServerError(403, "Forbidden")
         instance = OpenEdXInstanceFactory()
         instance.storage_type = StorageContainer.S3_STORAGE
-        instance.s3_access_key = 'test'
+        instance.s3_access_key = 'test_0123456789a'
         instance.s3_secret_access_key = 'test'
         instance.s3_bucket_name = 'test'
         with self.assertLogs("instance.models.instance"):
-            instance.deprovision_s3()
+            with S3Stubber(s3_client) as stubber, IAMStubber(iam_client) as iamstubber:
+                iamstubber.stub_put_user_policy(
+                    instance.iam_username,
+                    storage.USER_POLICY_NAME,
+                    instance.get_s3_policy()
+                )
+                stubber.stub_create_bucket(location='')
+                stubber.stub_put_cors()
+                stubber.stub_set_expiration()
+                stubber.stub_versioning()
+                instance.provision_s3()
+
+                stubber.stub_list_object_versions(result={})
+                stubber.stub_delete_bucket()
+
+                iamstubber.stub_delete_access_key(instance.iam_username, instance.s3_access_key)
+                iamstubber.stub_delete_user_policy(instance.iam_username)
+                iamstubber.add_client_error('delete_user')
+                instance.deprovision_s3()
         # Since it failed deleting the user, access_keys should not be empty
-        self.assertEqual(instance.s3_access_key, "test")
+        instance.refresh_from_db()
+        self.assertEqual(instance.s3_access_key, "test_0123456789a")
         self.assertEqual(instance.s3_secret_access_key, "test")
 
-    @patch('boto.connect_iam')
-    @patch('boto.s3.connection.S3Connection')
-    def test_deprovision_s3_delete_bucket_fails(self, s3_connection, connect_iam):
+    @patch('instance.models.mixins.storage.S3BucketInstanceMixin.iam', iam_client)
+    @patch('instance.models.mixins.storage.S3BucketInstanceMixin.s3', s3_client)
+    def test_deprovision_s3_delete_bucket_fails(self):
         """
         Test s3 deprovisioning fails on delete_bucket
         """
-        s3_connection = s3_connection()
-        s3_connection.delete_bucket.side_effect = boto.exception.S3ResponseError(403, "Forbidden")
         instance = OpenEdXInstanceFactory()
         instance.storage_type = StorageContainer.S3_STORAGE
-        instance.s3_access_key = 'test'
+        instance.s3_access_key = 'test_0123456789a'
         instance.s3_secret_access_key = 'test'
         instance.s3_bucket_name = 'test'
         instance.s3_region = 'test'
         with self.assertLogs("instance.models.instance"):
-            instance.deprovision_s3()
+            with S3Stubber(s3_client) as stubber, IAMStubber(iam_client) as iamstubber:
+                iamstubber.stub_put_user_policy(
+                    instance.iam_username,
+                    storage.USER_POLICY_NAME,
+                    instance.get_s3_policy()
+                )
+                stubber.stub_create_bucket()
+                stubber.stub_put_cors()
+                stubber.stub_set_expiration()
+                stubber.stub_versioning()
+                instance.provision_s3()
+
+                stubber.stub_list_object_versions(result={})
+                stubber.add_client_error('delete_bucket')
+
+                iamstubber.stub_delete_access_key(instance.iam_username, instance.s3_access_key)
+                iamstubber.stub_delete_user_policy(instance.iam_username)
+                iamstubber.stub_delete_user(instance.iam_username)
+                instance.deprovision_s3()
         instance.refresh_from_db()
         # Since it failed deleting the bucket, s3_bucket_name should not be empty
         self.assertEqual(instance.s3_bucket_name, "test")
@@ -452,10 +572,8 @@ class SwiftContainerInstanceTestCase(TestCase):
         self.assertEqual(instance.s3_secret_access_key, "")
         self.assertEqual(instance.s3_access_key, "")
 
-    @patch('boto.s3.connection.S3Connection.create_bucket')
-    @patch('boto.s3.bucket.Bucket.set_cors')
     @override_settings(AWS_S3_DEFAULT_REGION='test')
-    def test_provision_s3_swift(self, set_cors, create_bucket):
+    def test_provision_s3_swift(self):
         """
         Test s3 provisioning does nothing when SWIFT is enabled
         """
@@ -468,20 +586,28 @@ class SwiftContainerInstanceTestCase(TestCase):
         self.assertEqual(instance.s3_secret_access_key, '')
         self.assertEqual(instance.s3_region, settings.AWS_S3_DEFAULT_REGION)
 
-    @patch('boto.s3.connection.S3Connection.create_bucket')
-    @patch('boto.s3.bucket.Bucket.set_cors')
-    @override_settings(AWS_S3_DEFAULT_REGION='')
-    def test_provision_s3_unconfigured(self, set_cors, create_bucket):
+    @patch('instance.models.mixins.storage.S3BucketInstanceMixin.iam', iam_client)
+    @patch('instance.models.mixins.storage.S3BucketInstanceMixin.s3', s3_client)
+    def test_provision_s3_unconfigured(self):
         """
         Test s3 provisioning works with default bucket and IAM
         """
         instance = OpenEdXInstanceFactory()
         instance.storage_type = StorageContainer.S3_STORAGE
-        instance.provision_s3()
-        create_bucket.assert_called_once_with(
-            instance.s3_bucket_name,
-            location=settings.AWS_S3_DEFAULT_REGION
-        )
+        instance.s3_bucket_name = instance.bucket_name  # For stubbing to work correctly
+        with S3Stubber(s3_client) as stubber, IAMStubber(iam_client) as iamstubber:
+            iamstubber.stub_create_user(instance.iam_username)
+            iamstubber.stub_create_access_key(instance.iam_username)
+            iamstubber.stub_put_user_policy(
+                instance.iam_username,
+                storage.USER_POLICY_NAME,
+                instance.get_s3_policy()
+            )
+            stubber.stub_create_bucket(bucket=instance.s3_bucket_name, location='')
+            stubber.stub_put_cors(bucket=instance.s3_bucket_name)
+            stubber.stub_set_expiration(bucket=instance.s3_bucket_name)
+            stubber.stub_versioning(bucket=instance.s3_bucket_name)
+            instance.provision_s3()
         instance.refresh_from_db()
         self.assertIsNotNone(instance.s3_bucket_name)
         self.assertIsNotNone(instance.s3_access_key)
@@ -489,47 +615,35 @@ class SwiftContainerInstanceTestCase(TestCase):
         self.assertEqual(instance.s3_region, settings.AWS_S3_DEFAULT_REGION)
         self.assertEqual(instance.s3_hostname, settings.AWS_S3_DEFAULT_HOSTNAME)
 
-    @patch('boto.connect_iam')
-    @override_settings(AWS_ACCESS_KEY_ID='test', AWS_SECRET_ACCESS_KEY='test')
-    def test_create_iam_user(self, connect_iam):
+    @override_settings(AWS_ACCESS_KEY_ID='test_0123456789a', AWS_SECRET_ACCESS_KEY='secret')
+    @patch('instance.models.mixins.storage.S3BucketInstanceMixin.iam', iam_client)
+    def test_create_iam_user(self):
         """
         Test create_iam_user succeeds and sets the required attributes
         """
-        access_keys = {
-            'create_access_key_response': {
-                'create_access_key_result': {
-                    'access_key': {
-                        'access_key_id': 'test',
-                        'secret_access_key': 'test'
-                    }
-                }
-            }
-        }
-        connect_iam().create_access_key.return_value = access_keys
         instance = OpenEdXInstanceFactory()
         instance.storage_type = StorageContainer.S3_STORAGE
-        instance.create_iam_user()
-        instance.refresh_from_db()
-        self.assertEqual(instance.s3_access_key, 'test')
-        self.assertEqual(instance.s3_secret_access_key, 'test')
+
+        with IAMStubber(iam_client) as iamstubber:
+            iamstubber.stub_create_user(instance.iam_username)
+            iamstubber.stub_create_access_key(instance.iam_username)
+            iamstubber.stub_put_user_policy(
+                instance.iam_username,
+                storage.USER_POLICY_NAME,
+                instance.get_s3_policy()
+            )
+            instance.create_iam_user()
+            instance.refresh_from_db()
+            self.assertEqual(instance.s3_access_key, 'test_0123456789a')
+            self.assertEqual(instance.s3_secret_access_key, 'secret')
 
     def test_get_s3_cors(self):
         """
         Test get_s3_config succeeds
         """
-        s3_cors_config = get_s3_cors_config()
-        self.assertEqual(s3_cors_config[0].allowed_method, ['GET', 'PUT'])
-        self.assertEqual(s3_cors_config[0].allowed_header, ['*'])
-        self.assertEqual(s3_cors_config[0].allowed_origin, ['*'])
-
-    @patch('boto.connect_iam')
-    @override_settings(AWS_ACCESS_KEY_ID='test', AWS_SECRET_ACCESS_KEY='test')
-    def test_get_master_iam_connection(self, connect_iam):  # pylint: disable=no-self-use
-        """
-        Test get_s3_config succeeds
-        """
-        get_master_iam_connection()
-        connect_iam.assert_called_once_with('test', 'test')
+        self.assertEqual(S3_CORS['CORSRules'][0]['AllowedMethods'], ['GET', 'PUT'])
+        self.assertEqual(S3_CORS['CORSRules'][0]['AllowedHeaders'], ['*'])
+        self.assertEqual(S3_CORS['CORSRules'][0]['AllowedOrigins'], ['*'])
 
     def test_bucket_name(self):
         """

--- a/instance/tests/models/utils.py
+++ b/instance/tests/models/utils.py
@@ -1,0 +1,158 @@
+"""
+Helper functions to stub botocore requests in unit tests
+"""
+
+import json
+
+from botocore.stub import Stubber
+
+from instance.models.mixins import storage
+
+
+class S3Stubber(Stubber):
+    """
+    Helper class to simplify stubbing S3 operations
+    """
+
+    def stub_create_bucket(self, bucket='test', location='test'):
+        """ Stub helper for 'create_bucket' """
+        if not location or location == 'us-east-1':
+            expected_params = {
+                'Bucket': bucket
+            }
+        else:
+            expected_params = {
+                'Bucket': bucket, 'CreateBucketConfiguration': {
+                    'LocationConstraint': location
+                }
+            }
+        self.add_response('create_bucket', {
+            'Location': location
+        }, expected_params)
+
+    def stub_put_cors(self, bucket='test'):
+        """ Stub helper for 'put_bucket_cors' """
+        self.add_response('put_bucket_cors', {}, {
+            'Bucket': bucket,
+            'CORSConfiguration': {
+                'CORSRules': [{
+                    'AllowedHeaders': ['*'],
+                    'AllowedMethods': ['GET', 'PUT'],
+                    'AllowedOrigins': ['*'],
+                    'ExposeHeaders': ['GET', 'PUT']
+                }]
+            }
+        })
+
+    def stub_set_expiration(self, bucket='test', days=30, prefix=''):
+        """ Stub helper for 'put_bucket_lifecycle_configuration' """
+        self.add_response('put_bucket_lifecycle_configuration', {}, {
+            'Bucket': bucket,
+            'LifecycleConfiguration': {
+                'Rules': [
+                    {
+                        'NoncurrentVersionExpiration': {
+                            'NoncurrentDays': days
+                        },
+                        'Prefix': prefix,
+                        'Status': 'Enabled',
+                    },
+                ]
+            }
+        })
+
+    def stub_versioning(self, bucket='test', status='Enabled'):
+        """ Stub helper for 'put_bucket_versioning' """
+        self.add_response('put_bucket_versioning', {}, {
+            'Bucket': bucket,
+            'VersioningConfiguration': {
+                'Status': status
+            }
+        })
+
+    def stub_put_object(self, body, key, bucket='test'):
+        """ Stub helper for 'put_object' """
+        self.add_response('put_object', {}, {
+            'Bucket': bucket,
+            'Body': body,
+            'Key': key
+        })
+
+    def stub_delete_object(self, key, version_id=None, bucket='test'):
+        """ Stub helper for 'delete_object' """
+        if version_id is None:
+            self.add_response('delete_object', {}, {
+                'Bucket': bucket,
+                'Key': key
+            })
+        else:
+            self.add_response('delete_object', {}, {
+                'Bucket': bucket,
+                'Key': key,
+                'VersionId': version_id
+            })
+
+    def stub_list_object_versions(self, result, bucket='test'):
+        """ Stub helper for 'list_object_versions' """
+        self.add_response('list_object_versions', result, {
+            'Bucket': bucket
+        })
+
+    def stub_delete_bucket(self, bucket='test'):
+        """ Stub helper for 'delete_bucket' """
+        self.add_response('delete_bucket', {}, {
+            'Bucket': bucket
+        })
+
+
+class IAMStubber(Stubber):
+    """
+    Helper class to simplify stubbing IAM operations
+    """
+
+    def stub_create_user(self, username):
+        """ Stub helper for 'create_user' """
+        self.add_response('create_user', {}, {
+            'UserName': username
+        })
+
+    def stub_put_user_policy(self, username, policy_name, policy_document):
+        """ Stub helper for 'put_user_policy' """
+        self.add_response('put_user_policy', {}, {
+            'UserName': username,
+            'PolicyName': policy_name,
+            'PolicyDocument': json.dumps(policy_document)
+        })
+
+    def stub_create_access_key(self, username, access_key='test_0123456789a', secret='secret'):
+        """ Stub helper for 'create_access_key' """
+        self.add_response('create_access_key', service_response={
+            'AccessKey': {
+                'UserName': username,
+                'AccessKeyId': access_key,
+                'SecretAccessKey': secret,
+                'Status': 'Active'
+            }
+        }, expected_params={
+            'UserName': username
+        })
+
+    def stub_delete_access_key(self, username, access_key_id):
+        """ Stub helper for 'delete_access_key' """
+        self.add_response('delete_access_key', {}, {
+            'UserName': username,
+            'AccessKeyId': access_key_id
+        })
+
+    def stub_delete_user_policy(self, username, policy_name=storage.USER_POLICY_NAME):
+        """ Stub helper for 'delete_user_policy' """
+        self.add_response('delete_user_policy', {}, {
+            'UserName': username,
+            'PolicyName': policy_name
+        })
+
+    def stub_delete_user(self, username):
+        """ Stub helper for 'delete_user' """
+        self.add_response('delete_user', {}, {
+            'UserName': username
+        })

--- a/opencraft/settings.py
+++ b/opencraft/settings.py
@@ -718,3 +718,6 @@ FILEBEAT_KEY = env('FILEBEAT_KEY', default='')
 
 # Common fields for all Filebeat prospectors.
 FILEBEAT_COMMON_PROSPECTOR_FIELDS = env.json('FILEBEAT_COMMON_PROSPECTOR_FIELDS', default={})
+
+# AWS S3
+S3_VERSION_EXPIRATION = env.json('S3_VERSION_EXPIRATION', default=30)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,8 @@ astroid==1.4.8
 Babel==2.3.4
 backports.shutil-get-terminal-size==1.0.0
 beautifulsoup4==4.5.1
-boto==2.48.0
+boto3==1.9.64
+botocore==1.12.64
 chardet==2.3.0
 CherryPy==3.8.2
 click==6.6
@@ -27,13 +28,16 @@ django-grappelli==2.8.3
 django-libsass==0.7
 django-redis==4.6.0
 django-simple-email-confirmation==0.21
+django-storage-swift==1.2.17
 django-zurb-foundation==5.5.0
 djangorestframework==3.5.3
+docutils==0.14
 dodgy==0.1.9
 factory-boy==2.7.0
 fake-factory==0.7.2
 Flask==0.11.1
 freezegun==0.3.8
+future==0.17.1
 futures==3.0.5
 gitdb==0.6.4
 gitdb2==2.0.0
@@ -54,6 +58,7 @@ jasmine==2.5.0
 jasmine-core==2.5.2
 Jinja2==2.8
 jira==1.0.7
+jmespath==0.9.3
 jsonpatch==1.14
 jsonpointer==1.10
 jsonschema==2.5.1
@@ -70,6 +75,7 @@ mysqlclient==1.3.9
 netaddr==0.7.19
 netifaces==0.10.5
 oauthlib==2.0.0
+olefile==0.46
 openstacksdk==0.9.12
 ordereddict==1.1
 os-client-config==1.22.0
@@ -85,6 +91,7 @@ pep8==1.7.0
 pep8-naming==0.4.1
 pexpect==4.2.1
 pickleshare==0.7.4
+Pillow==4.3.0
 positional==1.1.1
 prettytable==0.7.2
 prompt-toolkit==1.0.9
@@ -92,11 +99,11 @@ prospector==0.12.4
 psycopg2==2.7.3.2
 ptyprocess==0.5.1
 pycodestyle==2.0.0
+pycryptodomex==3.7.0
 pydocstyle==1.0.0
 pyflakes==1.3.0
 Pygments==2.1.3
-# Pylint 1.6.* does not work with prospector 0.12.4, so we have to use 1.5.6 for now.
-# See: https://github.com/landscapeio/prospector/issues/183
+pyjwkest==1.4.0
 pylint==1.5.6
 pylint-celery==0.3
 pylint-common==0.2.2
@@ -110,6 +117,7 @@ python-consul==1.1.0
 python-dateutil==2.6.0
 python-glanceclient==2.5.0
 python-keystoneclient==3.8.0
+python-magic==0.4.15
 python-neutronclient==6.0.0
 python-novaclient==6.0.0
 python-openstackclient==3.6.0
@@ -127,6 +135,7 @@ requirements-detector==0.5.2
 responses==0.10.4
 rfc3986==0.4.1
 rjsmin==1.0.12
+s3transfer==0.1.13
 selenium==2.53.6
 setoptconf==0.2.0
 simplegeneric==0.8.1
@@ -145,12 +154,9 @@ tornado==4.4.2
 tornado-redis==2.4.18
 traitlets==4.3.1
 unicodecsv==0.14.1
+urllib3==1.24.1
 virtualenv==15.0.3
 warlock==1.2.0
 wcwidth==0.1.7
 Werkzeug==0.11.1
 wrapt==1.10.8
-Pillow==4.3.0
-django_storage_swift==1.2.17
-pycryptodomex==3.7.0
-pyjwkest==1.4.0


### PR DESCRIPTION
Description
------------
This PR upgrades the requirement from boto2 to boto3.

It also implements versioning and lifecycle management of s3 buckets

Related tickets: BB-719 BB-329

Testing
-------

1. Checkout the changes and load the shell using `make shell` (this can be done using the admin as well).

2. Create an instance using the shell as mentioned in the README:
```python
from instance.factories import instance_factory, production_instance_factory

# Creating an instance with defaults appropriate for sandboxes:
instance = instance_factory(name="Sandbox instance", sub_domain="sandbox")

# Creating an instance with defaults appropriate for production:
production_instance = production_instance_factory(name="Production instance", sub_domain="production")
```

3. Spawn an AppServer using on `stage.console.opencraft.com`

4. Use either the shell or `awscli` to query the bucket exists, CORS and lifecycle are correct, i.e:
```python
instance.s3.get_bucket_cors(Bucket=instance.s3_bucket_name)
instance.s3.get_bucket_lifecycle(Bucket=instance.s3_bucket_name)
instance.s3.get_bucket_lifecycle_configuration(Bucket=instance.s3_bucket_name)
```

5. Delete the instance and make sure the bucket is deleted as well, i.e:
```python
bucket = instance.s3_bucket_name
instance.delete()
boto3.client('s3').list_objects(Bucket=bucket)  # Should not exist
```


Management Command
------------------------

A management command called `reprovision_buckets` was added to reprovision and configure iam, versioning and lifecycle on existing instance.

This needs to be tested in stage using:
```bash
$ make manage reprovision_buckets
```

This can be tested with the step `4` shown above.