### PR TITLE
BB-804 - Clean up old MySQL instances as part of CI cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,7 +126,7 @@ endif
 test.integration_cleanup: clean ## Run the integration cleanup script.
 ifneq ($(wildcard .env.integration),)
 	echo -e "\nRunning integration test cleanup script with credentials from .env.integration file..."
-	PYTHONPATH=$PYTHONPATH:$(pwd) honcho -e .env.integration run python3 cleanup_utils/integration_cleanup.py
+	PYTHONPATH=$(PYTHONPATH):$(pwd) honcho -e .env.integration run python3 cleanup_utils/integration_cleanup.py
 else ifdef OPENSTACK_USER
 	echo -e "\nRunning integration test cleanup script with credentials from environment variables..."
 	PYTHONPATH=$PYTHONPATH:$(pwd) python3 cleanup_utils/integration_cleanup.py

--- a/Makefile
+++ b/Makefile
@@ -129,7 +129,7 @@ ifneq ($(wildcard .env.integration),)
 	PYTHONPATH=$(PYTHONPATH):$(pwd) honcho -e .env.integration run python3 cleanup_utils/integration_cleanup.py
 else ifdef OPENSTACK_USER
 	echo -e "\nRunning integration test cleanup script with credentials from environment variables..."
-	PYTHONPATH=$PYTHONPATH:$(pwd) python3 cleanup_utils/integration_cleanup.py
+	PYTHONPATH=$(PYTHONPATH):$(pwd) python3 cleanup_utils/integration_cleanup.py
 else
 	echo -e "\nIntegration test cleanup script skipped (create a '.env.integration' file to run them)"
 endif

--- a/README.md
+++ b/README.md
@@ -49,13 +49,13 @@ Before activating a server, there's the option to test it through a
 basic-auth password-protected link in the "Authenticated Link" section
 (the username and password are embedded in the link).
 
-Sometimes Open edX playbook fails, and then you need to read the log, which is
-shown in real-time in the web console.  You can fix the settings and then spawn
-another server.  Failed and old inactive servers and MySQL databases are
-automatically cleaned up after three days.  An important feature is that Ocim
-*grants SSH access* to members of a configurable GitHub organization, so you
-can always SSH to an appserver's IP, *even if Open edX's deployment failed*,
-and then debug it.  You can use your GitHub username and key.
+Sometimes Open edX playbook fails, and then you need to read the log,
+which is shown in real-time in the web console.
+You can fix the settings and then spawn another server.
+Failed and old inactive servers are automatically cleaned up after some configurable amount of days.
+An important feature is that Ocim *grants SSH access* to members of a configurable GitHub organization,
+so you can always SSH to an appserver's IP, *even if Open edX's deployment failed*, and then debug it.
+You can use your GitHub username and key.
 
 To create a new instance, you use Django's admin and you need to fill in the domain name,
 the prefixed domain names (for Studio, e-commerce, etc.), the edx-platform/configuration branches to use,

--- a/README.md
+++ b/README.md
@@ -639,10 +639,12 @@ your development environment is likely a good starting point:
     cp .env .env.integration
 
 
-There is also a cleanup routine intended for use by CI services to check for and
-clean up any dangling OpenStack VMs past a certain age threshold. While it isn't
-necessary in the usual case, old integration tests that were killed without cleanup
-can be cleaned up after four hours by running the make target:
+There is also a cleanup routine intended for use by CI services to check for
+and clean up any dangling OpenStack VMs and MySQL databases past a certain age
+threshold. While it isn't necessary in the usual case, old integration tests
+that were killed without cleanup that are older than four hours, and old MySQL
+databases that are older than three days can be cleaned up by running the make
+target:
 
     make test.integration_cleanup
 

--- a/README.md
+++ b/README.md
@@ -49,13 +49,13 @@ Before activating a server, there's the option to test it through a
 basic-auth password-protected link in the "Authenticated Link" section
 (the username and password are embedded in the link).
 
-Sometimes Open edX playbook fails, and then you need to read the log,
-which is shown in real-time in the web console.
-You can fix the settings and then spawn another server.
-Failed and old inactive servers are automatically cleaned up after some configurable amount of days.
-An important feature is that Ocim *grants SSH access* to members of a configurable GitHub organization,
-so you can always SSH to an appserver's IP, *even if Open edX's deployment failed*, and then debug it.
-You can use your GitHub username and key.
+Sometimes Open edX playbook fails, and then you need to read the log, which is
+shown in real-time in the web console.  You can fix the settings and then spawn
+another server.  Failed and old inactive servers and MySQL databases are
+automatically cleaned up after three days.  An important feature is that Ocim
+*grants SSH access* to members of a configurable GitHub organization, so you
+can always SSH to an appserver's IP, *even if Open edX's deployment failed*,
+and then debug it.  You can use your GitHub username and key.
 
 To create a new instance, you use Django's admin and you need to fill in the domain name,
 the prefixed domain names (for Studio, e-commerce, etc.), the edx-platform/configuration branches to use,
@@ -638,24 +638,13 @@ your development environment is likely a good starting point:
 
     cp .env .env.integration
 
-
 There is also a cleanup routine intended for use by CI services to check for
 and clean up any dangling OpenStack VMs and MySQL databases past a certain age
 threshold. While it isn't necessary in the usual case, old integration tests
-that were killed without cleanup that are older than four hours, and old MySQL
-databases that are older than three days can be cleaned up by running the make
-target:
+that were killed without cleanup and old MySQL databases that are older than
+three days can be cleaned up by running the make target:
 
     make test.integration_cleanup
-
-The age threshold for the cleanup script defaults to four hours, but this can be
-adjusted by setting `INSTANCE_AGE_THRESHOLD` to a number (in seconds) in the
-`.env.integration` file.
-
-Note that, if executing locally and with the same environment as Circle CI, setting
-the `INSTANCE_AGE_THRESHOLD` to a number too low may result in interrupted
-integration test builds on Circle CI.
-
 
 Debug
 -----

--- a/cleanup_utils/integration_cleanup.py
+++ b/cleanup_utils/integration_cleanup.py
@@ -41,7 +41,8 @@ from cleanup_utils.openstack_cleanup import OpenStackCleanupInstance
 # Default age at which things should be cleaned up, in days
 DEFAULT_AGE_LIMIT = 3
 DEFAULT_CUTOFF_TIME = (
-    datetime.utcnow().replace(tzinfo=UTC) - timedelta(days=DEFAULT_AGE_LIMIT))
+    datetime.utcnow().replace(tzinfo=UTC) - timedelta(days=DEFAULT_AGE_LIMIT)
+)
 
 
 # Logging #####################################################################
@@ -118,7 +119,8 @@ def run_integration_cleanup(dry_run=False):
     # the deletion_blacklist
     hashes_to_clean = (
         aws_cleanup.cleaned_up_hashes + os_cleanup.cleaned_up_hashes +
-        mysql_cleanup.cleaned_up_hashes)
+        mysql_cleanup.cleaned_up_hashes
+    )
     dns_cleanup.run_cleanup(
         hashes_to_clean=hashes_to_clean
     )

--- a/cleanup_utils/integration_cleanup.py
+++ b/cleanup_utils/integration_cleanup.py
@@ -38,7 +38,10 @@ from cleanup_utils.openstack_cleanup import OpenStackCleanupInstance
 
 # Constants ###################################################################
 
-DEFAULT_AGE_LIMIT = datetime.utcnow().replace(tzinfo=UTC) - timedelta(days=3)
+# Default age at which things should be cleaned up, in days
+DEFAULT_AGE_LIMIT = 3
+DEFAULT_CUTOFF_TIME = (
+    datetime.utcnow().replace(tzinfo=UTC) - timedelta(days=DEFAULT_AGE_LIMIT))
 
 
 # Logging #####################################################################
@@ -84,7 +87,7 @@ def main():
 
     # Clean up AWS
     aws_cleanup = AwsCleanupInstance(
-        age_limit=DEFAULT_AGE_LIMIT,
+        age_limit=DEFAULT_CUTOFF_TIME,
         aws_access_key_id=os.environ['AWS_ACCESS_KEY_ID'],
         aws_secret_access_key=os.environ['AWS_SECRET_ACCESS_KEY'],
         dry_run=args.dry_run
@@ -100,7 +103,7 @@ def main():
         'region_name': os.environ['OPENSTACK_REGION'],
     }
     os_cleanup = OpenStackCleanupInstance(
-        age_limit=DEFAULT_AGE_LIMIT,
+        age_limit=DEFAULT_CUTOFF_TIME,
         openstack_settings=openstack_settings,
         dry_run=args.dry_run
     )
@@ -110,6 +113,7 @@ def main():
     mysql_cleanup = MySqlCleanupInstance(
         age_limit=DEFAULT_AGE_LIMIT,
         url=os.environ['DEFAULT_INSTANCE_MYSQL_URL'],
+        domain=os.environ['DEFAULT_INSTANCE_BASE_DOMAIN'],
         dry_run=args.dry_run
     )
     mysql_cleanup.run_cleanup()

--- a/cleanup_utils/integration_cleanup.py
+++ b/cleanup_utils/integration_cleanup.py
@@ -31,8 +31,9 @@ import os
 from pytz import UTC
 
 from cleanup_utils.aws_cleanup import AwsCleanupInstance
-from cleanup_utils.openstack_cleanup import OpenStackCleanupInstance
 from cleanup_utils.dns_cleanup import DnsCleanupInstance
+from cleanup_utils.mysql_cleanup import MySqlCleanupInstance
+from cleanup_utils.openstack_cleanup import OpenStackCleanupInstance
 
 
 # Constants ###################################################################
@@ -117,6 +118,14 @@ def main():
     dns_cleanup.run_cleanup(
         hashes_to_clean=hashes_to_clean
     )
+
+    # Run MySQL cleanup
+    mysql_cleanup = MySqlCleanupInstance(
+        age_limit=DEFAULT_AGE_LIMIT,
+        url=os.environ['DEFAULT_INSTANCE_MYSQL_URL'],
+        dry_run=args.dry_run
+    )
+    mysql_cleanup.run_cleanup()
 
     logger.info("\nIntegration cleanup tool finished.")
 

--- a/cleanup_utils/integration_cleanup.py
+++ b/cleanup_utils/integration_cleanup.py
@@ -106,6 +106,14 @@ def main():
     )
     os_cleanup.run_cleanup()
 
+    # Run MySQL cleanup
+    mysql_cleanup = MySqlCleanupInstance(
+        age_limit=DEFAULT_AGE_LIMIT,
+        url=os.environ['DEFAULT_INSTANCE_MYSQL_URL'],
+        dry_run=args.dry_run
+    )
+    mysql_cleanup.run_cleanup()
+
     # Run DNS cleanup
     dns_cleanup = DnsCleanupInstance(
         zone_id=int(os.environ['GANDI_ZONE_ID']),
@@ -114,18 +122,12 @@ def main():
     )
     # Run DNS cleanup erasing all integration entries except for those on
     # the deletion_blacklist
-    hashes_to_clean = aws_cleanup.cleaned_up_hashes + os_cleanup.cleaned_up_hashes
+    hashes_to_clean = (
+        aws_cleanup.cleaned_up_hashes + os_cleanup.cleaned_up_hashes +
+        mysql_cleanup.cleaned_up_hashes)
     dns_cleanup.run_cleanup(
         hashes_to_clean=hashes_to_clean
     )
-
-    # Run MySQL cleanup
-    mysql_cleanup = MySqlCleanupInstance(
-        age_limit=DEFAULT_AGE_LIMIT,
-        url=os.environ['DEFAULT_INSTANCE_MYSQL_URL'],
-        dry_run=args.dry_run
-    )
-    mysql_cleanup.run_cleanup()
 
     logger.info("\nIntegration cleanup tool finished.")
 

--- a/cleanup_utils/integration_cleanup.py
+++ b/cleanup_utils/integration_cleanup.py
@@ -105,7 +105,7 @@ def run_integration_cleanup(dry_run=False):
         age_limit=DEFAULT_AGE_LIMIT,
         url=os.environ['DEFAULT_INSTANCE_MYSQL_URL'],
         domain=os.environ['DEFAULT_INSTANCE_BASE_DOMAIN'],
-        dry_run=args.dry_run
+        dry_run=dry_run
     )
     mysql_cleanup.run_cleanup()
 

--- a/cleanup_utils/mysql_cleanup.py
+++ b/cleanup_utils/mysql_cleanup.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+#
+# OpenCraft -- tools to aid developing and hosting free software projects
+# Copyright (C) 2015-2019 OpenCraft <contact@opencraft.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+"""
+MySQL Cleanup Script
+
+Cleans up all MySQL databases left behind from CI
+"""
+
+import logging
+
+
+# Logging ####################################################################
+
+logger = logging.getLogger('integration_cleanup')
+
+
+# Classes ####################################################################
+
+class MySqlCleanupInstance:
+    """
+    Handles the cleanup of old MySQL databases
+    """
+    def __init__(self, age_limit, url, dry_run):
+        """
+        Set up variables needed for cleanup
+        """
+        self.age_limit = age_limit
+        self.dry_run = dry_run
+        self.url = url
+
+    def run_cleanup(self):
+        """
+        Runs the cleanup of MySQL databases older than the age limit
+        """
+        logger.info("\n --- Starting MySQL Cleanup ---")
+        if self.dry_run:
+            logger.info("Running in DRY_RUN mode, no actions will be taken.")

--- a/cleanup_utils/mysql_cleanup.py
+++ b/cleanup_utils/mysql_cleanup.py
@@ -115,6 +115,11 @@ class MySqlCleanupInstance:
         logger.info('Found %d old databases', len(databases))
 
         for (database, create_date) in databases:
+            # The regex match here serves a dual purpose: firstly, it acts as
+            # an additional precaution against removing databases not related
+            # to CI. Secondly, it allows us to gather the hashes of the removed
+            # databases so they can be returned to the calling script and used
+            # in DNS cleanup.
             logger.info('  > Considering database %s', database)
             instance_database_re = r'^([0-9a-f]{8})([_0-9a-z]+)?_%s' % (self.domain_suffix,)
             match = re.match(instance_database_re, database)

--- a/cleanup_utils/mysql_cleanup.py
+++ b/cleanup_utils/mysql_cleanup.py
@@ -80,6 +80,10 @@ class MySqlCleanupInstance:
         """
         Returns a list of databases older than the age limit
         """
+        if not self.cursor:
+            logger.error('ERROR: Not connected to the database')
+            return []
+
         query = """SELECT table_schema, MAX(create_time) AS create_time
             FROM information_schema.tables
             WHERE create_time <= DATE_SUB(NOW(), INTERVAL %(age_limit)s DAY)
@@ -101,12 +105,6 @@ class MySqlCleanupInstance:
         Runs the cleanup of MySQL databases older than the age limit
         """
         logger.info("\n --- Starting MySQL Cleanup ---")
-        if not self.cursor:
-            logger.error(
-                'ERROR: Not connected to the database, '
-                'MySQL cleanup will be skipped.'
-            )
-            return
 
         if self.dry_run:
             logger.info("Running in DRY_RUN mode, no actions will be taken.")

--- a/cleanup_utils/mysql_cleanup.py
+++ b/cleanup_utils/mysql_cleanup.py
@@ -23,6 +23,10 @@ Cleans up all MySQL databases left behind from CI
 """
 
 import logging
+from urllib.parse import urlparse
+
+import MySQLdb as mysql
+from MySQLdb import Error as MySQLError
 
 
 # Logging ####################################################################
@@ -41,8 +45,26 @@ class MySqlCleanupInstance:
         Set up variables needed for cleanup
         """
         self.age_limit = age_limit
+        self.cleaned_up_hashes = []
         self.dry_run = dry_run
-        self.url = url
+        self.cursor = self._get_cursor(url)
+
+    def _get_cursor(self, url):
+        """
+        Returns a cursor on the database
+        """
+        database_url_obj = urlparse(url)
+        try:
+            connection = mysql.connect(
+                host=database_url_obj.hostname,
+                user=database_url_obj.username or '',
+                passwd=database_url_obj.password or '',
+                port=database_url_obj.port or 3306,
+            )
+        except MySQLError as exc:
+            logger.excecption('Cannot get MySQL cursor: %s', exc)
+            raise
+        return connection.cursor()
 
     def run_cleanup(self):
         """
@@ -51,3 +73,8 @@ class MySqlCleanupInstance:
         logger.info("\n --- Starting MySQL Cleanup ---")
         if self.dry_run:
             logger.info("Running in DRY_RUN mode, no actions will be taken.")
+
+        # mysql> SELECT table_schema, MAX(create_time) AS create_time,
+        # MAX(update_time) AS update_time FROM information_schema.tables WHERE
+        # create_time <= DATE_SUB(NOW(), INTERVAL 3 DAY) GROUP BY table_schema
+        # ORDER BY create_time DESC;

--- a/cleanup_utils/mysql_cleanup.py
+++ b/cleanup_utils/mysql_cleanup.py
@@ -101,10 +101,13 @@ class MySqlCleanupInstance:
 
         for (database, create_date) in databases:
             logger.info('  > Considering database %s', database)
-            match = re.match('^([0-9a-f]{8})_%s' % (self.domain_suffix,),
-                             database)
+            instance_database_re = '^([0-9a-f]{8})_%s' % (self.domain_suffix,)
+            match = re.match(instance_database_re, database)
             if not match:
-                logger.info('    * SKIPPING: Did not match expected format.')
+                logger.info(
+                    '    * SKIPPING: Did not match expected format %r.',
+                    instance_database_re
+                )
                 continue
 
             logger.info(

--- a/cleanup_utils/mysql_cleanup.py
+++ b/cleanup_utils/mysql_cleanup.py
@@ -89,7 +89,11 @@ class MySqlCleanupInstance:
             'age_limit': self.age_limit,
             'domain_filter': '%_{}_%'.format(self.domain_suffix)
         }
-        self.cursor.execute(query, params)
+        try:
+            self.cursor.execute(query, params)
+        except MySQLError as exc:
+            logger.exception('Unable to retrieve old databases: %s', exc)
+            return []
         return self.cursor.fetchall()
 
     def run_cleanup(self):
@@ -123,7 +127,8 @@ class MySqlCleanupInstance:
 
             logger.info(
                 '    * Dropping MySQL DB `%s` created at %s', database,
-                datetime.strftime(create_date, '%Y-%m-%dT%H:%M:%SZ'))
+                datetime.strftime(create_date, '%Y-%m-%dT%H:%M:%SZ')
+            )
             if not self.dry_run:
                 try:
                     self.cursor.execute(

--- a/cleanup_utils/mysql_cleanup.py
+++ b/cleanup_utils/mysql_cleanup.py
@@ -101,7 +101,8 @@ class MySqlCleanupInstance:
 
         for (database, create_date) in databases:
             logger.info('  > Considering database %s', database)
-            instance_database_re = '^([0-9a-f]{8})_%s' % (self.domain_suffix,)
+            instance_database_re = r'^([0-9a-f]{8})([_0-9a-z]+)?_%s' % (
+                self.domain_suffix,)
             match = re.match(instance_database_re, database)
             if not match:
                 logger.info(

--- a/cleanup_utils/requirements.txt
+++ b/cleanup_utils/requirements.txt
@@ -1,2 +1,3 @@
 boto3==1.9.61
+mysqlclient==1.3.9
 python-novaclient==6.0.0


### PR DESCRIPTION
This PR adds an extra cleanup instance to the Integration Cleanup script, to remove MySQL databases that are older than three days.

## Testing

You can test the cleanup function on a local OCIM instance:

    $ vagrant ssh
    (opencraft) vagrant@ubuntu-xenial:~$ cd opencraft
    (opencraft) vagrant@ubuntu-xenial:~/opencraft$ mysql -u root -h localhost
    Welcome to the MySQL monitor.  Commands end with ; or \g.
    Your MySQL connection id is 20                                                                                                                      
    Server version: 5.7.24-0ubuntu0.16.04.1 (Ubuntu)
    
    Copyright (c) 2000, 2018, Oracle and/or its affiliates. All rights reserved.
    
    Oracle is a registered trademark of Oracle Corporation and/or its
    affiliates. Other names may be trademarks of their respective
    owners.
    
    Type 'help;' or '\h' for help. Type '\c' to clear the current input statement.
    
    mysql> CREATE DATABASE f4ad7be3_integration_plebia_net_edxapp;
    Query OK, 1 row affected (0.01 sec)
    
    mysql> use f4ad7be3_integration_plebia_net_edxapp
    Database changed
    mysql> CREATE TABLE foo (id int);
    Query OK, 0 rows affected (0.04 sec)
    
    mysql> CREATE DATABASE unrelated)db;
    Query OK, 1 row affected (0.01 sec)
    
    mysql> use unrelated_db
    Database changed
    mysql> CREATE TABLE foo (id int);
    Query OK, 0 rows affected (0.04 sec)
    
    mysql> \q
    Bye
    (opencraft) vagrant@ubuntu-xenial:~/opencraft$ make shell
    ...
    In [1]: from cleanup_utils import mysql_cleanup
    
    In [2]: my_cleanup = mysql_cleanup.MySqlCleanupInstance(0, settings.DEFAULT_INSTANCE_MYSQL_URL, 'plebia.net', False)
    
    In [3]: my_cleanup._get_old_databases()
    Out[3]:
    (('f4ad7be3_integration_plebia_net_edxapp',
      datetime.datetime(2019, 1, 18, 11, 23, 58)),)
    
    In [4]: my_cleanup.run_cleanup()
    
    In [5]: my_cleanup._get_old_databases()
    Out[5]: ()
    
    In [6]: my_cleanup.cleaned_up_hashes
    Out[6]: ['f4ad7be3']
    
    In [7]: 
    Do you really want to exit ([y]/n)? 
    (opencraft) vagrant@ubuntu-xenial:~/opencraft$ mysql -u root -h localhost
    mysql> show DATABASES;
    +-------------------------------------------------+
    | Database                                        |
    +-------------------------------------------------+
    | information_schema                              |
    | ...                                             |
    | mysql                                           |
    | performance_schema                              |
    | sys                                             |
    | unrelated_db                                    |
    +-------------------------------------------------+
    38 rows in set (0.00 sec)

    mysql> 

