### PR TITLE
BB-209: Add setting to disable celery heartbeats

### DIFF
--- a/README.md
+++ b/README.md
@@ -495,7 +495,6 @@ set the following configuration variables:
 * `OPENEDX_APPSERVER_SECURITY_GROUP_RULES`: This specifies the firewall rules
   that the above security group will have. The default allows ingress on ports
   22, 80, and 443 only.
-* `EDX_WORKERS_ENABLE_CELERY_HEARTBEAT`: Switch to enable/disable celery
 * `EDX_WORKERS_ENABLE_CELERY_HEARTBEATS`: Switch to enable/disable celery
   heartbeats used to detect connection drops. Disabling heartbeats can have a
   drastic reduction RabbitMQ usage. This setting sets

--- a/README.md
+++ b/README.md
@@ -495,6 +495,10 @@ set the following configuration variables:
 * `OPENEDX_APPSERVER_SECURITY_GROUP_RULES`: This specifies the firewall rules
   that the above security group will have. The default allows ingress on ports
   22, 80, and 443 only.
+* `EDX_WORKERS_ENABLE_CELERY_HEARTBEAT`: Switch to enable/disable celery
+  heartbeats used to detect connection drops. Disabling heartbeats can have a
+  drastic reduction RabbitMQ usage. This setting sets
+  `worker_django_enable_heartbeats` on supported playbooks. Defaults to `False`.
 
 Migrations
 ----------

--- a/README.md
+++ b/README.md
@@ -496,6 +496,7 @@ set the following configuration variables:
   that the above security group will have. The default allows ingress on ports
   22, 80, and 443 only.
 * `EDX_WORKERS_ENABLE_CELERY_HEARTBEAT`: Switch to enable/disable celery
+* `EDX_WORKERS_ENABLE_CELERY_HEARTBEATS`: Switch to enable/disable celery
   heartbeats used to detect connection drops. Disabling heartbeats can have a
   drastic reduction RabbitMQ usage. This setting sets
   `worker_django_enable_heartbeats` on supported playbooks. Defaults to `False`.

--- a/instance/models/mixins/openedx_config.py
+++ b/instance/models/mixins/openedx_config.py
@@ -302,10 +302,10 @@ class OpenEdXConfigMixin(ConfigMixinBase):
             # Disable celery heartbeats
             # The current default setup of Celery in Open edX uses something called
             # heartbeats to detect connection drops to the celery broker (RabbitMQ).
-            # With as many 15 celery processes running on Open edX servers this can mean
-            # a lot of the RabbitMQ usage is used up just to check for connection drops,
-            # and that too mostly to get around issues with RabbitMQ behind a load-balancer,
-            # which is not our setup.
+            # With as many 15 celery processes running on each Open edX AppServer this
+            # can mean that a lot of the RabbitMQ capacity is used just to check
+            # for connection drops, and that's mostly to get around issues with
+            # RabbitMQ behind a load-balancer, which is not our setup.
             # Disabling heartbeats can have a drastic reduction RabbitMQ usage.
             "worker_django_enable_heartbeats": settings.EDX_WORKERS_ENABLE_CELERY_HEARTBEATS,
         }

--- a/instance/models/mixins/openedx_config.py
+++ b/instance/models/mixins/openedx_config.py
@@ -297,7 +297,17 @@ class OpenEdXConfigMixin(ConfigMixinBase):
 
             # Insights and analytics_api
             "SANDBOX_ENABLE_ANALYTICS_API": False, # set to true to enable analytics_api
-            "SANDBOX_ENABLE_INSIGHTS": False # set to true to enable insights
+            "SANDBOX_ENABLE_INSIGHTS": False, # set to true to enable insights
+
+            # Disable celery heartbeats
+            # The current default setup of Celery in Open edX uses something called
+            # heartbeats to detect connection drops to the celery broker (RabbitMQ).
+            # With as many 15 celery processes running on Open edX servers this can mean
+            # a lot of the RabbitMQ usage is used up just to check for connection drops,
+            # and that too mostly to get around issues with RabbitMQ behind a load-balancer,
+            # which is not our setup.
+            # Disabling heartbeats can have a drastic reduction RabbitMQ usage.
+            "worker_django_enable_heartbeats": settings.EDX_WORKERS_ENABLE_CELERY_HEARTBEAT,
         }
 
         if self.smtp_relay_settings:

--- a/instance/models/mixins/openedx_config.py
+++ b/instance/models/mixins/openedx_config.py
@@ -304,8 +304,9 @@ class OpenEdXConfigMixin(ConfigMixinBase):
             # heartbeats to detect connection drops to the celery broker (RabbitMQ).
             # With as many 15 celery processes running on each Open edX AppServer this
             # can mean that a lot of the RabbitMQ capacity is used just to check
-            # for connection drops, and that's mostly to get around issues with
-            # RabbitMQ behind a load-balancer, which is not our setup.
+            # for connection drops. That's mostly to get around issues when using
+            # the RabbitMQ server behind a load-balancer, which is not the case
+            # in Ocim deployments.
             # Disabling heartbeats can have a drastic reduction RabbitMQ usage.
             "worker_django_enable_heartbeats": settings.EDX_WORKERS_ENABLE_CELERY_HEARTBEATS,
         }

--- a/instance/models/mixins/openedx_config.py
+++ b/instance/models/mixins/openedx_config.py
@@ -307,7 +307,7 @@ class OpenEdXConfigMixin(ConfigMixinBase):
             # and that too mostly to get around issues with RabbitMQ behind a load-balancer,
             # which is not our setup.
             # Disabling heartbeats can have a drastic reduction RabbitMQ usage.
-            "worker_django_enable_heartbeats": settings.EDX_WORKERS_ENABLE_CELERY_HEARTBEAT,
+            "worker_django_enable_heartbeats": settings.EDX_WORKERS_ENABLE_CELERY_HEARTBEATS,
         }
 
         if self.smtp_relay_settings:

--- a/opencraft/settings.py
+++ b/opencraft/settings.py
@@ -479,6 +479,9 @@ OPENEDX_APPSERVER_SECURITY_GROUP_RULES = [
     },
 ]
 
+# Enable or disable celery heartbeats on instances managed by Ocim
+EDX_WORKERS_ENABLE_CELERY_HEARTBEAT = env.bool('EDX_WORKERS_ENABLE_CELERY_HEARTBEAT', default=False)
+
 # Ansible #####################################################################
 
 # Ansible requires a Python 2 interpreter

--- a/opencraft/settings.py
+++ b/opencraft/settings.py
@@ -480,7 +480,7 @@ OPENEDX_APPSERVER_SECURITY_GROUP_RULES = [
 ]
 
 # Enable or disable celery heartbeats on instances managed by Ocim
-EDX_WORKERS_ENABLE_CELERY_HEARTBEAT = env.bool('EDX_WORKERS_ENABLE_CELERY_HEARTBEAT', default=False)
+EDX_WORKERS_ENABLE_CELERY_HEARTBEATS = env.bool('EDX_WORKERS_ENABLE_CELERY_HEARTBEATS', default=False)
 
 # Ansible #####################################################################
 


### PR DESCRIPTION
This PR adds a default ansible variable to disable celery heartbeats on supported configurations.

**Testing instructions:**
1. Check out this branch on your Ocim devstack
2. Create a new OpenEdX instance on Django Shell:
```
make shell
> instance = OpenEdXInstance.objects.create(        
>     name='Test Sandbox',                                                               
>     sub_domain='test-heartbeats',
> )
```
3. Spawn a new appserver from the web interface (you might have to do this twice, the first time it'll fail with a load balancer error)
4. Check on the appserver configuration if the ansible variable was correctly set: 
**Combined ansible vars:**
```
worker_django_enable_heartbeats: false
```

This is just to check if the variable wa correctly set, no need to wait for the AppServer to completely spawn (I'll set up Ocim stage for that).
Don't forget to delete your instance with `instance.delete()` after testing locally (you should never delete instances on stage or production.

**Reviewers:**
- [ ] @jamestait 
- [ ] @lgp171188 


