### PR TITLE
[BB-853] Automatically activates first manually created AppServer for beta tester 

### DIFF
--- a/registration/approval.py
+++ b/registration/approval.py
@@ -58,13 +58,18 @@ def accept_application(application, appserver):
     launched, activates it and sends an email to the user to notify them that their instance is
     ready.
     """
-    if application.instance is None:
+    instance = application.instance
+    if instance is None:
         raise ApplicationNotReady('No instance provisioned yet.')
 
     if appserver is None:
         raise ApplicationNotReady('The instance does not have an active AppServer yet.')
     if appserver.status != AppServer.Status.Running:
         raise ApplicationNotReady('The AppServer is not running yet.')
+
+    # Automatically activates AppServer if it's the first one from the instance
+    if not instance.first_activated:
+        appserver.make_active()
 
     _send_mail(application, 'registration/welcome_email.txt', settings.BETATEST_WELCOME_SUBJECT)
     application.status = BetaTestApplication.ACCEPTED

--- a/registration/tests/test_approval.py
+++ b/registration/tests/test_approval.py
@@ -125,3 +125,19 @@ class ApprovalTestCase(TestCase):
             with self.assertRaises(ApplicationNotReady):
                 on_appserver_spawned(sender=None, instance=instance, appserver=None)
             mock_application.assert_not_called()
+
+    def test_first_appserver_is_active(self):
+        """
+        Check if the the first Appserver is correctly activated even when
+        spawned manually
+        """
+        appserver = mock.Mock(status=AppServer.Status.Running)
+        instance = mock.Mock(first_activated=None)
+        application = mock.Mock(status=BetaTestApplication.PENDING)
+
+        application.instance = instance
+        instance.betatestapplication_set.first = lambda: application
+
+        # Test accepted application does nothing
+        on_appserver_spawned(sender=None, instance=instance, appserver=appserver)
+        self.assertEqual(appserver.make_active.call_count, 1)


### PR DESCRIPTION
This PR fixes a small bug while provisioning instances for beta testers:
If an automatic provisioning fails and a new AppServer is spawned manually, the automatic activation email is sent to the client but the AppServer is not marked as active.
This PR automatically marks the first instance of a beta tester instance as active, even if it's created manually after the automatic provisioning fails.

**Testing instructions:**
*Note: These changes are deployed on **stage**.*
1. Create an account on https://stage.console.opencraft.com/registration/ and confirm your email
2. Login with a admin account and find the instance that you just registered. On my case I registered [giovanni-test-manual-activation-email](https://stage.console.opencraft.com/instance/3220/).
3. Get the IP address of the first spawned appserver, SSH into it and reboot it:
```
ssh user@147.135.193.152
$ sudo reboot
```
4. This will break the provisioning and make Ocim retry the deployment on another VM. SSH into it and reboot it too. This way, we've spent all the retries for the automatic redeployment.
5. On the console, click on `Launch new AppServer` and wait. 
6. When the machine is successfully provisioned, check that it's marked as active and that you received the activation email.

**Reviewers:**
@viadanna 