### PR TITLE
BB-834: Fix simple-theme deployments

### DIFF
--- a/instance/models/mixins/openedx_theme.py
+++ b/instance/models/mixins/openedx_theme.py
@@ -73,8 +73,6 @@ class OpenEdXThemeMixin(models.Model):
                     "variable": "link-color",
                     "value": application.link_color,
                 },
-                # TODO: These are specific to Ginkgo and can be removed
-                # after Hawthorn upgrade
                 {
                     "variable": "header-bg",
                     "value": application.header_bg_color,
@@ -83,7 +81,6 @@ class OpenEdXThemeMixin(models.Model):
                     "variable": "footer-bg",
                     "value": application.footer_bg_color,
                 },
-                # END TODO
                 {
                     "variable": "button-color",
                     "value": application.main_color,
@@ -102,16 +99,6 @@ class OpenEdXThemeMixin(models.Model):
                         primary=application.main_color,
                         secondary=application.main_color
                     ),
-                },
-            ],
-            "SIMPLETHEME_SASS_BOOTSTRAP_OVERRIDES": [
-                {
-                    "variable": "primary",
-                    "value": application.main_color,
-                },
-                {
-                    "variable": "secondary",
-                    "value": application.main_color,
                 },
             ],
             "SIMPLETHEME_STATIC_FILES_URLS": [

--- a/instance/models/mixins/openedx_theme.py
+++ b/instance/models/mixins/openedx_theme.py
@@ -120,9 +120,9 @@ class OpenEdXThemeMixin(models.Model):
                 $main-color: {main_color};
                 $link-color: {link_color};
                 $header-bg: {header_bg};
-                $header-font-color {header_font_color};
+                $header-font-color: {header_font_color};
                 $footer-bg: {footer_bg};
-                $footer-font-color {footer_font_color};
+                $footer-font-color: {footer_font_color};
             """.format(
                 link_color=application.link_color,
                 main_color=application.main_color,

--- a/instance/models/mixins/openedx_theme.py
+++ b/instance/models/mixins/openedx_theme.py
@@ -22,6 +22,7 @@ Open edX instance theme mixin, e.g. for simple_theme related settings
 import yaml
 
 from django.db import models
+from django.conf import settings
 
 
 # Classes #####################################################################
@@ -65,7 +66,7 @@ class OpenEdXThemeMixin(models.Model):
             return ""
 
         # These settings set the values required by simple_theme
-        settings = {
+        theme_settings = {
             # This block defines our theme by applying the chosen colors to SASS-defined color variables
             "SIMPLETHEME_SASS_OVERRIDES": [
                 {
@@ -125,54 +126,13 @@ class OpenEdXThemeMixin(models.Model):
             ],
             "SIMPLETHEME_ENABLE_DEPLOY": True,
             "EDXAPP_DEFAULT_SITE_THEME": "simple-theme",
+            "EDXAPP_COMPREHENSIVE_THEME_SOURCE_REPO": settings.EDXAPP_COMPREHENSIVE_THEME_SOURCE_REPO,
+            "EDXAPP_COMPREHENSIVE_THEME_VERSION": settings.EDXAPP_COMPREHENSIVE_THEME_VERSION,
             "SIMPLETHEME_EXTRA_SASS": """
-                .global-header {{
-                    background: {header_bg};
-
-                    span {{
-                      color: {link_color}; // Link Color
-                    }}
-
-                    .nav-links .secondary {{
-                      .secondary .nav-item a, .dropdown-user-menu .dropdown-item a {{
-                        color: {link_color};
-                      }}
-                    }}
-                }}
-                .wrapper-footer {{
-                    background: {footer_bg}; // Footer color
-                    background-color: {footer_bg} !important; // Footer color
-
-                    p.copyright
-                    {{
-                      color: {main_color}; // Link color
-                    }}
-
-                    footer .site-nav .nav-item .nav-link
-                    {{
-                      color: {link_color} !important; // Link color
-                    }}
-
-                    footer#footer-openedx {{
-                      .colophon .nav-colophon li a, .copyright, a {{
-                        color: {link_color}; // Link Color
-                      }}
-                    }}
-                }}
-                // User profile photo bar
-                .view-profile .wrapper-profile-section-container-one .wrapper-profile-section-one {{
-                  border-top-color: {link_color}; // Link Color
-                }}
-
-                // Login and registration fixes
-                .login-register-content h2 {{
-                  color: {main_color} !important; // Main Color
-                }}
-                .login-register .action-primary
-                .login-register .action-primary:hover
-                {{
-                  background: {main_color} !important; // Link color
-                }}
+                $main-color: {main_color};
+                $link-color: {link_color};
+                $header-bg: {header_bg};
+                $footer-bg: {footer_bg};
             """.format(
                 link_color=application.link_color,
                 main_color=application.main_color,
@@ -181,4 +141,4 @@ class OpenEdXThemeMixin(models.Model):
             )
         }
 
-        return yaml.dump(settings, default_flow_style=False)
+        return yaml.dump(theme_settings, default_flow_style=False)

--- a/instance/models/mixins/openedx_theme.py
+++ b/instance/models/mixins/openedx_theme.py
@@ -126,112 +126,112 @@ class OpenEdXThemeMixin(models.Model):
             "SIMPLETHEME_ENABLE_DEPLOY": True,
             "EDXAPP_DEFAULT_SITE_THEME": "simple-theme",
             "SIMPLETHEME_EXTRA_SASS": """
-                .global-header {
+                .global-header {{
                     background: {header_bg}; // Header color
 
-                    span {
+                    span {{
                       color: {link_color}; // Link Color
-                    }
+                    }}
 
-                    .nav-links .secondary {
-                       a.sign-in-btn {
+                    .nav-links .secondary {{
+                       a.sign-in-btn {{
                         // Fixed main color for button bg
                         color: #ffffff !important;
-                      }
-                      a.sign-in-btn:hover {
+                      }}
+                      a.sign-in-btn:hover {{
                        color: {link_color} !important; // Link Color
-                     }
+                     }}
 
-                      .nav-item a {
+                      .nav-item a {{
                         color: {link_color}; // Link Color
-                      }
+                      }}
 
-                      .dropdown-user-menu .dropdown-item a {
+                      .dropdown-user-menu .dropdown-item a {{
                          // Dropdown color fixed to black
                         color: #000000;
-                      }
-                    }
-                }
-                .wrapper-footer {
+                      }}
+                    }}
+                }}
+                .wrapper-footer {{
                     background: {footer_bg}; // Footer color
 
-                    footer#footer-openedx {
-                      .colophon .nav-colophon li a, .copyright, a {
+                    footer#footer-openedx {{
+                      .colophon .nav-colophon li a, .copyright, a {{
                         color: {link_color}; // Link Color
-                      }
-                    }
-                }
-                .view-profile .wrapper-profile-section-container-one .wrapper-profile-section-one {
+                      }}
+                    }}
+                }}
+                .view-profile .wrapper-profile-section-container-one .wrapper-profile-section-one {{
                   border-top-color: {link_color}; // Link Color
-                }
+                }}
 
                 // Login and registration buttons
                 #forgot-password-modal #password-reset .form-actions button[type="submit"]:hover,
                 .view-register .form-actions button[type="submit"]:hover,
-                .view-login .form-actions button[type="submit"]:hover {
+                .view-login .form-actions button[type="submit"]:hover {{
                     box-shadow: 0 0 0 0;
                     color: {link_color}; // Link Color
                     border: 1px solid #006400;
                     background: rgba(255, 255, 255, 1);
-                }
+                }}
 
                 .view-register .form-actions button[type="submit"],
                 .view-passwordreset .form-actions button[type="submit"],
-                .view-login .form-actions button[type="submit"] {
+                .view-login .form-actions button[type="submit"] {{
                   box-shadow: 0 0 0 0;
-                }
+                }}
 
                 .view-register .introduction header .title .title-super,
                 .view-login .introduction header .title .title-super,
                 .view-passwordreset .introduction header .title .title-super
-                {
+                {{
                   color: {link_color} !important; // Link Color
-                }
+                }}
 
                 // Fixing colors on registration page
-                .register {
-                  aside .btn-login h3.title {
+                .register {{
+                  aside .btn-login h3.title {{
                     color: rgba(255, 255, 255, 1);
-                  }
-                  aside .btn-login:hover {
-                    h3.title {
+                  }}
+                  aside .btn-login:hover {{
+                    h3.title {{
                       color: {link_color}; // Link Color
-                    }
-                  }
+                    }}
+                  }}
 
-                  aside .btn-login .btn-login-action {
+                  aside .btn-login .btn-login-action {{
                     color: {link_color}; // Link Color
                     background: rgba(255, 255, 255, 1);
-                  }
-                  aside .btn-login .btn-login-action:hover {
+                  }}
+                  aside .btn-login .btn-login-action:hover {{
                     color: rgba(255, 255, 255, 1);
                     background: {link_color}; // Link Color
-                  }
-                }
+                  }}
+                }}
 
                 .btn-primary:hover, .btn-brand:hover, .btn-primary.is-hovered
-                {
+                {{
                   background: rgba(255, 255, 255, 1);
-                }
+                }}
 
                 // Override for components that always stay on white bg
                 .wrapper-course-material .course-tabs .tab a.active,
                 .wiki-wrapper section.wiki .nav-tabs li.active a,
                 .content-wrapper .course-tabs .nav-item.active .nav-link,
-                {
+                {{
                   color: #000000 !important;
                   font-weight: bold !important;
-                }
+                }}
                 .content-wrapper .course-tabs .nav-item .nav-link
-                {
+                {{
                     color: #000000 !important;
-                }
-                .fa-chevron-right:before {
+                }}
+                .fa-chevron-right:before {{
                   border-top-color: {main_color}; // Main Color
-                }
-                .date-summary-container .date-summary-todays-date {
+                }}
+                .date-summary-container .date-summary-todays-date {{
                   border-left-color: {link_color}; // Link Color
-                }
+                }}
             """.format(
                 link_color=application.link_color,
                 main_color=application.main_color,

--- a/instance/models/mixins/openedx_theme.py
+++ b/instance/models/mixins/openedx_theme.py
@@ -137,15 +137,15 @@ class OpenEdXThemeMixin(models.Model):
                       a.sign-in-btn,
                       a.register-btn:hover
                       {{
-                        color: {main_color} !important; // Main color
+                        color: {header_bg} !important; // Header color
                         background: {link_color} !important; // Link color
-                        border-color: {main_color} !important; // Main color
+                        border-color: {header_bg} !important; // Header color
                       }}
                       a.register-btn,
                       a.sign-in-btn:hover
                       {{
                         color: {link_color} !important; // Link color
-                        background: {main_color} !important; // Main color
+                        background: {header_bg} !important; // Header color
                         border-color: {link_color} !important; // Link color
                       }}
 
@@ -179,14 +179,14 @@ class OpenEdXThemeMixin(models.Model):
                 }}
                 .login-register .action-primary
                 {{
-                  color: {main_color} !important; // Main color
+                  color: {header_bg} !important; // Header color
                   background: {link_color} !important; // Link color
-                  border-color: {main_color} !important; // Main color
+                  border-color: {header_bg} !important; // Header color
                 }}
                 .login-register .action-primary:hover
                 {{
                   color: {link_color} !important; // Link color
-                  background: {main_color} !important; // Main color
+                  background: {header_bg} !important; // Header color
                   border-color: {link_color} !important; // Link color
                 }}
 

--- a/instance/models/mixins/openedx_theme.py
+++ b/instance/models/mixins/openedx_theme.py
@@ -145,9 +145,13 @@ class OpenEdXThemeMixin(models.Model):
         Takes in a hexcolor code and returns black or white, depending
         which gives the better contrast
         """
+        # Return black if background_color not set
+        if not background_color:
+            return "#000000"
+
         try:
             color = Color(background_color)
-        except ValueError:
+        except (ValueError, AttributeError):
             return "#000000"
 
         # Using Web Content Accessibility Guidelines (WCAG) 2.0 and comparing

--- a/instance/models/mixins/openedx_theme.py
+++ b/instance/models/mixins/openedx_theme.py
@@ -127,40 +127,31 @@ class OpenEdXThemeMixin(models.Model):
             "EDXAPP_DEFAULT_SITE_THEME": "simple-theme",
             "SIMPLETHEME_EXTRA_SASS": """
                 .global-header {{
-                    background: {header_bg}; // Header color
+                    background: {header_bg_color};
 
                     span {{
                       color: {link_color}; // Link Color
                     }}
 
                     .nav-links .secondary {{
-                      a.sign-in-btn,
-                      a.register-btn:hover
-                      {{
-                        color: {header_bg} !important; // Header color
-                        background: {link_color} !important; // Link color
-                        border-color: {header_bg} !important; // Header color
-                      }}
-                      a.register-btn,
-                      a.sign-in-btn:hover
-                      {{
-                        color: {link_color} !important; // Link color
-                        background: {header_bg} !important; // Header color
-                        border-color: {link_color} !important; // Link color
-                      }}
-
-                      .nav-item a {{
-                        color: {link_color}; // Link Color
-                      }}
-
-                      .dropdown-user-menu .dropdown-item a {{
-                         // Dropdown color fixed to black
-                        color: #000000;
+                      .secondary .nav-item a, .dropdown-user-menu .dropdown-item a {{
+                        color: {link_color};
                       }}
                     }}
                 }}
                 .wrapper-footer {{
-                    background: {footer_bg}; // Footer color
+                    background: {footer_bg_color}; // Footer color
+                    background-color: {footer_bg_color} !important; // Footer color
+
+                    p.copyright
+                    {{
+                      color: {main_color}; // Link color
+                    }}
+
+                    footer .site-nav .nav-item .nav-link
+                    {{
+                      color: {link_color} !important; // Link color
+                    }}
 
                     footer#footer-openedx {{
                       .colophon .nav-colophon li a, .copyright, a {{
@@ -178,36 +169,9 @@ class OpenEdXThemeMixin(models.Model):
                   color: {main_color} !important; // Main Color
                 }}
                 .login-register .action-primary
-                {{
-                  color: {header_bg} !important; // Header color
-                  background: {link_color} !important; // Link color
-                  border-color: {header_bg} !important; // Header color
-                }}
                 .login-register .action-primary:hover
                 {{
-                  color: {link_color} !important; // Link color
-                  background: {header_bg} !important; // Header color
-                  border-color: {link_color} !important; // Link color
-                }}
-
-                // Override for components that always stay on white bg
-                .wrapper-course-material .course-tabs .tab a.active,
-                .wiki-wrapper section.wiki .nav-tabs li.active a,
-                .content-wrapper .course-tabs .nav-item.active .nav-link,
-                {{
-                  color: #000000 !important;
-                  font-weight: bold !important;
-                }}
-                .content-wrapper .course-tabs .nav-item .nav-link,
-                .wrapper-course-material .course-tabs .tab a:hover
-                {{
-                    color: #000000 !important;
-                }}
-                .fa-chevron-right {{
-                  color: {main_color} !important; // Main Color
-                }}
-                .date-summary-container .date-summary-todays-date {{
-                  border-left-color: {link_color}; // Link Color
+                  background: {main_color} !important; // Link color
                 }}
             """.format(
                 link_color=application.link_color,

--- a/instance/models/mixins/openedx_theme.py
+++ b/instance/models/mixins/openedx_theme.py
@@ -103,6 +103,16 @@ class OpenEdXThemeMixin(models.Model):
                     ),
                 },
             ],
+            "SIMPLETHEME_SASS_OVERRIDES": [
+                {
+                    "variable": "primary",
+                    "value": application.main_color,
+                },
+                {
+                    "variable": "secondary",
+                    "value": application.main_color,
+                },
+            ],
             "SIMPLETHEME_STATIC_FILES_URLS": [
                 {
                     "url": application.logo.url,
@@ -116,13 +126,118 @@ class OpenEdXThemeMixin(models.Model):
             "SIMPLETHEME_ENABLE_DEPLOY": True,
             "EDXAPP_DEFAULT_SITE_THEME": "simple-theme",
             "SIMPLETHEME_EXTRA_SASS": """
-                .global-header {{
-                    background: {header_bg};
-                }}
-                .wrapper-footer {{
-                    background: {footer_bg};
-                }}""".format(header_bg=application.header_bg_color,
-                             footer_bg=application.footer_bg_color)
+                .global-header {
+                    background: {header_bg}; // Header color
+
+                    span {
+                      color: {link_color}; // Link Color
+                    }
+
+                    .nav-links .secondary {
+                       a.sign-in-btn {
+                        // Fixed main color for button bg
+                        color: #ffffff !important;
+                      }
+                      a.sign-in-btn:hover {
+                       color: {link_color} !important; // Link Color
+                     }
+
+                      .nav-item a {
+                        color: {link_color}; // Link Color
+                      }
+
+                      .dropdown-user-menu .dropdown-item a {
+                         // Dropdown color fixed to black
+                        color: #000000;
+                      }
+                    }
+                }
+                .wrapper-footer {
+                    background: {footer_bg}; // Footer color
+
+                    footer#footer-openedx {
+                      .colophon .nav-colophon li a, .copyright, a {
+                        color: {link_color}; // Link Color
+                      }
+                    }
+                }
+                .view-profile .wrapper-profile-section-container-one .wrapper-profile-section-one {
+                  border-top-color: {link_color}; // Link Color
+                }
+
+                // Login and registration buttons
+                #forgot-password-modal #password-reset .form-actions button[type="submit"]:hover,
+                .view-register .form-actions button[type="submit"]:hover,
+                .view-login .form-actions button[type="submit"]:hover {
+                    box-shadow: 0 0 0 0;
+                    color: {link_color}; // Link Color
+                    border: 1px solid #006400;
+                    background: rgba(255, 255, 255, 1);
+                }
+
+                .view-register .form-actions button[type="submit"],
+                .view-passwordreset .form-actions button[type="submit"],
+                .view-login .form-actions button[type="submit"] {
+                  box-shadow: 0 0 0 0;
+                }
+
+                .view-register .introduction header .title .title-super,
+                .view-login .introduction header .title .title-super,
+                .view-passwordreset .introduction header .title .title-super
+                {
+                  color: {link_color} !important; // Link Color
+                }
+
+                // Fixing colors on registration page
+                .register {
+                  aside .btn-login h3.title {
+                    color: rgba(255, 255, 255, 1);
+                  }
+                  aside .btn-login:hover {
+                    h3.title {
+                      color: {link_color}; // Link Color
+                    }
+                  }
+
+                  aside .btn-login .btn-login-action {
+                    color: {link_color}; // Link Color
+                    background: rgba(255, 255, 255, 1);
+                  }
+                  aside .btn-login .btn-login-action:hover {
+                    color: rgba(255, 255, 255, 1);
+                    background: {link_color}; // Link Color
+                  }
+                }
+
+                .btn-primary:hover, .btn-brand:hover, .btn-primary.is-hovered
+                {
+                  background: rgba(255, 255, 255, 1);
+                }
+
+                // Override for components that always stay on white bg
+                .wrapper-course-material .course-tabs .tab a.active,
+                .wiki-wrapper section.wiki .nav-tabs li.active a,
+                .content-wrapper .course-tabs .nav-item.active .nav-link,
+                {
+                  color: #000000 !important;
+                  font-weight: bold !important;
+                }
+                .content-wrapper .course-tabs .nav-item .nav-link
+                {
+                    color: #000000 !important;
+                }
+                .fa-chevron-right:before {
+                  border-top-color: {main_color}; // Main Color
+                }
+                .date-summary-container .date-summary-todays-date {
+                  border-left-color: {link_color}; // Link Color
+                }
+            """.format(
+                link_color=application.link_color,
+                main_color=application.main_color,
+                header_bg=application.header_bg_color,
+                footer_bg=application.footer_bg_color
+            )
         }
 
         return yaml.dump(settings, default_flow_style=False)

--- a/instance/models/mixins/openedx_theme.py
+++ b/instance/models/mixins/openedx_theme.py
@@ -127,7 +127,7 @@ class OpenEdXThemeMixin(models.Model):
             "EDXAPP_DEFAULT_SITE_THEME": "simple-theme",
             "SIMPLETHEME_EXTRA_SASS": """
                 .global-header {{
-                    background: {header_bg_color};
+                    background: {header_bg};
 
                     span {{
                       color: {link_color}; // Link Color
@@ -140,8 +140,8 @@ class OpenEdXThemeMixin(models.Model):
                     }}
                 }}
                 .wrapper-footer {{
-                    background: {footer_bg_color}; // Footer color
-                    background-color: {footer_bg_color} !important; // Footer color
+                    background: {footer_bg}; // Footer color
+                    background-color: {footer_bg} !important; // Footer color
 
                     p.copyright
                     {{

--- a/instance/models/mixins/openedx_theme.py
+++ b/instance/models/mixins/openedx_theme.py
@@ -134,13 +134,20 @@ class OpenEdXThemeMixin(models.Model):
                     }}
 
                     .nav-links .secondary {{
-                       a.sign-in-btn {{
-                        // Fixed main color for button bg
-                        color: #ffffff !important;
+                      a.sign-in-btn,
+                      a.register-btn:hover
+                      {{
+                        color: {main_color} !important; // Main color
+                        background: {link_color} !important; // Link color
+                        border-color: {main_color} !important; // Main color
                       }}
-                      a.sign-in-btn:hover {{
-                       color: {link_color} !important; // Link Color
-                     }}
+                      a.register-btn,
+                      a.sign-in-btn:hover
+                      {{
+                        color: {link_color} !important; // Link color
+                        background: {main_color} !important; // Main color
+                        border-color: {link_color} !important; // Link color
+                      }}
 
                       .nav-item a {{
                         color: {link_color}; // Link Color
@@ -161,57 +168,26 @@ class OpenEdXThemeMixin(models.Model):
                       }}
                     }}
                 }}
+                // User profile photo bar
                 .view-profile .wrapper-profile-section-container-one .wrapper-profile-section-one {{
                   border-top-color: {link_color}; // Link Color
                 }}
 
-                // Login and registration buttons
-                #forgot-password-modal #password-reset .form-actions button[type="submit"]:hover,
-                .view-register .form-actions button[type="submit"]:hover,
-                .view-login .form-actions button[type="submit"]:hover {{
-                    box-shadow: 0 0 0 0;
-                    color: {link_color}; // Link Color
-                    border: 1px solid #006400;
-                    background: rgba(255, 255, 255, 1);
+                // Login and registration fixes
+                .login-register-content h2 {{
+                  color: {main_color} !important; // Main Color
                 }}
-
-                .view-register .form-actions button[type="submit"],
-                .view-passwordreset .form-actions button[type="submit"],
-                .view-login .form-actions button[type="submit"] {{
-                  box-shadow: 0 0 0 0;
-                }}
-
-                .view-register .introduction header .title .title-super,
-                .view-login .introduction header .title .title-super,
-                .view-passwordreset .introduction header .title .title-super
+                .login-register .action-primary
                 {{
-                  color: {link_color} !important; // Link Color
+                  color: {main_color} !important; // Main color
+                  background: {link_color} !important; // Link color
+                  border-color: {main_color} !important; // Main color
                 }}
-
-                // Fixing colors on registration page
-                .register {{
-                  aside .btn-login h3.title {{
-                    color: rgba(255, 255, 255, 1);
-                  }}
-                  aside .btn-login:hover {{
-                    h3.title {{
-                      color: {link_color}; // Link Color
-                    }}
-                  }}
-
-                  aside .btn-login .btn-login-action {{
-                    color: {link_color}; // Link Color
-                    background: rgba(255, 255, 255, 1);
-                  }}
-                  aside .btn-login .btn-login-action:hover {{
-                    color: rgba(255, 255, 255, 1);
-                    background: {link_color}; // Link Color
-                  }}
-                }}
-
-                .btn-primary:hover, .btn-brand:hover, .btn-primary.is-hovered
+                .login-register .action-primary:hover
                 {{
-                  background: rgba(255, 255, 255, 1);
+                  color: {link_color} !important; // Link color
+                  background: {main_color} !important; // Main color
+                  border-color: {link_color} !important; // Link color
                 }}
 
                 // Override for components that always stay on white bg
@@ -222,12 +198,13 @@ class OpenEdXThemeMixin(models.Model):
                   color: #000000 !important;
                   font-weight: bold !important;
                 }}
-                .content-wrapper .course-tabs .nav-item .nav-link
+                .content-wrapper .course-tabs .nav-item .nav-link,
+                .wrapper-course-material .course-tabs .tab a:hover
                 {{
                     color: #000000 !important;
                 }}
-                .fa-chevron-right:before {{
-                  border-top-color: {main_color}; // Main Color
+                .fa-chevron-right {{
+                  color: {main_color} !important; // Main Color
                 }}
                 .date-summary-container .date-summary-todays-date {{
                   border-left-color: {link_color}; // Link Color

--- a/instance/models/mixins/openedx_theme.py
+++ b/instance/models/mixins/openedx_theme.py
@@ -106,8 +106,8 @@ class OpenEdXThemeMixin(models.Model):
             ],
             "SIMPLETHEME_ENABLE_DEPLOY": True,
             "EDXAPP_DEFAULT_SITE_THEME": "simple-theme",
-            "EDXAPP_COMPREHENSIVE_THEME_SOURCE_REPO": settings.EDXAPP_COMPREHENSIVE_THEME_SOURCE_REPO,
-            "EDXAPP_COMPREHENSIVE_THEME_VERSION": settings.EDXAPP_COMPREHENSIVE_THEME_VERSION,
+            "EDXAPP_COMPREHENSIVE_THEME_SOURCE_REPO": settings.SIMPLE_THEME_SKELETON_THEME_REPO,
+            "EDXAPP_COMPREHENSIVE_THEME_VERSION": settings.SIMPLE_THEME_SKELETON_THEME_VERSION,
             "SIMPLETHEME_EXTRA_SASS": """
                 $main-color: {main_color};
                 $link-color: {link_color};

--- a/instance/models/mixins/openedx_theme.py
+++ b/instance/models/mixins/openedx_theme.py
@@ -140,24 +140,22 @@ class OpenEdXThemeMixin(models.Model):
         return yaml.dump(theme_settings, default_flow_style=False)
 
     @staticmethod
-    def get_contrasting_font_color(background_color):
+    def get_contrasting_font_color(background_color, delta=0.5):
         """
         Takes in a hexcolor code and returns black or white, depending
         which gives the better contrast
         """
         try:
-            color = Colour(background_color)
+            color = Color(background_color)
         except ValueError:
             return "#000000"
 
         # Using Web Content Accessibility Guidelines (WCAG) 2.0 and comparing
-        # the background to the black color we can define which is the best color
-        # to improve readability on the page
-        # Following the given formula using L2 as black (0 luminance):
-        # (L1 + 0.05) / (L2 + 0.05) = sqrt(1.05 * 0.05) - 0.05 ~~ 0.179
+        # the background to the black color we can define which is the
+        # best color to improve readability on the page
         # More info:
         # https://www.w3.org/TR/WCAG20/
-        if color.luminance > 0.179:
+        if color.luminance > delta:
             return '#000000'
         else:
             return '#ffffff'

--- a/instance/models/mixins/openedx_theme.py
+++ b/instance/models/mixins/openedx_theme.py
@@ -75,14 +75,6 @@ class OpenEdXThemeMixin(models.Model):
                     "value": application.link_color,
                 },
                 {
-                    "variable": "header-bg",
-                    "value": application.header_bg_color,
-                },
-                {
-                    "variable": "footer-bg",
-                    "value": application.footer_bg_color,
-                },
-                {
                     "variable": "button-color",
                     "value": application.main_color,
                 },

--- a/instance/models/mixins/openedx_theme.py
+++ b/instance/models/mixins/openedx_theme.py
@@ -103,7 +103,7 @@ class OpenEdXThemeMixin(models.Model):
                     ),
                 },
             ],
-            "SIMPLETHEME_SASS_OVERRIDES": [
+            "SIMPLETHEME_SASS_BOOTSTRAP_OVERRIDES": [
                 {
                     "variable": "primary",
                     "value": application.main_color,

--- a/instance/tests/models/test_openedx_theme_mixins.py
+++ b/instance/tests/models/test_openedx_theme_mixins.py
@@ -21,7 +21,7 @@ OpenEdXInstance Theme Mixins - Tests
 """
 
 # Imports #####################################################################
-
+import ddt
 import yaml
 from django.contrib.auth import get_user_model
 
@@ -34,6 +34,7 @@ from registration.models import BetaTestApplication
 
 # Tests #######################################################################
 
+@ddt.ddt
 class OpenEdXThemeMixinTestCase(TestCase):
     """
     Tests for OpenEdXThemeMixin, to check that settings from the beta application form are
@@ -141,7 +142,20 @@ class OpenEdXThemeMixinTestCase(TestCase):
             self.assertNotIn('SIMPLETHEME_SASS_OVERRIDES', parsed_vars)
             self.assertNotIn('EDXAPP_DEFAULT_SITE_THEME', parsed_vars)
 
-    def test_get_contrasting_font_color(self):
+    @ddt.data(
+        # Invalid or empty color returns black
+        ('', '#000000'),
+        ('#@!Vb]´', '#000000'),
+        ('#zzzzzz', '#000000'),
+        # Check for some colors
+        ('#ffffff', '#000000'),    # white, black
+        ('#4286f4', '#000000'), # light blue, black
+        ('#45e052', '#000000'), # light green, black
+        ('#000000', '#ffffff'),    # black, white
+        ('#1f365b', '#ffffff'),    # dark blue, white
+        ('#7c702f', '#ffffff'),    # dark gold, white
+    )
+    def test_get_contrasting_font_color(self, test_colors):
         """
         Tests if the automatic font color selection is working properly
         """
@@ -150,21 +164,8 @@ class OpenEdXThemeMixinTestCase(TestCase):
         instance = OpenEdXInstance.objects.get()
 
         # Test if the font color is correctly returned depending on the background color
-        test_colors = [
-            # Invalid or empty color returns black
-            ('', '#000000'),
-            ('#@!Vb]´', '#000000'),
-            ('#zzzzzz', '#000000'),
-            # Check for some colors
-            ('#ffffff', '#000000'),    # white, black
-            ('#4286f4', '#000000'), # light blue, black
-            ('#45e052', '#000000'), # light green, black
-            ('#000000', '#ffffff'),    # black, white
-            ('#1f365b', '#ffffff'),    # dark blue, white
-            ('#7c702f', '#ffffff'),    # dark gold, white
-        ]
-        for bg_color, font_color in test_colors:
-            self.assertEqual(
-                instance.get_contrasting_font_color(bg_color),
-                font_color
-            )
+        bg_color, font_color = test_colors
+        self.assertEqual(
+            instance.get_contrasting_font_color(bg_color),
+            font_color
+        )

--- a/instance/tests/models/test_openedx_theme_mixins.py
+++ b/instance/tests/models/test_openedx_theme_mixins.py
@@ -125,15 +125,15 @@ class OpenEdXThemeMixinTestCase(TestCase):
                       a.sign-in-btn,
                       a.register-btn:hover
                       {
-                        color: #001122 !important; // Main color
+                        color: #caaffe !important; // Header color
                         background: #003344 !important; // Link color
-                        border-color: #001122 !important; // Main color
+                        border-color: #caaffe !important; // Header color
                       }
                       a.register-btn,
                       a.sign-in-btn:hover
                       {
                         color: #003344 !important; // Link color
-                        background: #001122 !important; // Main color
+                        background: #caaffe !important; // Header color
                         border-color: #003344 !important; // Link color
                       }
 
@@ -167,14 +167,14 @@ class OpenEdXThemeMixinTestCase(TestCase):
                 }
                 .login-register .action-primary
                 {
-                  color: #001122 !important; // Main color
+                  color: #caaffe !important; // Header color
                   background: #003344 !important; // Link color
-                  border-color: #001122 !important; // Main color
+                  border-color: #caaffe !important; // Header color
                 }
                 .login-register .action-primary:hover
                 {
                   color: #003344 !important; // Link color
-                  background: #001122 !important; // Main color
+                  background: #caaffe !important; // Header color
                   border-color: #003344 !important; // Link color
                 }
 

--- a/instance/tests/models/test_openedx_theme_mixins.py
+++ b/instance/tests/models/test_openedx_theme_mixins.py
@@ -115,40 +115,31 @@ class OpenEdXThemeMixinTestCase(TestCase):
                 # for SIMPLETHEME_STATIC_FILES_URLS, see below
                 'SIMPLETHEME_EXTRA_SASS': """
                 .global-header {
-                    background: #caaffe; // Header color
+                    background: #caaffe;
 
                     span {
                       color: #003344; // Link Color
                     }
 
                     .nav-links .secondary {
-                      a.sign-in-btn,
-                      a.register-btn:hover
-                      {
-                        color: #caaffe !important; // Header color
-                        background: #003344 !important; // Link color
-                        border-color: #caaffe !important; // Header color
-                      }
-                      a.register-btn,
-                      a.sign-in-btn:hover
-                      {
-                        color: #003344 !important; // Link color
-                        background: #caaffe !important; // Header color
-                        border-color: #003344 !important; // Link color
-                      }
-
-                      .nav-item a {
-                        color: #003344; // Link Color
-                      }
-
-                      .dropdown-user-menu .dropdown-item a {
-                         // Dropdown color fixed to black
-                        color: #000000;
+                      .secondary .nav-item a, .dropdown-user-menu .dropdown-item a {
+                        color: #003344;
                       }
                     }
                 }
                 .wrapper-footer {
                     background: #ffff11; // Footer color
+                    background-color: #ffff11 !important; // Footer color
+
+                    p.copyright
+                    {
+                      color: #001122; // Link color
+                    }
+
+                    footer .site-nav .nav-item .nav-link
+                    {
+                      color: #003344 !important; // Link color
+                    }
 
                     footer#footer-openedx {
                       .colophon .nav-colophon li a, .copyright, a {
@@ -166,36 +157,9 @@ class OpenEdXThemeMixinTestCase(TestCase):
                   color: #001122 !important; // Main Color
                 }
                 .login-register .action-primary
-                {
-                  color: #caaffe !important; // Header color
-                  background: #003344 !important; // Link color
-                  border-color: #caaffe !important; // Header color
-                }
                 .login-register .action-primary:hover
                 {
-                  color: #003344 !important; // Link color
-                  background: #caaffe !important; // Header color
-                  border-color: #003344 !important; // Link color
-                }
-
-                // Override for components that always stay on white bg
-                .wrapper-course-material .course-tabs .tab a.active,
-                .wiki-wrapper section.wiki .nav-tabs li.active a,
-                .content-wrapper .course-tabs .nav-item.active .nav-link,
-                {
-                  color: #000000 !important;
-                  font-weight: bold !important;
-                }
-                .content-wrapper .course-tabs .nav-item .nav-link,
-                .wrapper-course-material .course-tabs .tab a:hover
-                {
-                    color: #000000 !important;
-                }
-                .fa-chevron-right {
-                  color: #001122 !important; // Main Color
-                }
-                .date-summary-container .date-summary-todays-date {
-                  border-left-color: #003344; // Link Color
+                  background: #001122 !important; // Link color
                 }
             """
             }

--- a/instance/tests/models/test_openedx_theme_mixins.py
+++ b/instance/tests/models/test_openedx_theme_mixins.py
@@ -85,13 +85,10 @@ class OpenEdXThemeMixinTestCase(TestCase):
                 'SIMPLETHEME_SASS_OVERRIDES': [
                     {'variable': 'link-color',
                      'value': '#003344', },
-                    # TODO: These are specific to Ginkgo and can be removed
-                    # after Hawthorn upgrade
                     {'variable': 'header-bg',
                      'value': '#caaffe', },
                     {'variable': 'footer-bg',
                      'value': '#ffff11', },
-                    # END TODO
                     {'variable': 'button-color',
                      'value': '#001122', },
                     {'variable': 'action-primary-bg',
@@ -101,66 +98,13 @@ class OpenEdXThemeMixinTestCase(TestCase):
                     {'variable': 'theme-colors',
                      'value': '("primary": #001122, "secondary": #001122)'}
                 ],
-                'SIMPLETHEME_SASS_BOOTSTRAP_OVERRIDES': [
-                    {
-                        'variable': 'primary',
-                        'value': '#001122',
-                    },
-                    {
-                        'variable': 'secondary',
-                        'value': '#001122',
-                    }
-                ],
                 'EDXAPP_DEFAULT_SITE_THEME': 'simple-theme',
                 # for SIMPLETHEME_STATIC_FILES_URLS, see below
                 'SIMPLETHEME_EXTRA_SASS': """
-                .global-header {
-                    background: #caaffe;
-
-                    span {
-                      color: #003344; // Link Color
-                    }
-
-                    .nav-links .secondary {
-                      .secondary .nav-item a, .dropdown-user-menu .dropdown-item a {
-                        color: #003344;
-                      }
-                    }
-                }
-                .wrapper-footer {
-                    background: #ffff11; // Footer color
-                    background-color: #ffff11 !important; // Footer color
-
-                    p.copyright
-                    {
-                      color: #001122; // Link color
-                    }
-
-                    footer .site-nav .nav-item .nav-link
-                    {
-                      color: #003344 !important; // Link color
-                    }
-
-                    footer#footer-openedx {
-                      .colophon .nav-colophon li a, .copyright, a {
-                        color: #003344; // Link Color
-                      }
-                    }
-                }
-                // User profile photo bar
-                .view-profile .wrapper-profile-section-container-one .wrapper-profile-section-one {
-                  border-top-color: #003344; // Link Color
-                }
-
-                // Login and registration fixes
-                .login-register-content h2 {
-                  color: #001122 !important; // Main Color
-                }
-                .login-register .action-primary
-                .login-register .action-primary:hover
-                {
-                  background: #001122 !important; // Link color
-                }
+                $main-color: #001122;
+                $link-color: #003344;
+                $header-bg: #caaffe;
+                $footer-bg: #ffff11;
             """
             }
             for ansible_var, value in expected_settings.items():

--- a/instance/tests/models/test_openedx_theme_mixins.py
+++ b/instance/tests/models/test_openedx_theme_mixins.py
@@ -85,10 +85,6 @@ class OpenEdXThemeMixinTestCase(TestCase):
                 'SIMPLETHEME_SASS_OVERRIDES': [
                     {'variable': 'link-color',
                      'value': '#003344', },
-                    {'variable': 'header-bg',
-                     'value': '#caaffe', },
-                    {'variable': 'footer-bg',
-                     'value': '#ffff11', },
                     {'variable': 'button-color',
                      'value': '#001122', },
                     {'variable': 'action-primary-bg',

--- a/instance/tests/models/test_openedx_theme_mixins.py
+++ b/instance/tests/models/test_openedx_theme_mixins.py
@@ -104,7 +104,9 @@ class OpenEdXThemeMixinTestCase(TestCase):
                 $main-color: #001122;
                 $link-color: #003344;
                 $header-bg: #caaffe;
+                $header-font-color: #000000;
                 $footer-bg: #ffff11;
+                $footer-font-color: #000000;
             """
             }
             for ansible_var, value in expected_settings.items():

--- a/instance/tests/models/test_openedx_theme_mixins.py
+++ b/instance/tests/models/test_openedx_theme_mixins.py
@@ -101,15 +101,103 @@ class OpenEdXThemeMixinTestCase(TestCase):
                     {'variable': 'theme-colors',
                      'value': '("primary": #001122, "secondary": #001122)'}
                 ],
+                'SIMPLETHEME_SASS_BOOTSTRAP_OVERRIDES': [
+                    {
+                        'variable': 'primary',
+                        'value': '#001122',
+                    },
+                    {
+                        'variable': 'secondary',
+                        'value': '#001122',
+                    }
+                ],
                 'EDXAPP_DEFAULT_SITE_THEME': 'simple-theme',
                 # for SIMPLETHEME_STATIC_FILES_URLS, see below
-                'SIMPLETHEME_EXTRA_SASS': '''
+                'SIMPLETHEME_EXTRA_SASS': """
                 .global-header {
-                    background: #caaffe;
+                    background: #caaffe; // Header color
+
+                    span {
+                      color: #003344; // Link Color
+                    }
+
+                    .nav-links .secondary {
+                      a.sign-in-btn,
+                      a.register-btn:hover
+                      {
+                        color: #001122 !important; // Main color
+                        background: #003344 !important; // Link color
+                        border-color: #001122 !important; // Main color
+                      }
+                      a.register-btn,
+                      a.sign-in-btn:hover
+                      {
+                        color: #003344 !important; // Link color
+                        background: #001122 !important; // Main color
+                        border-color: #003344 !important; // Link color
+                      }
+
+                      .nav-item a {
+                        color: #003344; // Link Color
+                      }
+
+                      .dropdown-user-menu .dropdown-item a {
+                         // Dropdown color fixed to black
+                        color: #000000;
+                      }
+                    }
                 }
                 .wrapper-footer {
-                    background: #ffff11;
-                }'''
+                    background: #ffff11; // Footer color
+
+                    footer#footer-openedx {
+                      .colophon .nav-colophon li a, .copyright, a {
+                        color: #003344; // Link Color
+                      }
+                    }
+                }
+                // User profile photo bar
+                .view-profile .wrapper-profile-section-container-one .wrapper-profile-section-one {
+                  border-top-color: #003344; // Link Color
+                }
+
+                // Login and registration fixes
+                .login-register-content h2 {
+                  color: #001122 !important; // Main Color
+                }
+                .login-register .action-primary
+                {
+                  color: #001122 !important; // Main color
+                  background: #003344 !important; // Link color
+                  border-color: #001122 !important; // Main color
+                }
+                .login-register .action-primary:hover
+                {
+                  color: #003344 !important; // Link color
+                  background: #001122 !important; // Main color
+                  border-color: #003344 !important; // Link color
+                }
+
+                // Override for components that always stay on white bg
+                .wrapper-course-material .course-tabs .tab a.active,
+                .wiki-wrapper section.wiki .nav-tabs li.active a,
+                .content-wrapper .course-tabs .nav-item.active .nav-link,
+                {
+                  color: #000000 !important;
+                  font-weight: bold !important;
+                }
+                .content-wrapper .course-tabs .nav-item .nav-link,
+                .wrapper-course-material .course-tabs .tab a:hover
+                {
+                    color: #000000 !important;
+                }
+                .fa-chevron-right {
+                  color: #001122 !important; // Main Color
+                }
+                .date-summary-container .date-summary-todays-date {
+                  border-left-color: #003344; // Link Color
+                }
+            """
             }
             for ansible_var, value in expected_settings.items():
                 self.assertEqual(value, parsed_vars[ansible_var])

--- a/instance/tests/models/test_openedx_theme_mixins.py
+++ b/instance/tests/models/test_openedx_theme_mixins.py
@@ -144,3 +144,31 @@ class OpenEdXThemeMixinTestCase(TestCase):
             self.assertNotIn('SIMPLETHEME_ENABLE_DEPLOY', parsed_vars)
             self.assertNotIn('SIMPLETHEME_SASS_OVERRIDES', parsed_vars)
             self.assertNotIn('EDXAPP_DEFAULT_SITE_THEME', parsed_vars)
+
+    def test_get_contrasting_font_color(self):
+        """
+        Tests if the automatic font color selection is working properly
+        """
+        # Create objects
+        OpenEdXInstanceFactory(name='Integration - test_colors_applied', deploy_simpletheme=True)
+        instance = OpenEdXInstance.objects.get()
+
+        # Test if the font color is correctly returned depending on the background color
+        test_colors = [
+            # Invalid or empty color returns black
+            ('', '#000000'),
+            ('#@!Vb]´', '#000000'),
+            ('#zzzzzz', '#000000'),
+            # Check for some colors
+            ('#ffffff', '#000000'),    # white, black
+            ('#4286f4', '#000000'), # light blue, black
+            ('#45e052', '#000000'), # light green, black
+            ('#000000', '#ffffff'),    # black, white
+            ('#1f365b', '#ffffff'),    # dark blue, white
+            ('#7c702f', '#ffffff'),    # dark gold, white
+        ]
+        for bg_color, font_color in test_colors:
+            self.assertEqual(
+                instance.get_contrasting_font_color(bg_color),
+                font_color
+            )

--- a/opencraft/settings.py
+++ b/opencraft/settings.py
@@ -482,8 +482,8 @@ OPENEDX_APPSERVER_SECURITY_GROUP_RULES = [
 # Enable or disable celery heartbeats on instances managed by Ocim
 EDX_WORKERS_ENABLE_CELERY_HEARTBEATS = env.bool('EDX_WORKERS_ENABLE_CELERY_HEARTBEATS', default=False)
 
-# Open EdX Instance custom theme for Ocim Managed client instances
-# The `simple-theme` ansible role uses the below repository as a skeleton
+# This repository is used as a skeleton theme for the betatest instances
+# to apply the specified theming configuration through the `simple-theme` role.
 SIMPLE_THEME_SKELETON_THEME_REPO = env(
     'SIMPLE_THEME_SKELETON_THEME_REPO',
     default='https://github.com/open-craft/edx-simple-theme/'

--- a/opencraft/settings.py
+++ b/opencraft/settings.py
@@ -483,7 +483,10 @@ OPENEDX_APPSERVER_SECURITY_GROUP_RULES = [
 EDX_WORKERS_ENABLE_CELERY_HEARTBEATS = env.bool('EDX_WORKERS_ENABLE_CELERY_HEARTBEATS', default=False)
 
 # Open EdX Instance custom theme for clients ##################################
-EDXAPP_COMPREHENSIVE_THEME_SOURCE_REPO = env('EDXAPP_COMPREHENSIVE_THEME_SOURCE_REPO', default='https://github.com/open-craft/opencraft-simple-theme/')
+EDXAPP_COMPREHENSIVE_THEME_SOURCE_REPO = env(
+    'EDXAPP_COMPREHENSIVE_THEME_SOURCE_REPO',
+    default='https://github.com/open-craft/opencraft-simple-theme/'
+)
 EDXAPP_COMPREHENSIVE_THEME_VERSION = env('EDXAPP_COMPREHENSIVE_THEME_VERSION', default='master')
 
 # Ansible #####################################################################

--- a/opencraft/settings.py
+++ b/opencraft/settings.py
@@ -488,10 +488,7 @@ SIMPLE_THEME_SKELETON_THEME_REPO = env(
     'SIMPLE_THEME_SKELETON_THEME_REPO',
     default='https://github.com/open-craft/edx-simple-theme/'
 )
-SIMPLE_THEME_SKELETON_THEME_VERSION = env(
-    'SIMPLE_THEME_SKELETON_THEME_VERSION',
-    default='giovanni/bb-834-improve-simple-theme'
-)
+SIMPLE_THEME_SKELETON_THEME_VERSION = env('SIMPLE_THEME_SKELETON_THEME_VERSION', default='master')
 
 # Ansible #####################################################################
 

--- a/opencraft/settings.py
+++ b/opencraft/settings.py
@@ -483,7 +483,7 @@ OPENEDX_APPSERVER_SECURITY_GROUP_RULES = [
 EDX_WORKERS_ENABLE_CELERY_HEARTBEATS = env.bool('EDX_WORKERS_ENABLE_CELERY_HEARTBEATS', default=False)
 
 # Open EdX Instance custom theme for Ocim Managed client instances
-# The `simple-theme` ansible role uses the below repository as a skeleton theme
+# The `simple-theme` ansible role uses the below repository as a skeleton
 SIMPLE_THEME_SKELETON_THEME_REPO = env(
     'SIMPLE_THEME_SKELETON_THEME_REPO',
     default='https://github.com/open-craft/edx-simple-theme/'

--- a/opencraft/settings.py
+++ b/opencraft/settings.py
@@ -482,12 +482,13 @@ OPENEDX_APPSERVER_SECURITY_GROUP_RULES = [
 # Enable or disable celery heartbeats on instances managed by Ocim
 EDX_WORKERS_ENABLE_CELERY_HEARTBEATS = env.bool('EDX_WORKERS_ENABLE_CELERY_HEARTBEATS', default=False)
 
-# Open EdX Instance custom theme for clients ##################################
-EDXAPP_COMPREHENSIVE_THEME_SOURCE_REPO = env(
-    'EDXAPP_COMPREHENSIVE_THEME_SOURCE_REPO',
-    default='https://github.com/open-craft/opencraft-simple-theme/'
+# Open EdX Instance custom theme for Ocim Managed client instances
+# The `simple-theme` ansible role uses the below repository as a skeleton theme
+SIMPLE_THEME_SKELETON_THEME_REPO = env(
+    'SIMPLE_THEME_SKELETON_THEME_REPO',
+    default='https://github.com/open-craft/edx-simple-theme/'
 )
-EDXAPP_COMPREHENSIVE_THEME_VERSION = env('EDXAPP_COMPREHENSIVE_THEME_VERSION', default='master')
+SIMPLE_THEME_SKELETON_THEME_VERSION = env('SIMPLE_THEME_SKELETON_THEME_VERSION', default='master')
 
 # Ansible #####################################################################
 

--- a/opencraft/settings.py
+++ b/opencraft/settings.py
@@ -482,6 +482,10 @@ OPENEDX_APPSERVER_SECURITY_GROUP_RULES = [
 # Enable or disable celery heartbeats on instances managed by Ocim
 EDX_WORKERS_ENABLE_CELERY_HEARTBEATS = env.bool('EDX_WORKERS_ENABLE_CELERY_HEARTBEATS', default=False)
 
+# Open EdX Instance custom theme for clients ##################################
+EDXAPP_COMPREHENSIVE_THEME_SOURCE_REPO = env('EDXAPP_COMPREHENSIVE_THEME_SOURCE_REPO', default='https://github.com/open-craft/opencraft-simple-theme/')
+EDXAPP_COMPREHENSIVE_THEME_VERSION = env('EDXAPP_COMPREHENSIVE_THEME_VERSION', default='master')
+
 # Ansible #####################################################################
 
 # Ansible requires a Python 2 interpreter

--- a/opencraft/settings.py
+++ b/opencraft/settings.py
@@ -488,7 +488,7 @@ SIMPLE_THEME_SKELETON_THEME_REPO = env(
     'SIMPLE_THEME_SKELETON_THEME_REPO',
     default='https://github.com/open-craft/edx-simple-theme/'
 )
-SIMPLE_THEME_SKELETON_THEME_VERSION = env('SIMPLE_THEME_SKELETON_THEME_VERSION', default='master')
+SIMPLE_THEME_SKELETON_THEME_VERSION = env('SIMPLE_THEME_SKELETON_THEME_VERSION', default='giovanni/bb-834-improve-simple-theme')
 
 # Ansible #####################################################################
 

--- a/opencraft/settings.py
+++ b/opencraft/settings.py
@@ -488,7 +488,10 @@ SIMPLE_THEME_SKELETON_THEME_REPO = env(
     'SIMPLE_THEME_SKELETON_THEME_REPO',
     default='https://github.com/open-craft/edx-simple-theme/'
 )
-SIMPLE_THEME_SKELETON_THEME_VERSION = env('SIMPLE_THEME_SKELETON_THEME_VERSION', default='giovanni/bb-834-improve-simple-theme')
+SIMPLE_THEME_SKELETON_THEME_VERSION = env(
+    'SIMPLE_THEME_SKELETON_THEME_VERSION',
+    default='giovanni/bb-834-improve-simple-theme'
+)
 
 # Ansible #####################################################################
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -160,3 +160,4 @@ warlock==1.2.0
 wcwidth==0.1.7
 Werkzeug==0.11.1
 wrapt==1.10.8
+colour==0.1.5


### PR DESCRIPTION
This PR fixes a lot of styling errors and improves readability for simple-theme deployments on Ocim.

**Testing instructions:**
Note: These changes are deployed to Ocim stage.
1. Use Ocim stage to deploy an instance using [the beta testing application form](https://stage.console.opencraft.com/registration/) and this [configuration branch](https://github.com/open-craft/configuration/pull/87).
2. Check if the theme is correctly deployed in the appserver.

I already done this with 2 sets of colors, so you can check the result at:
Light colors: https://stage.console.opencraft.com/instance/3230/edx-appserver/1022/
Darker colors: https://stage.console.opencraft.com/instance/3230/edx-appserver/1020/

**Reviewers:**
- [ ] @lgp171188 