### PR TITLE
[BB-857] Falsy values stored in Consul are still values.

### DIFF
--- a/instance/models/openedx_instance.py
+++ b/instance/models/openedx_instance.py
@@ -479,7 +479,7 @@ class OpenEdXInstance(
         version_number = agent.get('version') or 0
         for key, value in configurations.items():
             index, stored_value = agent.get(key, index=True)
-            cas = index if stored_value else 0
+            cas = index if stored_value is not None else 0
             agent.put(key, value, cas=cas)
 
             if not version_updated and value != stored_value:


### PR DESCRIPTION
When we had an actual value at some key path in Consul, such as `[]` for `ocim/instances/<ID>/active_app_servers`, Ocim would bring it in and assume that because it's a falsy value that it shouldn't be updated. So if the instance had any new active appservers, nothing would get updated.