### PR TITLE
improve the consistency of the values stored in consul

### DIFF
--- a/instance/models/utils.py
+++ b/instance/models/utils.py
@@ -460,7 +460,7 @@ class ConsulAgent(object):
         :return: Either True or False. If False is returned, then the update has not taken place.
         """
         consul_key = self.prefix + key
-        value = json.dumps(value) if self._is_json_serializable(value) else str(value)
+        value = json.dumps(value)
 
         return self._client.kv.put(consul_key, value, **kwargs)
 
@@ -515,11 +515,3 @@ class ConsulAgent(object):
             pass
 
         return value
-
-    @staticmethod
-    def _is_json_serializable(obj):
-        """
-        :param obj: Object to check
-        :return: Boolean True if object is list or dictionary, False otherwise.
-        """
-        return isinstance(obj, dict) or isinstance(obj, list) or isinstance(obj, bool)

--- a/instance/tests/models/test_utils.py
+++ b/instance/tests/models/test_utils.py
@@ -553,6 +553,25 @@ class ConsulAgentTest(TestCase):
         self.assertEqual(agent.prefix, prefix)
         self.assertIsInstance(agent._client, consul.Consul)
 
+    def test_get_index(self):
+        """
+        Tests getting the key value and the index.
+        """
+        agent = ConsulAgent()
+
+        for key, value in(('some/key1', {'some': 'value'}),
+                          ('some/key2', 'null'),
+                          ('some/key3', None)):
+            self.assertTrue(agent.put(key, value))
+            returned_index, returned_value = agent.get(key, index=True)
+            self.assertEqual(value, returned_value)
+            self.assertTrue(int(returned_index) > 0)
+
+        key = 'does/not/exist'
+        returned_index, returned_value = agent.get(key, index=True)
+        self.assertEqual(None, returned_value)
+        self.assertTrue(int(returned_index) == 0)
+
     def test_get_no_prefix(self):
         """
         Tests getting bare keys of different data types from Consul's Key-Value store.

--- a/instance/tests/models/test_utils.py
+++ b/instance/tests/models/test_utils.py
@@ -629,6 +629,14 @@ class ConsulAgentTest(TestCase):
         self.assertIsInstance(fetched_value, str)
         self.assertEqual(fetched_value, stored_value)
 
+        # Test None
+        key = 'none_key'
+        stored_value = None  # pylint: disable=redefined-variable-type
+        self.client.kv.put(prefix + key, json.dumps(stored_value))
+
+        fetched_value = agent.get(key)
+        self.assertEqual(fetched_value, stored_value)
+
         # Test integer values
         key = 'int_key'
         stored_value = 23  # pylint: disable=redefined-variable-type
@@ -687,7 +695,7 @@ class ConsulAgentTest(TestCase):
 
         _, data = self.client.kv.get(key)
         fetched_value = data['Value'].decode()
-        self.assertEqual(fetched_value, value)
+        self.assertEqual(fetched_value, json.dumps(value))
 
         # Put int values
         key = 'key'
@@ -696,7 +704,7 @@ class ConsulAgentTest(TestCase):
 
         _, data = self.client.kv.get(key)
         fetched_value = data['Value'].decode()
-        self.assertEqual(fetched_value, str(value))
+        self.assertEqual(fetched_value, json.dumps(value))
 
         # Put float values
         key = 'key'
@@ -705,7 +713,7 @@ class ConsulAgentTest(TestCase):
 
         _, data = self.client.kv.get(key)
         fetched_value = data['Value'].decode()
-        self.assertEqual(fetched_value, str(value))
+        self.assertEqual(fetched_value, json.dumps(value))
 
         # Put list values
         key = 'key'
@@ -747,7 +755,7 @@ class ConsulAgentTest(TestCase):
 
         _, data = self.client.kv.get(prefix + key)
         fetched_value = data['Value'].decode()
-        self.assertEqual(fetched_value, value)
+        self.assertEqual(fetched_value, json.dumps(value))
 
         # Put int values
         key = 'key'
@@ -756,7 +764,7 @@ class ConsulAgentTest(TestCase):
 
         _, data = self.client.kv.get(prefix + key)
         fetched_value = data['Value'].decode()
-        self.assertEqual(fetched_value, str(value))
+        self.assertEqual(fetched_value, json.dumps(value))
 
         # Put float values
         key = 'key'
@@ -765,7 +773,7 @@ class ConsulAgentTest(TestCase):
 
         _, data = self.client.kv.get(prefix + key)
         fetched_value = data['Value'].decode()
-        self.assertEqual(fetched_value, str(value))
+        self.assertEqual(fetched_value, json.dumps(value))
 
         # Put list values
         key = 'key'
@@ -883,18 +891,6 @@ class ConsulAgentTest(TestCase):
         fetched_value = json.dumps(dict_value).encode()
         self.assertEqual(self.agent._cast_value(fetched_value), dict_value)
         self.assertIsNone(self.agent._cast_value(None))
-
-    def test_is_json_serializable(self):
-        """
-        Tests that lists and dicts are identified as json objects or not.
-        """
-        self.assertTrue(self.agent._is_json_serializable([1, 2, 3, 4, 5]))
-        self.assertTrue(self.agent._is_json_serializable({'key': 'value'}))
-        self.assertTrue(self.agent._is_json_serializable(False))
-
-        self.assertFalse(self.agent._is_json_serializable('nope'))
-        self.assertFalse(self.agent._is_json_serializable(1))
-        self.assertFalse(self.agent._is_json_serializable(1.1))
 
     def tearDown(self):
         self.client.kv.delete('', recurse=True)


### PR DESCRIPTION
This is a followup to [the subtle bug fixed a few days ago](https://github.com/open-craft/opencraft/pull/386). It addresses border cases that are unlikely to be an issue right now but may create problems similarly difficult diagnose problems later on.

It would also allow functions that use **get** to differentiate key containing None from non existent keys. For instance:

```
modified   instance/models/openedx_instance.py
@@ -489,13 +489,13 @@ class OpenEdXInstance(
         version_number = agent.get('version') or 0
         for key, value in configurations.items():
             index, stored_value = agent.get(key, index=True)
-            cas = index if stored_value is not None else 0
-            agent.put(key, value, cas=cas)
+            if index == '0' or value != stored_value:
+                agent.put(key, value, cas=index)
 
-            if not version_updated and value != stored_value:
-                version_updated = True
-                version_number += 1
-                agent.put('version', version_number)
+                if not version_updated:
+                    version_updated = True
+                    version_number += 1
+                    agent.put('version', version_number)
 
         return version_number, version_updated
```