### PR TITLE
[BB-200] add validators for color fields in the registration form

### DIFF
--- a/registration/models.py
+++ b/registration/models.py
@@ -36,6 +36,16 @@ from instance.models.utils import ValidateModelMixin
 
 # Models ######################################################################
 
+def validate_color(color):
+    """
+    Check the color is either #123 or #123456
+    """
+    validators.RegexValidator(
+        r'^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$',
+        '{} is not a valid color, it must be either #123 or #123456'.format(color),
+    )(color)
+
+
 def validate_available_subdomain(subdomain):
     """
     Check that the given subdomain is not blacklisted.
@@ -132,6 +142,7 @@ class BetaTestApplication(ValidateModelMixin, TimeStampedModel):
                   'It is used as filler for buttons.',
         # #126f9a == $m-blue-d3 in variables.scss. It's rgb(18,111,154)
         default='#126f9a',
+        validators=[validate_color],
     )
     link_color = models.CharField(
         max_length=7,
@@ -139,7 +150,7 @@ class BetaTestApplication(ValidateModelMixin, TimeStampedModel):
                   'instance.',
         # Same as main_color. Almost like openedx's #0075b4 == rgb(0, 117, 180)
         default='#126f9a',
-
+        validators=[validate_color],
     )
     header_bg_color = models.CharField(
         max_length=7,
@@ -147,6 +158,7 @@ class BetaTestApplication(ValidateModelMixin, TimeStampedModel):
         help_text='Used as the background color for the top bar.',
         # openedx also uses white by default
         default='#ffffff',
+        validators=[validate_color],
     )
     footer_bg_color = models.CharField(
         max_length=7,
@@ -154,6 +166,7 @@ class BetaTestApplication(ValidateModelMixin, TimeStampedModel):
         help_text='Used as the background color for the footer.',
         # openedx also uses white by default
         default='#ffffff',
+        validators=[validate_color],
     )
     # If you're using SWIFT (OpenStack) to store files (this is enabled through
     # the MEDIAFILES_SWIFT_ENABLE environment variable) then you'll need to

--- a/registration/tests/test_views.py
+++ b/registration/tests/test_views.py
@@ -475,6 +475,23 @@ class BetaTestApplicationViewTestCase(BetaTestApplicationViewTestMixin,
     url = reverse('registration:register')
     request_method = 'post'
 
+    def test_invalid_color(self):
+        """
+        Colors that are not in the expected format
+        Note: this does not need testing in the browser, only server side
+              because the color picker already does the sanity checks
+              for fields of type=color
+        """
+        color_fields = ('main_color', 'link_color', 'footer_bg_color', 'header_bg_color')
+        bad_color = '#1234'
+        expected_errors = {}
+        for field in color_fields:
+            self.form_data[field] = bad_color
+            expected_errors[field] = [
+                '{} is not a valid color, it must be either #123 or #123456'.format(bad_color)
+            ]
+        self._assert_registration_fails(self.form_data, expected_errors=expected_errors)
+
     def test_modify_immutable_fields(self):
         """
         Check that non-modifiable fields cannot be modified once a user has

--- a/registration/tests/utils.py
+++ b/registration/tests/utils.py
@@ -77,12 +77,14 @@ class BrowserTestMixin:
                     # Before moving on, make sure checkbox state (checked/unchecked) corresponds to desired value
                     WebDriverWait(self.client, timeout=5) \
                         .until(expected_conditions.element_selection_state_to_be(element, value))
-            elif element.get_attribute('type') == 'color':
-                # Selenium doesn't support typing into HTML5 color field with send_keys, so we use JS to change it
-                # See https://stackoverflow.com/a/43404924
+                continue
+
+            if element.get_attribute('type') == 'color':
+                # Selenium doesn't support typing into HTML5 color field with send_keys
                 id_elem = element.get_attribute('id')
-                self.client.execute_script("document.getElementById('{}').value='{}'".format(id_elem, value))
-            elif not element.get_attribute('readonly') and not element.get_attribute('type') == 'hidden':
+                self.client.execute_script("document.getElementById('{}').type='text'".format(id_elem))
+
+            if not element.get_attribute('readonly') and not element.get_attribute('type') == 'hidden':
                 element.clear()
                 element.send_keys(value)
                 # Before moving on, make sure input field contains desired text


### PR DESCRIPTION
### Implementation notes

The regex validation only happens when the form is submitted for the same reason [subdomain needs a special patch|https://github.com/open-craft/opencraft/blob/914b759abd4e99c48f3514177b34e0436898dc47/registration/forms.py#L180]. This is not a problem however since this validation is only a safeguard against the **very** rare case where someone (or a program) fills the registration form without the help of a color picker.

### Instructions to test manually:

* make run.dev
* firefox http://localhost:5000/registration
* remove **type="color"** from one color field (right click + inspect)
* enter **#1234** in the field revealed
* enter all required values in the form
* click the submit button
* check there is an error message under the field looking like this:

![z](https://user-images.githubusercontent.com/46968996/54061314-980e0680-4200-11e9-8232-06c997fd74a8.png)

