### PR TITLE
[BB-1072] consul: replace lock with a transaction

### DIFF
--- a/instance/management/commands/update_metadata.py
+++ b/instance/management/commands/update_metadata.py
@@ -84,12 +84,12 @@ class Command(BaseCommand):
         metadata from Consul.
         """
         instances_ids = self.get_archived_instances()
-        with ConsulAgent() as agent:
-            self.stdout.write('Cleaning metadata for {} archived instances...'.format(len(instances_ids)))
-            for instances_id in instances_ids:
-                prefix = settings.CONSUL_PREFIX.format(ocim=settings.OCIM_ID, instance=instances_id)
-                agent.delete(prefix, recurse=True)
-            self.stdout.write(self.style.SUCCESS('Successfully cleaned archived instances\' metadata'))
+        agent = ConsulAgent()
+        self.stdout.write('Cleaning metadata for {} archived instances...'.format(len(instances_ids)))
+        for instances_id in instances_ids:
+            prefix = settings.CONSUL_PREFIX.format(ocim=settings.OCIM_ID, instance=instances_id)
+            agent.delete(prefix, recurse=True)
+        self.stdout.write(self.style.SUCCESS('Successfully cleaned archived instances\' metadata'))
 
     @staticmethod
     def get_running_instances():

--- a/instance/models/openedx_instance.py
+++ b/instance/models/openedx_instance.py
@@ -482,18 +482,7 @@ class OpenEdXInstance(
         :return: A pair (version, changed) with the current version number and
                  a bool to indicate whether the information was updated.
         """
-        with ConsulAgent(prefix=self.consul_prefix) as agent:
-            version_updated = False
-            version_number = agent.get('version') or 0
-            for key, value in configurations.items():
-                stored_value = agent.get(key)
-                agent.put(key, value)
-                if not version_updated and value != stored_value:
-                    version_updated = True
-                    version_number += 1
-                    agent.put('version', version_number)
-
-        return version_number, version_updated
+        return ConsulAgent(prefix=self.consul_prefix).txn_put(configurations)
 
     def update_consul_metadata(self):
         """

--- a/instance/models/utils.py
+++ b/instance/models/utils.py
@@ -552,29 +552,15 @@ class ConsulAgent(object):
     @staticmethod
     def _cast_value(value):
         """
-        Will decode the value to make it a string object, then tries to cast it
-        the proper data-type as we're expecting.
-        Currently supporting the following data-types:
-            * int
-            * float
-            * list
-            * dict
-            * string
-        :param value: The fetched value from Consul to be checked.
+        Will decode the value to make it a string object, then json.loads
+        it. If the json string cannot be decoded for any reason, return the
+        string object.
+
+        :param value: The fetched value from Consul to be converted.
         :return: The casted value if the data-type identified, an str object of
                  the value if not
         """
-        value = value.decode('latin-1') if value else None
-
-        try:
-            return int(value)
-        except (ValueError, TypeError):
-            pass
-
-        try:
-            return float(value)
-        except (ValueError, TypeError):
-            pass
+        value = value.decode('utf-8') if value else None
 
         try:
             return json.loads(value)

--- a/instance/tests/models/test_utils.py
+++ b/instance/tests/models/test_utils.py
@@ -873,7 +873,7 @@ class ConsulAgentTest(TestCase):
         floats, lists, dictionaries and strings
         """
         self.assertEqual(self.agent._cast_value(b'string'), 'string')
-        self.assertEqual(self.agent._cast_value(bytes('ãáé string', 'latin-1')), 'ãáé string')
+        self.assertEqual(self.agent._cast_value(bytes('ãáé string', 'utf-8')), 'ãáé string')
         self.assertEqual(self.agent._cast_value(b'1'), 1)
         self.assertEqual(self.agent._cast_value(b'1.3'), 1.3)
 


### PR DESCRIPTION
the _write_metadata_to_consul function is the only function writing the configuration to consul and there are no other software writing the same keys. There is no need for a lock and a transaction ensuring the entire configuration is written as an atomic operation is enough.

distributed locks lead to subtle bugs that are hard to debug and diagnose