### PR TITLE
BB-839 update integration tests to use Hawthorn

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -84,7 +84,7 @@ jobs:
           command: |
             . venv/bin/activate
             bin/run-circleci-tests
-          no_output_timeout: 47m
+          no_output_timeout: 6h
           environment:
             ANSIBLE_HOST_KEY_CHECKING: False
   cleanup:

--- a/cleanup_utils/integration_cleanup.py
+++ b/cleanup_utils/integration_cleanup.py
@@ -106,6 +106,7 @@ def run_integration_cleanup(dry_run=False):
         age_limit=DEFAULT_AGE_LIMIT,
         url=os.environ['DEFAULT_INSTANCE_MYSQL_URL'],
         domain=os.environ['DEFAULT_INSTANCE_BASE_DOMAIN'],
+        drop_dbs_and_users=os.environ.get('DROP_INTEGRATION_DBS_AND_USERS', 'False').lower() == 'true',
         dry_run=dry_run
     )
     mysql_cleanup.run_cleanup()

--- a/cleanup_utils/mysql_cleanup.py
+++ b/cleanup_utils/mysql_cleanup.py
@@ -60,15 +60,44 @@ def _get_cursor(url):
 
 class MySqlCleanupInstance:
     """
-    Handles the cleanup of old MySQL databases
+    Handles the cleanup of old and integration MySQL databases and users.
+
+    Examples:
+        Deleting old integration databases:
+        >>> mysql_cleanup = MySqlCleanupInstance(
+        ...     age_limit=DEFAULT_AGE_LIMIT,
+        ...     url=os.environ['DEFAULT_INSTANCE_MYSQL_URL'],
+        ...     domain=os.environ['DEFAULT_INSTANCE_BASE_DOMAIN'],
+        ...     drop_dbs_and_users=False,
+        ...     dry_run=dry_run
+        ... )
+        >>> mysql_cleanup.run_cleanup()
+
+        Deleting all databases and users created for integration tests.
+        >>> mysql_cleanup = MySqlCleanupInstance(
+        ...     age_limit=DEFAULT_AGE_LIMIT,
+        ...     url=os.environ['DEFAULT_INSTANCE_MYSQL_URL'],
+        ...     domain=os.environ['DEFAULT_INSTANCE_BASE_DOMAIN'],
+        ...     drop_dbs_and_users=True,
+        ...     dry_run=dry_run
+        ... )
+        >>> mysql_cleanup.drop_integration_dbs_and_users()
     """
-    def __init__(self, age_limit, url, domain, dry_run):
+    def __init__(self, age_limit, url, domain, drop_dbs_and_users, dry_run):
         """
         Set up variables needed for cleanup
+
+        Args:
+            age_limit (int): Age limit to filter older databases in hours.
+            url (str): MySQL server url in the form mysql://[user]:[pwd]@[host]:[port]/
+            domain_suffix (str): Domain suffix used to create databses.
+            drop_dbs_and_users (bool): If `True` all DBs and users used in integration tests will be dropped.
+            dry_run (bool): If it's `True` no actions will be commited to the server.
         """
         self.age_limit = age_limit
         self.cleaned_up_hashes = []
         self.domain_suffix = domain.replace('.', '_')
+        self.drop_dbs_and_users = drop_dbs_and_users
         self.dry_run = dry_run
         self.cursor = _get_cursor(url)
 
@@ -96,6 +125,107 @@ class MySqlCleanupInstance:
             return []
         return self.cursor.fetchall()
 
+    def _get_integration_databases(self):
+        """
+        List of integration databases.
+        """
+        if not self.cursor:
+            logger.error('ERROR: Not connected to the database')
+            return []
+
+        query = (
+            "SELECT Db from mysql.db where Db REGEXP 'integration_{domain_suffix}'".format(
+                domain_suffix=self.domain_suffix
+            )
+        )
+        try:
+            self.cursor.execute(query)
+        except MySQLError as exc:
+            logger.exception('Unable to retrieve integrations databases: %s', exc)
+            return []
+        return self.cursor.fetchall()
+
+    def _get_db_users(self, hash_prefix):
+        """
+        List of users filtering on a hash prefix.
+
+        Args:
+            hash_prefix (str): Hash prefix used to filter users.
+
+        Returs:
+            [tuple]: List of tuples with usernames.
+        """
+        if not self.cursor:
+            logger.error('ERROR: Not connected to the database')
+            return []
+        prefix = "{hash_prefix}\\_%%".format(hash_prefix=hash_prefix)
+        try:
+            self.cursor.execute("SELECT User from mysql.user where User like %(prefix)s", {"prefix": prefix})
+        except MySQLError as exc:
+            logger.exception('Unable to retrieve old databases: %s', exc)
+            return []
+        return self.cursor.fetchall()
+
+    def _get_integration_users(self):
+        """
+        List of users used in integration tests.
+        """
+        if not self.cursor:
+            logger.error('ERROR: Not connected to the database')
+            return []
+
+        try:
+            self.cursor.execute(
+                """SELECT User from mysql.user where
+                    User LIKE '%\\_ecommerce' OR
+                    User LIKE '%\\_dashboard' OR
+                    User LIKE '%\\_xqueue' OR
+                    User LIKE '%\\_edxapp' OR
+                    User LIKE '%\\_notes' OR
+                    User LIKE '%\\_notifier' OR
+                    User LIKE '%\\_api' OR
+                    User LIKE '%\\_discovery' OR
+                    User LIKE '%\\_reports' OR
+                    User LIKE '%\\_program' OR
+                    User LIKE '%\\_migrate' OR
+                    User LIKE '%\\_read_only' OR
+                    User LIKE '%\\_admin'"""
+            )
+        except MySQLError as exc:
+            logger.exception('Unable to retrieve integration users: %s', exc)
+            return []
+        return self.cursor.fetchall()
+
+    def _drop_db(self, database):
+        """
+        Drop a single database.
+
+        Args:
+            database (str): Database name.
+        """
+        if not self.dry_run:
+            try:
+                self.cursor.execute(
+                    'DROP DATABASE IF EXISTS `{}`'.format(database)
+                )
+            except MySQLError as exc:
+                logger.exception(
+                    'Unable to remove MySQL DB: %s. %s', database, exc
+                )
+
+    def _drop_user(self, username):
+        """
+        Drop a single username.
+
+        Args:
+            username (str): Username.
+        """
+        if not self.dry_run:
+            try:
+                self.cursor.execute('DROP USER `{username}`'.format(username=username))
+            except MySQLError as exc:
+                logger.exception('Unable to drop user: %s. %s', username, exc)
+
     def run_cleanup(self):
         """
         Runs the cleanup of MySQL databases older than the age limit
@@ -104,7 +234,14 @@ class MySqlCleanupInstance:
 
         if self.dry_run:
             logger.info("Running in DRY_RUN mode, no actions will be taken.")
+        self.drop_old_dbs()
+        if self.drop_dbs_and_users:
+            self.drop_integration_dbs_and_users()
 
+    def drop_old_dbs(self):
+        """
+        Drop databases older than `age_limit`.
+        """
         databases = self._get_old_databases()
         logger.info('Found %d old databases', len(databases))
 
@@ -115,7 +252,7 @@ class MySqlCleanupInstance:
             # databases so they can be returned to the calling script and used
             # in DNS cleanup.
             logger.info('  > Considering database %s', database)
-            instance_database_re = r'^([0-9a-f]{8})([_0-9a-z]+)?_%s' % (self.domain_suffix,)
+            instance_database_re = r'^([0-9a-f]{6,8})([_0-9a-z]+)?_%s_[a-z0-9\_]+' % (self.domain_suffix,)
             match = re.match(instance_database_re, database)
             if not match:
                 logger.info(
@@ -123,18 +260,42 @@ class MySqlCleanupInstance:
                     instance_database_re
                 )
                 continue
-
+            db_hash = match.groups()[0]
             logger.info(
-                '    * Dropping MySQL DB `%s` created at %s', database,
+                '    * Dropping MySQL DB %s created at %s', database,
                 datetime.strftime(create_date, '%Y-%m-%dT%H:%M:%SZ')
             )
-            if not self.dry_run:
-                try:
-                    self.cursor.execute(
-                        'DROP DATABASE IF EXISTS {}'.format(database)
-                    )
-                    self.cleaned_up_hashes.append(match.groups()[0])
-                except MySQLError as exc:
-                    logger.exception(
-                        'Unable to remove MySQL DB: %s. %s', database, exc
-                    )
+            self._drop_db(database)
+            self.cleaned_up_hashes.append(db_hash)
+            self.drop_db_users(db_hash)
+
+    def drop_db_users(self, db_hash):
+        """
+        Drop DB Users based on hash prefix. When DBs and Users are created in integration tests
+        the same hash prefix is used for the database and for each user. Based on this prefix
+        we can also drop all users related to a database.
+
+        Args:
+            db_hash (str): Database hash prefix.
+        """
+        users = self._get_db_users(db_hash)
+        for user in users:
+            username = user[0]
+            logger.info('   * Dropping MySQL User %s', username)
+            self._drop_user(username)
+
+    def drop_integration_dbs_and_users(self):
+        """
+        Drop every database and user used in integration tests.
+        """
+        dbs = self._get_integration_databases()
+        for db in dbs:
+            database = db[0]
+            logger.info('    * Dropping MySQL Databse %s', database)
+            self._drop_db(database)
+
+        users = self._get_integration_users()
+        for user in users:
+            username = user[0]
+            logger.info('   * Dropping MySQL User %s', username)
+            self._drop_user(username)

--- a/instance/ansible.py
+++ b/instance/ansible.py
@@ -212,9 +212,9 @@ def capture_playbook_output(
                         logger_.error(line)
                 if collect_logs:
                     log_lines.append(line)
-        except TimeoutError:
+        except TimeoutError as exc:
             if logger_ is not None:
-                logger_.error('Playbook run timed out.  Terminating the Ansible process.')
+                logger_.exception('Playbook run timed out.  Terminating the Ansible process: %s', exc)
             process.terminate()
         process.wait()
         if collect_logs:

--- a/instance/models/openedx_instance.py
+++ b/instance/models/openedx_instance.py
@@ -69,6 +69,11 @@ class OpenEdXInstance(
 
     successfully_provisioned = models.BooleanField(default=False)
 
+    def __init__(self, *args, **kwargs):
+        """Init."""
+        self.random_prefix = kwargs.pop('random_prefix', None)
+        super().__init__(*args, **kwargs)
+
     class Meta:
         verbose_name = 'Open edX Instance'
 
@@ -115,6 +120,9 @@ class OpenEdXInstance(
         # based on the openedx release
         if not self.configuration_playbook_name:
             self.configuration_playbook_name = get_base_playbook_name(self.openedx_release)
+
+        if self.random_prefix is not None:
+            self.mysql_user = self.random_prefix
 
         super().save(**kwargs)
         self.update_consul_metadata()

--- a/instance/tests/integration/base.py
+++ b/instance/tests/integration/base.py
@@ -59,7 +59,7 @@ class IntegrationTestCase(TestCase):
         for load_balancer in LoadBalancingServer.objects.iterator():
             load_balancer.delete()
         for instance in OpenEdXInstance.objects.iterator():
-            instance.delete()
+            instance.delete(ignore_errors=True)
 
         super().tearDown()
 

--- a/instance/tests/integration/factories/instance.py
+++ b/instance/tests/integration/factories/instance.py
@@ -46,8 +46,9 @@ class OpenEdXInstanceFactory(DjangoModelFactory):
         # random value for 'internal_lms_domain' if neither 'sub_domain' nor 'internal_lms_domain' are provided.
         if 'sub_domain' not in kwargs and 'internal_lms_domain' not in kwargs:
             kwargs = kwargs.copy()
-            random_id = str(uuid.uuid4())[:8]
+            random_id = str(uuid.uuid4())[:6]
             sub_domain = '{}.integration'.format(random_id)
+            kwargs['random_prefix'] = random_id
             kwargs['internal_lms_domain'] = generate_internal_lms_domain(sub_domain)
         return super(OpenEdXInstanceFactory, cls).create(*args, **kwargs)
 
@@ -58,8 +59,8 @@ class OpenEdXInstanceFactory(DjangoModelFactory):
     # or a release candidate tag will work.  We point both the edx-platform and the configuration
     # versions to the branch "integration" in our own forks.  These branches are based on the
     # corresponding openedx_release versions from upstream, but can contain custom modifications.
-    openedx_release = 'open-release/ginkgo.1'
+    openedx_release = 'open-release/hawthorn.1'
     configuration_source_repo_url = 'https://github.com/open-craft/configuration.git'
-    configuration_version = 'integration-ginkgo'
+    configuration_version = 'integration-hawthorn'
     edx_platform_repository_url = 'https://github.com/open-craft/edx-platform.git'
-    edx_platform_commit = 'opencraft-release/ginkgo.1'
+    edx_platform_commit = 'opencraft-release/hawthorn.1'

--- a/instance/tests/integration/integration_instance.py
+++ b/instance/tests/integration/integration_instance.py
@@ -235,7 +235,7 @@ class InstanceIntegrationTestCase(IntegrationTestCase):
 
         # The logo is found in a line like this in the HTML:
         #       <img src="/static/simple-theme/images/logo.82fb8d18479f.png" alt="danieltest1b Home Page"/>
-        logo_extractor = re.search(r'<img src="(/static/simple-theme/images/logo.[a-z0-9]+\.png)" ',
+        logo_extractor = re.search(r'<img\s+class="logo"\s+src="(/static/simple-theme/images/logo.[a-z0-9]+\.png)"',
                                    server_html)
         self.assertTrue(logo_extractor)
         logo_url = logo_extractor.group(1)

--- a/instance/utils.py
+++ b/instance/utils.py
@@ -117,7 +117,7 @@ def poll_streams(*files, line_timeout=None, global_timeout=None):
         available = selector.select(next(timeout))
         if not available:
             # TODO(smarnach): This can also mean that the process received a signal.
-            raise TimeoutError
+            raise TimeoutError('Could not read line before timeout: {timeout}'.format(timeout=timeout))
         for key, unused_mask in available:
             line = key.fileobj.readline()
             if line:

--- a/opencraft/settings.py
+++ b/opencraft/settings.py
@@ -496,7 +496,7 @@ SIMPLE_THEME_SKELETON_THEME_VERSION = env('SIMPLE_THEME_SKELETON_THEME_VERSION',
 ANSIBLE_PYTHON_PATH = env('ANSIBLE_PYTHON_PATH', default='/usr/bin/python')
 
 # Time in seconds to wait for the next log line when running an Ansible playbook.
-ANSIBLE_LINE_TIMEOUT = env.int('ANSIBLE_LINE_TIMEOUT', default=1500)  # 25 minutes
+ANSIBLE_LINE_TIMEOUT = env.int('ANSIBLE_LINE_TIMEOUT', default=7200)  # 2 hours
 
 # Timeout in seconds for an entire Ansible playbook.
 ANSIBLE_GLOBAL_TIMEOUT = env.int('ANSIBLE_GLOBAL_TIMEOUT', default=9000)  # 2.5 hours


### PR DESCRIPTION
This PR updates the integration tests to use hawthorn edx and configuration branches.
While doing the update there was an issue with migrations taking too long. The reason was because the centralized MySQL server used to run integration tests had too many databses and users created. There's a cleanup script that runs on every CirlceCI pipeline that deletes databases older than 8 hours.
The cleanup script was updated. A new method was added to delete every database and user used in integration tests in case we eventually need to delete everything.
Also, the cleanup script (specifically the MySQL part) is using `information_schema.tables` (and there's no other way to do it). The issue is that if a database is created and no tables are added to the database then it will not appear in `information_schema.tables`. This PR also adds a dummy table named `opencraft` to every database created. This will force every database to appear in `information_schema.tables` table. In case creating an app server fails and no tables are created this will allow us to still keep track of old databases. If the instance created is not an integration instance this will not introduce any issues.
This PR also uses the same random prefix to create databases and users. This way if something goes wrong on a CircleCI run we can later check for old databases and delete the databases as well as the users related to those databases because the random prefix used is the same.