### PR TITLE
BB-1081: Disable Studio SSO login

### DIFF
--- a/instance/models/mixins/openedx_config.py
+++ b/instance/models/mixins/openedx_config.py
@@ -208,6 +208,10 @@ class OpenEdXConfigMixin(ConfigMixinBase):
                 "USE_MICROSITES": False,
                 "PREVENT_CONCURRENT_LOGINS": False,
                 "ENABLE_ACCOUNT_DELETION": True,
+                # Disable the unified login from Studio
+                # Since Ironwood, the Studio login changed from a separate login
+                # to using LMS as a SSO provider. This flag disables that behaviour.
+                "DISABLE_STUDIO_SSO_OVER_LMS": True,
                 # These are not part of the standard install:
                 # "CUSTOM_COURSES_EDX": True,
                 # "ENABLE_LTI_PROVIDER": True,
@@ -356,11 +360,6 @@ class OpenEdXConfigMixin(ConfigMixinBase):
                     "FUNCTION": "retirement_lms_retire",
                 },
             ],
-
-            # Disable the unified login from Studio
-            # Since Ironwood, the Studio login changed from a separate login
-            # to using LMS as a SSO provider. This flag disables that behaviour.
-            "DISABLE_STUDIO_SSO_OVER_LMS": True,
         }
 
         if self.smtp_relay_settings:

--- a/instance/models/mixins/openedx_config.py
+++ b/instance/models/mixins/openedx_config.py
@@ -57,9 +57,6 @@ class OpenEdXConfigMixin(ConfigMixinBase):
                 "HEARTBEAT_EXTENDED_CHECKS": [
                     "lms.lib.comment_client.utils.check_forum_heartbeat",
                 ],
-                # Set the LMS session cookie domain to '.<LMS domain>' in preparation for the Studio login
-                # in Ironwood which uses LMS login and requires LMS and Studio to be on cookie-compatible domains
-                "SESSION_COOKIE_DOMAIN": '.{}'.format(self.instance.domain),
             },
             "EDXAPP_LMS_NGINX_PORT": 80,
             "EDXAPP_LMS_SSL_NGINX_PORT": 443,
@@ -358,7 +355,12 @@ class OpenEdXConfigMixin(ConfigMixinBase):
                     "SERVICE": "LMS",
                     "FUNCTION": "retirement_lms_retire",
                 },
-            ]
+            ],
+
+            # Disable the unified login from Studio
+            # Since Ironwood, the Studio login changed from a separate login
+            # to using LMS as a SSO provider. This flag disables that behaviour.
+            "DISABLE_STUDIO_SSO_OVER_LMS": True,
         }
 
         if self.smtp_relay_settings:


### PR DESCRIPTION
This PR disables the Studio login via SSO that was introduced by Ironwood but keeps the subdomain functionality.

### Testing instructions:
1. Go to studio.
2. Check if the Sign In button lead to a login page inside Studio.
3. Check that the login on Studio works.
4. Check that the LMS login works.
5. Do the same steps for the external and internal domain names

### Sandboxes:
**hawthorn.1**: https://stage.console.opencraft.com/instance/3550/
**ironwood.1**: https://stage.console.opencraft.com/instance/3560/
**master**: https://stage.console.opencraft.com/instance/3570/

### Reviewers:
- [ ] @lgp171188 