### PR TITLE
[SE-943] Consul transactions

### DIFF
--- a/instance/management/commands/update_metadata.py
+++ b/instance/management/commands/update_metadata.py
@@ -84,12 +84,12 @@ class Command(BaseCommand):
         metadata from Consul.
         """
         instances_ids = self.get_archived_instances()
-        with ConsulAgent() as agent:
-            self.stdout.write('Cleaning metadata for {} archived instances...'.format(len(instances_ids)))
-            for instances_id in instances_ids:
-                prefix = settings.CONSUL_PREFIX.format(ocim=settings.OCIM_ID, instance=instances_id)
-                agent.delete(prefix, recurse=True)
-            self.stdout.write(self.style.SUCCESS('Successfully cleaned archived instances\' metadata'))
+        agent = ConsulAgent()
+        self.stdout.write('Cleaning metadata for {} archived instances...'.format(len(instances_ids)))
+        for instances_id in instances_ids:
+            prefix = settings.CONSUL_PREFIX.format(ocim=settings.OCIM_ID, instance=instances_id)
+            agent.delete(prefix, recurse=True)
+        self.stdout.write(self.style.SUCCESS('Successfully cleaned archived instances\' metadata'))
 
     @staticmethod
     def get_running_instances():

--- a/instance/models/openedx_instance.py
+++ b/instance/models/openedx_instance.py
@@ -482,18 +482,7 @@ class OpenEdXInstance(
         :return: A pair (version, changed) with the current version number and
                  a bool to indicate whether the information was updated.
         """
-        with ConsulAgent(prefix=self.consul_prefix) as agent:
-            version_updated = False
-            version_number = agent.get('version') or 0
-            for key, value in configurations.items():
-                stored_value = agent.get(key)
-                agent.put(key, value)
-                if not version_updated and value != stored_value:
-                    version_updated = True
-                    version_number += 1
-                    agent.put('version', version_number)
-
-        return version_number, version_updated
+        return ConsulAgent(prefix=self.consul_prefix).txn_put(configurations)
 
     def update_consul_metadata(self):
         """

--- a/instance/models/utils.py
+++ b/instance/models/utils.py
@@ -566,7 +566,7 @@ class ConsulAgent(object):
                 except consul.base.ClientError:
                     if attempt == num_retries:
                         raise
-                    time.sleep(10)
+                    time.sleep(5)
         return version, bool(put)
 
     def get(self, key, index=False, **kwargs):

--- a/instance/models/utils.py
+++ b/instance/models/utils.py
@@ -450,8 +450,19 @@ class ConsulAgent(object):
 
     @staticmethod
     def _tnx_decode(value):
-        "load the json from a txn value"
-        return json.loads(base64.b64decode(value).decode('utf-8'))
+        """
+        Decodes values received in Consul txn
+
+        :param value: base64 encoded value
+        :return: base64 decoded value, JSON decoded if serializable
+        """
+        value = base64.b64decode(value).decode('utf-8')
+        try:
+            # We did conditional JSON encoding before
+            # Now everything should be JSON encoded in _tnx_encode
+            return json.loads(value)
+        except json.JSONDecodeError:
+            return value
 
     @staticmethod
     def _tnx_encode(value):

--- a/instance/models/utils.py
+++ b/instance/models/utils.py
@@ -558,7 +558,7 @@ class ConsulAgent(object):
         # contact Consul & get the key-value tree located at `self.prefix`
         # see settings.CONSUL_PREFIX, e.g. ocim/instances/347/
         for attempt in range(num_retries + 1):
-            put, version = self._get_put_data(updates)
+            version, put = self._get_put_data(updates)
             if put:
                 try:
                     self._client.txn.put(put)

--- a/instance/models/utils.py
+++ b/instance/models/utils.py
@@ -542,7 +542,7 @@ class ConsulAgent(object):
                     self.prefix + "version", version, existing['version']["ModifyIndex"]))
             else:
                 put.append(self._tnx_set(self.prefix + "version", 1))
-            return put, version
+        return version, bool(put)
 
     def txn_put(self, updates, num_retries=3):
         """

--- a/instance/tests/models/test_utils.py
+++ b/instance/tests/models/test_utils.py
@@ -873,7 +873,7 @@ class ConsulAgentTest(TestCase):
         floats, lists, dictionaries and strings
         """
         self.assertEqual(self.agent._cast_value(b'string'), 'string')
-        self.assertEqual(self.agent._cast_value(bytes('ãáé string', 'latin-1')), 'ãáé string')
+        self.assertEqual(self.agent._cast_value(bytes('ãáé string', 'utf-8')), 'ãáé string')
         self.assertEqual(self.agent._cast_value(b'1'), 1)
         self.assertEqual(self.agent._cast_value(b'1.3'), 1.3)
 


### PR DESCRIPTION
We currently use [consul locks](https://github.com/open-craft/opencraft/blob/master/instance/models/utils.py#L468) to prevent race conditions between Ocim, cert-manager and other consul clients. However, the `ConsulAgent` class [here](https://github.com/open-craft/opencraft/blob/master/instance/models/utils.py#L447) is the only piece of code that writes instance/appserver configuration to Consul and all the other clients only read it. Due to the locking and the delays associated with locking and releasing the locks when there are multiple clients trying to acquire the lock, we often run into the `ConsulLockAcquisitionException` error due to one of the Ocim processes being unable to acquire the lock due to some reason - too much contention for the lock is a prime example.

By using [Consul transactions](https://www.consul.io/api/txn.html), which are atomic, we do not need locks and all the clients reading the information will only read the consistent values.