### PR TITLE
BB-1137 Add terminate button to app server UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@ may be required in some high-resource-utilization cases.
 Before activating a server, there's the option to test it through a
 basic-auth password-protected link in the "Authenticated Link" section
 (the username and password are embedded in the link).
+If you want to terminate a VM associated with an App Server, first you must
+**deactivate** it and then **terminate**. Notice that only instances with an
+associated pull request can have all its App Servers deactivates/terminated.
 
 Sometimes Open edX playbook fails, and then you need to read the log,
 which is shown in real-time in the web console.

--- a/instance/api/openedx_appserver.py
+++ b/instance/api/openedx_appserver.py
@@ -120,3 +120,16 @@ class OpenEdXAppServerViewSet(viewsets.ReadOnlyModelViewSet):
         app_server = self.get_object()
         make_appserver_active(app_server.pk, active=False)
         return Response({'status': 'App server deactivation initiated.'})
+
+    @detail_route(methods=['post'])
+    def terminate(self, request, pk):
+        """
+        Terminate the VM running the provided AppServer.
+        """
+        app_server = self.get_object()
+        if app_server.is_active:
+            return Response({
+                'error': 'Cannot terminate an active app server.'
+            }, status=status.HTTP_400_BAD_REQUEST)
+        app_server.terminate_vm()
+        return Response({'status': 'App server termination initiated.'})

--- a/instance/static/html/instance/appserver.html
+++ b/instance/static/html/instance/appserver.html
@@ -46,7 +46,7 @@
       </tbody>
     </table>
 
-    <button ng-disabled="is_active !== false || !appserver.is_healthy"
+    <button ng-disabled="is_active !== false || !is_running"
             tooltip="This will add this app server to the load balancer pool for this instance."
             tooltip-placement="top"
             ng-click="make_appserver_active(true)">

--- a/instance/static/html/instance/appserver.html
+++ b/instance/static/html/instance/appserver.html
@@ -46,14 +46,14 @@
       </tbody>
     </table>
 
-    <button ng-disabled="is_active || appserver.status !== 'running'"
+    <button ng-disabled="is_active !== false || !appserver.is_healthy"
             tooltip="This will add this app server to the load balancer pool for this instance."
             tooltip-placement="top"
             ng-click="make_appserver_active(true)">
       Activate
     </button>
 
-    <button ng-disabled="!is_active || (!instance.source_pr && instance.active_appservers.length < 2)"
+    <button ng-disabled="is_active !== true || (!instance.source_pr && instance.active_appservers.length < 2)"
             tooltip="This will remove this app server from the load balancer pool for this instance."
             tooltip-placement="top"
             ng-click="make_appserver_active(false)">
@@ -61,7 +61,7 @@
     </button>
 
     <button class="alert"
-            ng-disabled="!vm_running || is_active"
+            ng-disabled="is_active !== false || !vm_running"
             tooltip="This will terminate the app server virtual machine."
             tooltip-placement="top"
             ng-click="terminate_appserver()">

--- a/instance/static/html/instance/appserver.html
+++ b/instance/static/html/instance/appserver.html
@@ -46,18 +46,26 @@
       </tbody>
     </table>
 
-    <button ng-disabled="is_active || !appserver.is_healthy"
+    <button ng-disabled="is_active || appserver.status !== 'running'"
             tooltip="This will add this app server to the load balancer pool for this instance."
-            tooltip-placement="below"
+            tooltip-placement="top"
             ng-click="make_appserver_active(true)">
-      Activate this app server
+      Activate
     </button>
 
-    <button ng-disabled="!is_active || instance.active_appservers.length < 2"
+    <button ng-disabled="!is_active || (!instance.source_pr && instance.active_appservers.length < 2)"
             tooltip="This will remove this app server from the load balancer pool for this instance."
-            tooltip-placement="below"
+            tooltip-placement="top"
             ng-click="make_appserver_active(false)">
-      Deactivate this app server
+      Deactivate
+    </button>
+
+    <button class="alert"
+            ng-disabled="!vm_running || is_active"
+            tooltip="This will terminate the app server virtual machine."
+            tooltip-placement="top"
+            ng-click="terminate_appserver()">
+      Terminate
     </button>
   </accordion-group>
 

--- a/instance/static/html/instance/index.html
+++ b/instance/static/html/instance/index.html
@@ -20,7 +20,7 @@
              ng-class="{healthy: newer_appserver.is_healthy, unhealthy: newer_appserver.is_healthy === false}"
              tooltip="{{newer_appserver.name}} (newer than the active appserver): {{ newer_appserver.status_description }}"
              tooltip-placement="bottom" tooltip-append-to-body="true">
-          <i ng-attr-class="{{ newer_appserver.is_steady && (newer_appserver.is_healthy && 'fa fa-check' || 'fa fa-times') || 'fa fa-ellipsis-h' }}"></i>
+          <i ng-attr-class="{{ newer_appserver.is_steady && (newer_appserver.is_healthy && !newer_appserver.terminated && 'fa fa-check' || 'fa fa-times') || 'fa fa-ellipsis-h' }}"></i>
         </div>
         <div class="status-icon-newest" ng-if="!newer_appserver" tooltip="No newer appserver"
              tooltip="No newer appserver"

--- a/instance/static/js/src/openedx_appserver.js
+++ b/instance/static/js/src/openedx_appserver.js
@@ -48,6 +48,7 @@ app.controller("OpenEdXAppServerDetails", ['$scope', '$state', '$stateParams', '
                     throw "This appserver is associated with another instance.";
                 }
                 $scope.appserver = appserver;
+                $scope.vm_running = appserver.status === 'configuring' || appserver.status === 'running' || appserver.status === 'failed';
                 $scope.is_active = appserver.is_active;
             }, function() {
                 $scope.notify("Unable to load the appserver details.");
@@ -76,6 +77,20 @@ app.controller("OpenEdXAppServerDetails", ['$scope', '$state', '$stateParams', '
                 $scope.fetchLogs();
             }
         });
+
+        $scope.terminate_appserver = function() {
+            OpenCraftAPI.one("openedx_appserver", $stateParams.appserverId).post('terminate').then(function() {
+                // Refresh the list of app servers in the instance scope, then refresh this appserver
+                $scope.$parent.refresh().then(function() {
+                    $scope.refresh();
+                });
+                $scope.notify($scope.appserver.name + ' is now being terminated');
+
+            }, function() {
+                $scope.refresh();
+                $scope.notify('An error occurred. ' + $scope.appserver.name + ' could not be terminated.', 'alert');
+            });
+        }
 
         $scope.make_appserver_active = function(active) {
             var action = active ? 'active' : 'inactive';

--- a/instance/static/js/src/openedx_appserver.js
+++ b/instance/static/js/src/openedx_appserver.js
@@ -90,7 +90,7 @@ app.controller("OpenEdXAppServerDetails", ['$scope', '$state', '$stateParams', '
                 $scope.refresh();
                 $scope.notify('An error occurred. ' + $scope.appserver.name + ' could not be terminated.', 'alert');
             });
-        }
+        };
 
         $scope.make_appserver_active = function(active) {
             var action = active ? 'active' : 'inactive';

--- a/instance/static/js/src/openedx_appserver.js
+++ b/instance/static/js/src/openedx_appserver.js
@@ -94,7 +94,7 @@ app.controller("OpenEdXAppServerDetails", ['$scope', '$state', '$stateParams', '
 
         $scope.make_appserver_active = function(active) {
             var action = active ? 'active' : 'inactive';
-            $scope.is_active = active; // Toggle the button optimistically
+            $scope.is_active = null; // Toggle all buttons off
             OpenCraftAPI.one("openedx_appserver", $stateParams.appserverId).post('make_' + action).then(function() {
                 // Refresh the list of app servers in the instance scope, then refresh this appserver
                 $scope.$parent.refresh().then(function() {

--- a/instance/static/js/src/openedx_appserver.js
+++ b/instance/static/js/src/openedx_appserver.js
@@ -80,6 +80,7 @@ app.controller("OpenEdXAppServerDetails", ['$scope', '$state', '$stateParams', '
         });
 
         $scope.terminate_appserver = function() {
+            $scope.is_active = null; // Toggle all buttons off
             OpenCraftAPI.one("openedx_appserver", $stateParams.appserverId).post('terminate').then(function() {
                 // Refresh the list of app servers in the instance scope, then refresh this appserver
                 $scope.$parent.refresh().then(function() {

--- a/instance/static/js/src/openedx_appserver.js
+++ b/instance/static/js/src/openedx_appserver.js
@@ -48,8 +48,9 @@ app.controller("OpenEdXAppServerDetails", ['$scope', '$state', '$stateParams', '
                     throw "This appserver is associated with another instance.";
                 }
                 $scope.appserver = appserver;
-                $scope.vm_running = appserver.status === 'configuring' || appserver.status === 'running' || appserver.status === 'failed';
                 $scope.is_active = appserver.is_active;
+                $scope.is_running = appserver.status === 'running';
+                $scope.vm_running = appserver.status === 'configuring' || appserver.status === 'running' || appserver.status === 'failed';
             }, function() {
                 $scope.notify("Unable to load the appserver details.");
             });

--- a/instance/static/js/src/openedx_appserver.js
+++ b/instance/static/js/src/openedx_appserver.js
@@ -50,7 +50,7 @@ app.controller("OpenEdXAppServerDetails", ['$scope', '$state', '$stateParams', '
                 $scope.appserver = appserver;
                 $scope.is_active = appserver.is_active;
                 $scope.is_running = appserver.status === 'running';
-                $scope.vm_running = appserver.status === 'configuring' || appserver.status === 'running' || appserver.status === 'failed';
+                $scope.vm_running = appserver.server.status === 'ready';
             }, function() {
                 $scope.notify("Unable to load the appserver details.");
             });

--- a/instance/tests/api/test_openedx_appserver.py
+++ b/instance/tests/api/test_openedx_appserver.py
@@ -499,6 +499,9 @@ class OpenEdXAppServerAPITerminate(APITestCase):
         self.api_client.login(username='user3', password='pass')
 
     def _create_appserver(self, is_active):
+        """
+        Creates test instance and app server
+        """
         instance = OpenEdXInstanceFactory(edx_platform_commit='1' * 40)
         server = ReadyOpenStackServerFactory()
         app_server = make_test_appserver(instance=instance, server=server)


### PR DESCRIPTION
## Description
This change will allow for manual termination of app servers. This will be allowed for app servers that are not active and instances created from pull requests will be able to deactivate/terminate all app servers.

## Testing
1. Checkout this branch.
2. Create a test instance with an associated pull request and another one without it.
3. Manually add appservers in states such as `new`, `failed`, `running` and `configuring` to evaluate the UI behavior.
4. Check that only appservers in `running` state can be made active.
5. Make sure that only inactive appservers in `configuring`, `running` and `failed` can be terminated.

If it fails to mark an appserver active/inactive, make sure there's an associated server in the correct state:
```
In [25]: for apps in OpenEdXAppServer.objects.filter(_is_active=True):
    ...:     apps.server = OpenStackServer.objects.create(name_prefix='test', _status='ready', _public_ip='0.0.0.0')
    ...:     apps.save()
```