### PR TITLE
[BB-1216] Ironwood changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -499,7 +499,8 @@ set the following configuration variables:
 * `EDX_WORKERS_ENABLE_CELERY_HEARTBEATS`: Switch to enable/disable celery
   heartbeats used to detect connection drops. Disabling heartbeats can have a
   drastic reduction RabbitMQ usage. This setting sets
-  `worker_django_enable_heartbeats` on supported playbooks. Defaults to `False`.
+  `worker_django_enable_heartbeats` and `EDXAPP_CELERY_HEARTBEAT_ENABLED` on
+  supported playbooks. Defaults to `False`.
 
 Migrations
 ----------

--- a/instance/models/mixins/openedx_config.py
+++ b/instance/models/mixins/openedx_config.py
@@ -312,6 +312,10 @@ class OpenEdXConfigMixin(ConfigMixinBase):
             # in Ocim deployments.
             # Disabling heartbeats can have a drastic reduction RabbitMQ usage.
             "worker_django_enable_heartbeats": settings.EDX_WORKERS_ENABLE_CELERY_HEARTBEATS,
+            # The "worker_django_enable_heartbeats" variable was changed in the upstream PR
+            # merged to master (but not cherry-picked to Ironwood) to "EDXAPP_CELERY_HEARTBEAT_ENABLED".
+            # Both are present for backward-compatibility for the time-being.
+            "EDXAPP_CELERY_HEARTBEAT_ENABLED": settings.EDX_WORKERS_ENABLE_CELERY_HEARTBEATS,
 
             # Set up User Retirement Pipeline
             "RETIREMENT_SERVICE_SETUP": True,

--- a/instance/models/mixins/openedx_storage.py
+++ b/instance/models/mixins/openedx_storage.py
@@ -54,6 +54,10 @@ class OpenEdXStorageMixin(StorageContainer, SwiftContainerInstanceMixin, S3Bucke
         """
         s3_settings = {
             "COMMON_ENABLE_AWS_INTEGRATION": True,
+            # In Ironwood, the "COMMON_ENABLE_AWS_INTEGRATION" variable has been replaced by the
+            # "COMMON_ENABLE_AWS_ROLE" variable. Retaining both for backward compatibility till
+            # the former can be removed.
+            "COMMON_ENABLE_AWS_ROLE": True,
             "AWS_ACCESS_KEY_ID": self.s3_access_key,
             "AWS_SECRET_ACCESS_KEY": self.s3_secret_access_key,
 

--- a/instance/tests/models/test_openedx_storage_mixins.py
+++ b/instance/tests/models/test_openedx_storage_mixins.py
@@ -117,6 +117,7 @@ def get_s3_settings(instance):
     """
     s3_settings = {
         "COMMON_ENABLE_AWS_INTEGRATION": 'true',
+        "COMMON_ENABLE_AWS_ROLE": 'true',
         "AWS_ACCESS_KEY_ID": instance.s3_access_key,
         "AWS_SECRET_ACCESS_KEY": instance.s3_secret_access_key,
 


### PR DESCRIPTION
* Add the new ansible variable which enables installing the `aws` role in Ironwood. Retain the old one for backward compatibility till all the instances are upgraded to Ironwood.
* Add the new ansible variable for disabling celery heartbeats as merged upstream. Retain the old one for backward compatibility till all the instances are upgraded to Ironwood.

**Testing instructions**:
* Spawn an appserver with this PR and verify that it works correctly. There is [an instance]( https://ironwood-config.sandbox.stage.opencraft.hosting/) spawned for testing the configuration branch PR with this PR deployed on stage.