### PR TITLE
Fix a bug causing the load balancer configuration fragments to not get cleaned up and a datetime warning

### DIFF
--- a/cleanup_utils/load_balancer_cleanup.py
+++ b/cleanup_utils/load_balancer_cleanup.py
@@ -63,7 +63,7 @@ class LoadBalancerCleanup:
         ).format(
             age_limit=self.age_limit,
             fragment_prefix=self.fragment_prefix,
-            remove_fragments='true' if self.dry_run else 'false'
+            remove_fragments='true' if not self.dry_run else 'false'
         )
 
         return_code = ansible.capture_playbook_output(

--- a/instance/tests/integration/integration_instance.py
+++ b/instance/tests/integration/integration_instance.py
@@ -422,7 +422,6 @@ class InstanceIntegrationTestCase(IntegrationTestCase):
         # stdout should contain 3 lines (as opposed to 2) to account for the last newline.
         self.assertEqual(len(out_lines), 3)
 
-    @shard(3)
     @patch_git_checkout
     @override_settings(INSTANCE_STORAGE_TYPE='s3')
     def test_ansible_failure(self, git_checkout, git_working_dir):
@@ -443,7 +442,6 @@ class InstanceIntegrationTestCase(IntegrationTestCase):
         self.assertEqual(appserver.status, AppServerStatus.ConfigurationFailed)
         self.assertEqual(appserver.server.status, ServerStatus.Ready)
 
-    @shard(1)
     @patch_git_checkout
     @patch("instance.models.openedx_appserver.OpenEdXAppServer.heartbeat_active")
     @override_settings(INSTANCE_STORAGE_TYPE='s3')
@@ -466,7 +464,6 @@ class InstanceIntegrationTestCase(IntegrationTestCase):
         self.assertEqual(active_appservers[0].status, AppServerStatus.Running)
         self.assertEqual(active_appservers[0].server.status, ServerStatus.Ready)
 
-    @shard(1)
     @override_settings(INSTANCE_STORAGE_TYPE='s3')
     def test_openstack_server_terminated(self):
         """

--- a/registration/tests/test_provision.py
+++ b/registration/tests/test_provision.py
@@ -43,7 +43,7 @@ class ApprovalTestCase(TestCase):
         user = get_user_model().objects.create_user(username='test', email='test@example.com')
         with freeze_time('2019-01-02 09:30:00') as frozen_time:
             accepted_time = utc.localize(frozen_time())
-            accepted_time = accepted_time.strftime('%Y-%m-%d %H:%M:%S')
+            accepted_time = accepted_time.strftime('%Y-%m-%d %H:%M:%S%z')
             application = BetaTestApplication.objects.create(
                 user=user,
                 subdomain='test',


### PR DESCRIPTION
**Testing instructions**
* Verify that no integration test load balancer configuration fragments are skipped when the deletion task is run in the cleanup CI task.
* Verify that there are now no warnings about using a native datetime when timezone support is enabled.