### PR TITLE
[BB-936] Update integration tests to use the Ironwood branches

### DIFF
--- a/instance/tests/integration/factories/instance.py
+++ b/instance/tests/integration/factories/instance.py
@@ -59,8 +59,8 @@ class OpenEdXInstanceFactory(DjangoModelFactory):
     # or a release candidate tag will work.  We point both the edx-platform and the configuration
     # versions to the branch "integration" in our own forks.  These branches are based on the
     # corresponding openedx_release versions from upstream, but can contain custom modifications.
-    openedx_release = 'open-release/hawthorn.1'
+    openedx_release = 'open-release/ironwood.1'
     configuration_source_repo_url = 'https://github.com/open-craft/configuration.git'
-    configuration_version = 'integration-hawthorn'
+    configuration_version = 'integration-ironwood'
     edx_platform_repository_url = 'https://github.com/open-craft/edx-platform.git'
-    edx_platform_commit = 'opencraft-release/hawthorn.1'
+    edx_platform_commit = 'opencraft-release/ironwood.1'


### PR DESCRIPTION
Updates the `edx-platform` and `configuration` branches in the CI tests to Ironwood. 