### PR TITLE
[BB-1191] Update the default release to ironwood.2

### DIFF
--- a/bin/install-supported-firefox
+++ b/bin/install-supported-firefox
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+set -e
+
+FIREFOX_RELEASE="47.0.2"
+FIREFOX_BIN="/usr/local/bin/firefox"
+
+sudo curl -O "https://ftp.mozilla.org/pub/firefox/releases/$FIREFOX_RELEASE/linux-x86_64/en-US/firefox-$FIREFOX_RELEASE.tar.bz2"
+sudo tar xf "firefox-$FIREFOX_RELEASE.tar.bz2"
+
+if test -f "$FIREFOX_BIN"; then
+    sudo mv "$FIREFOX_BIN" "$FIREFOX_BIN.old"
+fi
+sudo ln -s $(pwd)/firefox/firefox "$FIREFOX_BIN"

--- a/circle.yml
+++ b/circle.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/python:3.5.4-browsers
+      - image: circleci/python:3.5-stretch-browsers
         environment:
           DEBUG: 'true'
           DEFAULT_FORK: 'open-craft/edx-platform'
@@ -54,11 +54,6 @@ jobs:
             . venv/bin/activate
             pip install --upgrade pip
             pip install --upgrade virtualenv
-            # The jessie-updates and jessie-backports areas are now removed from the repositories. So
-            # the lines corresponding to those areas have to be removed to fix the resulting errors.
-            # This can be removed after upgrading to the image based on Debian Stretch.
-            sudo sed -i '/jessie-updates/d' /etc/apt/sources.list
-            sudo sed -i '/jessie-backports/d' /etc/apt/sources.list
             sudo apt-get update; sudo apt-get install python2.7-dev
             sudo apt-get install mysql-client
             pip install -r requirements.txt
@@ -83,6 +78,10 @@ jobs:
           name: Run Tests
           command: |
             . venv/bin/activate
+            sed -i 's/libmysqlclient/default-libmysqlclient/' debian_packages.lst
+            make install_system_dependencies
+            sudo ln -s /usr/lib/x86_64-linux-gnu/libmysqlclient.so /usr/lib/x86_64-linux-gnu/libmysqlclient.so.18
+            bin/install-supported-firefox
             bin/run-circleci-tests
           no_output_timeout: 6h
           environment:

--- a/opencraft/settings.py
+++ b/opencraft/settings.py
@@ -348,7 +348,7 @@ DEFAULT_CONFIGURATION_VERSION = env('DEFAULT_CONFIGURATION_VERSION', default=DEF
 
 # Git ref for stable Open edX release. Used as a default refspec for
 # configuration, edx-platform, forum, notifier, xqueue, and certs when creating production instances.
-OPENEDX_RELEASE_STABLE_REF = env('OPENEDX_RELEASE_STABLE_REF', default='open-release/ironwood.1')
+OPENEDX_RELEASE_STABLE_REF = env('OPENEDX_RELEASE_STABLE_REF', default='open-release/ironwood.2')
 
 # The edx-platform repository used by default for production instances
 STABLE_EDX_PLATFORM_REPO_URL = env(
@@ -360,7 +360,7 @@ STABLE_EDX_PLATFORM_COMMIT = env('STABLE_EDX_PLATFORM_COMMIT', default=OPENEDX_R
 STABLE_CONFIGURATION_REPO_URL = env(
     'STABLE_CONFIGURATION_REPO_URL', default=DEFAULT_CONFIGURATION_REPO_URL
 )
-STABLE_CONFIGURATION_VERSION = env('STABLE_CONFIGURATION_VERSION', default='opencraft-release/ironwood.1')
+STABLE_CONFIGURATION_VERSION = env('STABLE_CONFIGURATION_VERSION', default='opencraft-release/ironwood.2')
 
 # The name of the security group to use for edxapp App servers.
 # This is used to set appropriate firewall rules to prevent external access to


### PR DESCRIPTION
The corresponding changes to the `ansible-secrets` repository made [here](https://github.com/open-craft/ansible-secrets/commit/0fa7327953634bc3353bc2f90a1bd4c8e2d01ffb) - pushed directly to the branch by mistake instead of creating a PR.