### PR TITLE
[BB-960] Don't fail when Github user does not exist

### DIFF
--- a/instance/models/mixins/openedx_config.py
+++ b/instance/models/mixins/openedx_config.py
@@ -9,7 +9,7 @@ from random import randint
 from django.conf import settings
 
 from instance.models.mixins.common_config import ConfigMixinBase
-from instance.models.utils import retry_session
+from instance.models.utils import check_github_users
 
 
 # Classes #####################################################################
@@ -384,11 +384,6 @@ class OpenEdXConfigMixin(ConfigMixinBase):
             })
 
         if self.admin_users:
-            session = retry_session()
-            users = [
-                username for username in self.admin_users
-                if session.get('https://github.com/{}.keys'.format(username)).status_code == 200
-            ]
             template.update({
                 "COMMON_USER_INFO": [
                     {
@@ -396,7 +391,7 @@ class OpenEdXConfigMixin(ConfigMixinBase):
                         "github": True,
                         "type": "admin"
                     }
-                    for github_username in users
+                    for github_username in check_github_users(self.admin_users)
                 ],
             })
 

--- a/instance/models/mixins/openedx_config.py
+++ b/instance/models/mixins/openedx_config.py
@@ -395,11 +395,8 @@ class OpenEdXConfigMixin(ConfigMixinBase):
                         "name": github_username,
                         "github": True,
                         "type": "admin"
-                    } if github_username in users else {
-                        "name": github_username,
-                        "type": "admin"
                     }
-                    for github_username in self.admin_users
+                    for github_username in users
                 ],
             })
 

--- a/instance/models/mixins/openedx_config.py
+++ b/instance/models/mixins/openedx_config.py
@@ -9,6 +9,7 @@ from random import randint
 from django.conf import settings
 
 from instance.models.mixins.common_config import ConfigMixinBase
+from instance.models.utils import retry_session
 
 
 # Classes #####################################################################
@@ -383,6 +384,11 @@ class OpenEdXConfigMixin(ConfigMixinBase):
             })
 
         if self.admin_users:
+            session = retry_session()
+            users = [
+                username for username in self.admin_users
+                if session.get('https://github.com/{}.keys'.format(username)).status_code == 200
+            ]
             template.update({
                 "COMMON_USER_INFO": [
                     {
@@ -390,7 +396,7 @@ class OpenEdXConfigMixin(ConfigMixinBase):
                         "github": True,
                         "type": "admin"
                     }
-                    for github_username in self.admin_users
+                    for github_username in users
                 ],
             })
 

--- a/instance/models/mixins/openedx_config.py
+++ b/instance/models/mixins/openedx_config.py
@@ -393,10 +393,10 @@ class OpenEdXConfigMixin(ConfigMixinBase):
                 "COMMON_USER_INFO": [
                     {
                         "name": github_username,
-                        "github": True,
+                        "github": github_username in users,
                         "type": "admin"
                     }
-                    for github_username in users
+                    for github_username in self.admin_users
                 ],
             })
 

--- a/instance/models/mixins/openedx_config.py
+++ b/instance/models/mixins/openedx_config.py
@@ -393,7 +393,10 @@ class OpenEdXConfigMixin(ConfigMixinBase):
                 "COMMON_USER_INFO": [
                     {
                         "name": github_username,
-                        "github": github_username in users,
+                        "github": True,
+                        "type": "admin"
+                    } if github_username in users else {
+                        "name": github_username,
                         "type": "admin"
                     }
                     for github_username in self.admin_users

--- a/instance/models/utils.py
+++ b/instance/models/utils.py
@@ -665,6 +665,5 @@ def retry_session(retries=5, session=None, backoff_factor=0.3, status_forcelist=
         status_forcelist=status_forcelist,
     )
     adapter = HTTPAdapter(max_retries=retry)
-    session.mount('http://', adapter)
     session.mount('https://', adapter)
     return session

--- a/registration/tests/utils.py
+++ b/registration/tests/utils.py
@@ -110,7 +110,8 @@ class BrowserTestMixin:
                 element.clear()
                 if value:
                     # A small delay is required for angular to properly mark field as dirty
-                    time.sleep(.25)
+                    element.click()
+                    time.sleep(.5)
                     element.send_keys(value)
                     # Before moving on, make sure input field contains desired text
                     WebDriverWait(self.client, timeout=5) \


### PR DESCRIPTION
Description
=========

This PR implements a check for the Github users before provisioning the servers to prevent failures when a user isn't found.

Testing
----------

1. Check out this branch in Stage and restart the server.
2. Replace a user's Github handle with one that does not exist.
3. Start provisioning a new App Server.
4. Make sure it does not fail when adding users, as the user that does not map to a Github user does not show the `github` key.

```
2019-06-25 10:29:07-0300 INFO
changed: [54.38.70.171] => (item={u'type': u'admin', u'name': u'viadannap'})
2019-06-25 10:29:07-0300 INFO
changed: [54.38.70.171] => (item={u'github': True, u'type': u'admin', u'name': u'viadanna'})
```