### PR TITLE
[BB-1009] Update how we save configuration to use the prefix as key and a json …

### DIFF
--- a/instance/models/openedx_instance.py
+++ b/instance/models/openedx_instance.py
@@ -490,7 +490,7 @@ class OpenEdXInstance(
         :return: A pair (version, changed) with the current version number and
                  a bool to indicate whether the information was updated.
         """
-        return ConsulAgent(prefix=self.consul_prefix).txn_put(configurations)
+        return ConsulAgent(prefix=self.consul_prefix).create_or_update_dict(configurations)
 
     def update_consul_metadata(self):
         """

--- a/instance/tests/integration/factories/instance.py
+++ b/instance/tests/integration/factories/instance.py
@@ -59,8 +59,8 @@ class OpenEdXInstanceFactory(DjangoModelFactory):
     # or a release candidate tag will work.  We point both the edx-platform and the configuration
     # versions to the branch "integration" in our own forks.  These branches are based on the
     # corresponding openedx_release versions from upstream, but can contain custom modifications.
-    openedx_release = 'open-release/ironwood.1'
+    openedx_release = 'open-release/ironwood.2'
     configuration_source_repo_url = 'https://github.com/open-craft/configuration.git'
     configuration_version = 'integration-ironwood'
     edx_platform_repository_url = 'https://github.com/open-craft/edx-platform.git'
-    edx_platform_commit = 'opencraft-release/ironwood.1'
+    edx_platform_commit = 'opencraft-release/ironwood.2'

--- a/instance/tests/management/test_update_metadata.py
+++ b/instance/tests/management/test_update_metadata.py
@@ -20,6 +20,7 @@
 Instance app - instances' metadata update management command
 """
 # Imports #####################################################################
+import json
 from unittest.mock import patch
 
 from django.conf import settings
@@ -97,8 +98,7 @@ class UpdateMetadataTestCase(TestCase):
 
         # Add some garbage data to consul
         bad_prefix = settings.CONSUL_PREFIX.format(ocim=settings.OCIM_ID, instance=333)
-        self.client.kv.put(bad_prefix + 'key1', 'value1')
-        self.client.kv.put(bad_prefix + 'key2', 'value2')
+        self.client.kv.put(bad_prefix, json.dumps({'key1': 'value1', 'key2': 'value2'}).encode('utf-8'))
 
         call_command('update_metadata', skip_update=True, stdout=out)
         objects_count = OpenEdXInstance.objects.count()
@@ -126,8 +126,7 @@ class UpdateMetadataTestCase(TestCase):
 
         # Add some garbage data to consul
         bad_prefix = settings.CONSUL_PREFIX.format(ocim=settings.OCIM_ID, instance=333)
-        self.client.kv.put(bad_prefix + 'key1', 'value1')
-        self.client.kv.put(bad_prefix + 'key2', 'value2')
+        self.client.kv.put(bad_prefix, json.dumps({'key1': 'value1', 'key2': 'value2'}).encode('utf-8'))
 
         # Create an active instance
         active_instances_total = 20

--- a/instance/tests/models/test_openedx_instance.py
+++ b/instance/tests/models/test_openedx_instance.py
@@ -980,7 +980,7 @@ class OpenEdXInstanceConsulTestCase(TestCase):
         expected shape.
         """
         instance = OpenEdXInstanceFactory()
-        self.assertEqual(instance.consul_prefix, '{}/instances/{}/'.format(settings.OCIM_ID, instance.pk))
+        self.assertEqual(instance.consul_prefix, '{}/instances/{}'.format(settings.OCIM_ID, instance.pk))
 
     @override_settings(CONSUL_ENABLED=True, OCIM_ID='ocim-test')
     def test_write_metadata_to_consul(self):
@@ -1022,7 +1022,18 @@ class OpenEdXInstanceConsulTestCase(TestCase):
         instance.purge_consul_metadata()
 
     @override_settings(CONSUL_ENABLED=True, OCIM_ID='ocim-test')
-    @patch('instance.models.openedx_instance.OpenEdXInstance._generate_consul_metadata')
+    @patch(
+        'instance.models.openedx_instance.OpenEdXInstance._generate_consul_metadata',
+        return_value={
+            'domain_slug': 'domain_slug',
+            'domain': 'domain',
+            'name': 'name',
+            'domains': ['domain1', 'domain2'],
+            'health_checks_enabled': False,
+            'basic_auth': 'basic_auth',
+            'active_app_servers': [],
+        }
+    )
     def test_update_consul_metadata(self, metadata_mock):
         """
         Tests whether the wrapper built around Consul writer returns the expected results.
@@ -1035,7 +1046,7 @@ class OpenEdXInstanceConsulTestCase(TestCase):
 
         # Initial store defaults
         version, updated = instance.update_consul_metadata()
-        self.assertEqual(version, 1)
+        self.assertEqual(version, 2)
         self.assertEqual(updated, True)
 
         # Test configurations changed
@@ -1045,12 +1056,12 @@ class OpenEdXInstanceConsulTestCase(TestCase):
             'dummyKey3': 'dummyValue3',
         }
         version, updated = instance.update_consul_metadata()
-        self.assertEqual(version, 2)
+        self.assertEqual(version, 3)
         self.assertEqual(updated, True)
 
         # Test configurations not changed
         version, updated = instance.update_consul_metadata()
-        self.assertEqual(version, 2)
+        self.assertEqual(version, 3)
         self.assertEqual(updated, False)
 
         instance.purge_consul_metadata()
@@ -1068,7 +1079,18 @@ class OpenEdXInstanceConsulTestCase(TestCase):
         self.assertEqual(updated, False)
 
     @override_settings(CONSUL_ENABLED=True, OCIM_ID='ocim-test')
-    @patch('instance.models.openedx_instance.OpenEdXInstance._generate_consul_metadata')
+    @patch(
+        'instance.models.openedx_instance.OpenEdXInstance._generate_consul_metadata',
+        return_value={
+            'domain_slug': 'domain_slug',
+            'domain': 'domain',
+            'name': 'name',
+            'domains': ['domain1', 'domain2'],
+            'health_checks_enabled': False,
+            'basic_auth': 'basic_auth',
+            'active_app_servers': [],
+        }
+    )
     def test_purge_consul_metadata(self, metadata_mock):
         """
         Tests the functionality of deleting the Consul metadata for a specific instance

--- a/opencraft/settings.py
+++ b/opencraft/settings.py
@@ -55,7 +55,7 @@ ENABLE_DEBUG_TOOLBAR = env.bool('ENABLE_DEBUG_TOOLBAR', default=False)
 # Consul #########################################################################
 CONSUL_ENABLED = env.bool('CONSUL_ENABLED', default=False)
 OCIM_ID = env('OCIM_ID', default='ocim')
-CONSUL_PREFIX = env('CONSUL_PREFIX', default='{ocim}/instances/{instance}/')
+CONSUL_PREFIX = env('CONSUL_PREFIX', default='{ocim}/instances/{instance}')
 
 # Auth ########################################################################
 


### PR DESCRIPTION
Update how we save configuration to use the prefix as key and a json object as value.
Currently the configuration values are saved in multiple key/value pairs, e.g.:
```json
[{
    "Key": "prefix/key1",
    "Value": "value1",
}, {
    "Key": "prefix/key2",
    "Value": "value2"
}
]
```
This PR will update the way the config values are saved to use the instance's prefix as key and the value will be a json object with all the configuration values.
There are different methods implemented in the 'ConsulAgent' utility class to do basic CRUD opreations on the new formatted config objects.

# Rationale

We are updating the way Consul saves instance's metadata but there are a lot of instances already running with a different metadata format. If we flip the switch and allow Ocim only handle one type of metadata format then we are going to have some down time while we update the other instance's metadata format. The code in this PR is backwards compatible and will only UPDATE old style metadata. For any new instance it will CREATE and UPDATE the new style of metadata.
This works because consul KV store is built in a way that uses prefixed. So, if there's three KV pairs with the prefix `ocmi/instances/121/` (e.g. `ocim/instances/121/slug`, `ocim/instance/121/domains`, `ocim/instances/121/key`) then Consul will only retrieve these values if `kv.get` is called with `recurse=True` if not consul will not return anything for `kv.get("ocim/instances/121")`.


# Testing instructions
1. (Before pulling this PR) In a Django shell, create an instance:
```python

instance = OpenEdXInstance.objects.create(
    name='Ironwood sandbox',
    sub_domain='ironwood',
    # The rest of the parameters are all optional:
    email='myname@opencraft.com',
    openedx_release='named-release/ironwood',
    configuration_version='named-release/ironwood',
    configuration_source_repo_url='https://github.com/edx/configuration.git',
    configuration_extra_settings='',
)
```
2. Make sure the metadata was saved:
```python
from instance.models.utils import ConsulAgent
ca = ConsulAgent(prefix='ocim/instances/<instasnce_id>')
ca._client.kv.get(ca.prefix, recurse=True)
```
3. Pull this branch and update the created instance metadata
```python
instsance.update_consul_metadata()
```
4. Make sure nothing changed in the consul stored data .This is ensuring the code is backwards compatible.
```python
from instance.models.utils import ConsulAgent
ca = ConsulAgent(prefix='ocim/instances/<instasnce_id>')
ca._client.kv.get(ca.prefix, recurse=True)
```
5. Create a new instance and make sure the metadata was saved in the new format:
```python

instance = OpenEdXInstance.objects.create(
    name='New sandbox',
    sub_domain='newsandbox',
    # The rest of the parameters are all optional:
    email='myname@opencraft.com',
    openedx_release='named-release/ironwood',
    configuration_version='named-release/ironwood',
    configuration_source_repo_url='https://github.com/edx/configuration.git',
    configuration_extra_settings='',
)
```
6. Make sure the metadata was save in the new format:
```python
from instance.models.utils import ConsulAgent
ca = ConsulAgent(prefix='ocim/instances/<instasnce_id>')
ca._client.kv.get(ca.prefix)
```