### PR TITLE
[BB-1481] Changes for fixing the preliminary page issue

### DIFF
--- a/instance/models/mixins/load_balanced.py
+++ b/instance/models/mixins/load_balanced.py
@@ -91,5 +91,7 @@ class LoadBalancedInstance(models.Model):
         self.logger.info("Configuring load balancer to point to the preliminary page.")
         backend_name = "be-preliminary-page-{}".format(primary_key)
         config = "    server preliminary-page {}:80".format(settings.PRELIMINARY_PAGE_SERVER_IP)
+        if settings.PRELIMINARY_PAGE_HOSTNAME:
+            config += "\n    http-request set-header Host '{}'".format(settings.PRELIMINARY_PAGE_HOSTNAME)
         backend_map = [(domain, backend_name) for domain in self.get_load_balanced_domains()]
         return backend_map, [(backend_name, config)]

--- a/opencraft/settings.py
+++ b/opencraft/settings.py
@@ -678,6 +678,7 @@ DEFAULT_LOAD_BALANCING_SERVER = env('DEFAULT_LOAD_BALANCING_SERVER', default=Non
 
 LOAD_BALANCER_FRAGMENT_NAME_PREFIX = env('LOAD_BALANCER_FRAGMENT_NAME_PREFIX', default='opencraft-')
 PRELIMINARY_PAGE_SERVER_IP = env('PRELIMINARY_PAGE_SERVER_IP', default=None)
+PRELIMINARY_PAGE_HOSTNAME = env('PRELIMINARY_PAGE_HOSTNAME', default=None)
 
 # AWS #########################################################################
 


### PR DESCRIPTION
Related to https://github.com/open-craft/ansible-secrets/pull/128 and has to be tested along with the changes in it.

**Testing instructions**:
* Update Ocim to the source branch of this PR.
* Apply the changes in the related `ansible-secrets` PR to the Ocim `.env` file.
* Restart Ocim.
* Create a new instance and launch a new appserver.
* Wait for the DNS records to propagate and then visit https://<instance domain>. Alternatively, add an entry in `/etc/hosts` for the instance domain, ignore an SSL certificate error and navigate to the URL.
* Verify that a page with the text `The instance is being provisioned. Please come back in a little while...` is loaded. This should have the same content as http://default.opencraft.com.
* Also check that the preliminary page configuration for the instance has been added correctly using the values defined the `ansible-secrets` PR.

**Author notes and concerns**:
* The `Host` header is required because multiple sites run on the server hosting `default.opencraft.com` and the default virtual host served when using the IP address instead of the hostname serves a different site (opencraft.com) and that cannot be changed as that will break that site as Cloudflare uses it.
* The related `ansible-secrets` again defines an IP address for `PRELIMINARY_PAGE_SERVER_IP` which could cause a similar issue again in the future. 
* Using a domain name `default.opencraft.com` works as the domain name is resolved at startup and on every reload. But if the domain name is not resolved, the HAProxy process dies. To prevent that, the `default-server init-addr` option with `none` as the value can be used so that the server process doesn't die (cf. [documentation](https://cbonte.github.io/haproxy-dconv/1.7/configuration.html#5.2-init-addr)). This requires changes to the default `haproxy` configuration and with the ongoing load balancer migration, this has to be changed in two places and requires a lot more testing. So it is better to limit the scope of changes in this ticket and create a follow-up ticket for checking and making those changes.