### PR TITLE
[BB-1481] Fix failing unit test

### DIFF
--- a/instance/tests/models/test_load_balanced_mixin.py
+++ b/instance/tests/models/test_load_balanced_mixin.py
@@ -144,6 +144,7 @@ class LoadBalancedInstanceTestCase(TestCase):
         self.assertEqual(instance.get_preliminary_page_config(instance.ref.pk), ([], []))
 
     @override_settings(PRELIMINARY_PAGE_SERVER_IP='0.0.0.0')
+    @override_settings(PRELIMINARY_PAGE_HOSTNAME=None)
     def test_preliminary_page_ip_address_configured(self):
         instance = OpenEdXInstanceFactory()
         _, [(backend_name, config)] = instance.get_preliminary_page_config(instance.ref.pk)


### PR DESCRIPTION
The unit test started failing after the `PRELIMINARY_PAGE_HOSTNAME` was
set in the CircleCI environment and the test expected it to not be
set. The fix explicitly makes the value `None` so that the test doesn't fail.