### PR TITLE
BB-1030 Reorganize system dependencies

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -43,23 +43,21 @@ jobs:
       - run:
           name: Install Dependencies
           command: |
+            sed -i 's/libmysqlclient/default-libmysqlclient/' debian_packages.lst
+            make install_system_dependencies
+            sudo ln -s /usr/lib/x86_64-linux-gnu/libmysqlclient.so /usr/lib/x86_64-linux-gnu/libmysqlclient.so.18
+            bin/install-supported-firefox
             python3 -m venv venv
             . venv/bin/activate
             pip install --upgrade pip
             pip install --upgrade virtualenv
-            sudo apt-get update; sudo apt-get install python2.7-dev
-            sudo apt-get install mysql-client
-            sudo apt-get install default-libmysqlclient-dev
             pip install -r requirements.txt
             pip install -r cleanup_utils/requirements.txt
-            sudo apt-get install postgresql-client
-            sudo apt-get install unzip
-            sudo wget -P /tmp https://releases.hashicorp.com/consul/1.2.1/consul_1.2.1_linux_amd64.zip
-            make install_system_dependencies
             npm install
       - run:
           name: Run Consul
           command: |
+            sudo wget -P /tmp https://releases.hashicorp.com/consul/1.2.1/consul_1.2.1_linux_amd64.zip
             sudo unzip /tmp/consul_1.2.1_linux_amd64.zip -d /usr/local/bin
             consul agent -dev
           background: true
@@ -74,10 +72,6 @@ jobs:
           name: Run Tests
           command: |
             . venv/bin/activate
-            sed -i 's/libmysqlclient/default-libmysqlclient/' debian_packages.lst
-            make install_system_dependencies
-            sudo ln -s /usr/lib/x86_64-linux-gnu/libmysqlclient.so /usr/lib/x86_64-linux-gnu/libmysqlclient.so.18
-            bin/install-supported-firefox
             mkdir -p /tmp/coverage
             make << parameters.tests_type >>
             if [ -e .coverage.* ]; then

--- a/debian_packages.lst
+++ b/debian_packages.lst
@@ -1,10 +1,14 @@
 git
 libffi-dev
+libmysqlclient-dev
 libpq-dev
 make
+mysql-client
+postgresql-client
 python-dev
+python2.7-dev
 python3-pip
 redis-server
 subversion
+unzip
 xvfb
-postgresql-client


### PR DESCRIPTION
This PR reorganizes Debian/Ubuntu dependencies to get both CircleCI and Vagrant devstack to install all requirements.

This was broken in #426 