### PR TITLE
BB-1576: Add variables required to gate playbook reconfiguration

### DIFF
--- a/instance/models/load_balancer.py
+++ b/instance/models/load_balancer.py
@@ -177,6 +177,13 @@ class LoadBalancingServer(ValidateModelMixin, TimeStampedModel):
         The triggering_instance_id indicates the id of the instance reference that initiated the
         reconfiguration of the load balancer.
         """
+        if settings.DISABLE_LOAD_BALANCER_CONFIGURATION:
+            self.logger.info(
+                'Direct load balancer reconfiguration disabled. Skipping %s configuration...',
+                self
+            )
+            return "", ""
+
         backend_map = []
         backend_conf = []
         for instance in self.get_instances():
@@ -221,6 +228,13 @@ class LoadBalancingServer(ValidateModelMixin, TimeStampedModel):
 
         This is factored out into a separate method so it can be mocked out in the tests.
         """
+        if settings.DISABLE_LOAD_BALANCER_CONFIGURATION:
+            self.logger.info(
+                'Direct load balancer reconfiguration disabled. Skipping %s configuration...',
+                self
+            )
+            return
+
         playbook_path = pathlib.Path(settings.SITE_ROOT) / "playbooks/load_balancer_conf/load_balancer_conf.yml"
         returncode = ansible.capture_playbook_output(
             requirements_path=str(playbook_path.parent / "requirements.txt"),

--- a/instance/models/mixins/load_balanced.py
+++ b/instance/models/mixins/load_balanced.py
@@ -77,7 +77,8 @@ class LoadBalancedInstance(models.Model):
                 'Direct load balancer reconfiguration disabled. Skipping %s configuration...',
                 self
             )
-            return 
+            return
+
         if load_balancing_server is None:
             load_balancing_server = self.load_balancing_server
             if load_balancing_server is None:

--- a/instance/models/mixins/load_balanced.py
+++ b/instance/models/mixins/load_balanced.py
@@ -72,6 +72,12 @@ class LoadBalancedInstance(models.Model):
         """
         Reconfigure the associated load balancer.
         """
+        if settings.DISABLE_LOAD_BALANCER_CONFIGURATION:
+            self.logger.info(
+                'Direct load balancer reconfiguration disabled. Skipping %s configuration...',
+                self
+            )
+            return 
         if load_balancing_server is None:
             load_balancing_server = self.load_balancing_server
             if load_balancing_server is None:

--- a/instance/models/openedx_instance.py
+++ b/instance/models/openedx_instance.py
@@ -134,6 +134,13 @@ class OpenEdXInstance(
         The triggered_by_instance flag indicates whether the reconfiguration was initiated by this
         instance, in which case we log additional information.
         """
+        if settings.DISABLE_LOAD_BALANCER_CONFIGURATION:
+            self.logger.info(
+                'Direct load balancer reconfiguration disabled. No haproxy '
+                'configuration fragment and backend map will be generated.'
+            )
+            return "", ""
+
         active_appservers = self.get_active_appservers()
         if not active_appservers.exists():
             return self.get_preliminary_page_config(self.ref.pk)

--- a/instance/tests/models/test_openedx_appserver.py
+++ b/instance/tests/models/test_openedx_appserver.py
@@ -28,7 +28,7 @@ import novaclient
 import requests
 import responses
 import yaml
-from ddt import ddt, data, unpack
+from ddt import ddt, data
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.core import mail as django_mail

--- a/instance/tests/models/test_openedx_appserver.py
+++ b/instance/tests/models/test_openedx_appserver.py
@@ -28,7 +28,7 @@ import novaclient
 import requests
 import responses
 import yaml
-from ddt import ddt, data
+from ddt import ddt, data, unpack
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.core import mail as django_mail
@@ -541,6 +541,42 @@ class OpenEdXAppServerTestCase(TestCase):
         self.assertEqual(appserver.last_activated, activation_time)
         self.assertFalse(instance.get_active_appservers().exists())
         self.assertEqual(mocks.mock_load_balancer_run_playbook.call_count, 3)
+        self.assertEqual(mocks.mock_disable_monitoring.call_count, 0)
+
+    @patch_services
+    @override_settings(DISABLE_LOAD_BALANCER_CONFIGURATION=True)
+    def test_make_active_no_load_balancer_reconfiguration(self, mocks):
+        """
+        Test make_active() and make_active(active=False) when the load balancer
+        reconfiguration is disabled
+        """
+        instance = OpenEdXInstanceFactory(internal_lms_domain='test.activate.opencraft.co.uk')
+        appserver_id = instance.spawn_appserver()
+        self.assertEqual(mocks.mock_load_balancer_run_playbook.call_count, 0)
+        appserver = instance.appserver_set.get(pk=appserver_id)
+
+        self.assertEqual(instance.appserver_set.get().last_activated, None)
+
+        with freeze_time('2017-01-17 11:25:00') as freezed_time:
+            appserver.make_active()
+        activation_time = utc.localize(freezed_time())
+
+        instance.refresh_from_db()
+        appserver.refresh_from_db()
+        self.assertTrue(appserver.is_active)
+        self.assertEqual(appserver.last_activated, activation_time)
+        self.assertEqual(instance.appserver_set.get().last_activated, activation_time)
+        self.assertEqual(mocks.mock_load_balancer_run_playbook.call_count, 0)
+        self.assertEqual(mocks.mock_enable_monitoring.call_count, 1)
+
+        # Test deactivate
+        appserver.make_active(active=False)
+        instance.refresh_from_db()
+        appserver.refresh_from_db()
+        self.assertFalse(appserver.is_active)
+        self.assertEqual(appserver.last_activated, activation_time)
+        self.assertFalse(instance.get_active_appservers().exists())
+        self.assertEqual(mocks.mock_load_balancer_run_playbook.call_count, 0)
         self.assertEqual(mocks.mock_disable_monitoring.call_count, 0)
 
     @patch_services

--- a/opencraft/settings.py
+++ b/opencraft/settings.py
@@ -680,6 +680,17 @@ LOAD_BALANCER_FRAGMENT_NAME_PREFIX = env('LOAD_BALANCER_FRAGMENT_NAME_PREFIX', d
 PRELIMINARY_PAGE_SERVER_IP = env('PRELIMINARY_PAGE_SERVER_IP', default=None)
 PRELIMINARY_PAGE_HOSTNAME = env('PRELIMINARY_PAGE_HOSTNAME', default=None)
 
+# This disables Load Balancer reconfiguration
+# If using the new load balancer, this setting must be set to True, as the
+# load balancing configuration is done by Consul Template on the load balancers,
+# without needing any direct action from Ocim on the load balancers.
+# !!! This should only be set after the new loab balancers are configured and
+# tested to be working !!!
+DISABLE_LOAD_BALANCER_CONFIGURATION = env.bool(
+    'DISABLE_LOAD_BALANCER_CONFIGURATION',
+    default=False
+)
+
 # AWS #########################################################################
 
 # Must be set if `INSTANCE_STORAGE_TYPE = 's3'`.


### PR DESCRIPTION
This PR adds a flag to gate load balancer reconfiguration on Ocim.

**Testing instructions**:
1. Checkout this branch on your Ocim devstack
2. Run tests related to this change and check that they pass.
```
make test.one instance.tests.models.test_openedx_appserver.OpenEdXAppServerTestCase.test_make_active_no_load_balancer_reconfiguration
make test.one instance.tests.models.test_openedx_appserver.OpenEdXAppServerTestCase.test_make_active
make test.one instance.tests.models.test_load_balanced_mixin
```
3. Configure Ocim with the `.env` used for development and add `DISABLE_LOAD_BALANCER_CONFIGURATION = True`.
4. Run Ocim Shell and check that the setting is correctly set.
5. Create a new instance:
```
from instance.factories import production_instance_factory
production_instance_factory(name='123', sub_domain='bb1576-test')
```
6. Run Ocim with `make run.dev` and spawn a new appserver. Check that the following log appears on the instance log:
```
Direct load balancer reconfiguration disabled. Skipping 123 (bb1576-test.plebia.net) configuration...
```

Make sure you clean up the instance afterwards.


**Reviewer:**
- [x] @Agrendalath 

FYI @SSPJ 