### PR TITLE
[BB-1543] Enable prerequisite subsections feature

### DIFF
--- a/instance/models/mixins/openedx_config.py
+++ b/instance/models/mixins/openedx_config.py
@@ -213,13 +213,14 @@ class OpenEdXConfigMixin(ConfigMixinBase):
                 # Since Ironwood, the Studio login changed from a separate login
                 # to using LMS as a SSO provider. This flag disables that behaviour.
                 "DISABLE_STUDIO_SSO_OVER_LMS": True,
+                # Enable prerequisite subsections feature
+                "ENABLE_PREREQUISITE_COURSES": True,
+                "MILESTONES_APP": True,
                 # These are not part of the standard install:
                 # "CUSTOM_COURSES_EDX": True,
                 # "ENABLE_LTI_PROVIDER": True,
-                # "ENABLE_PREREQUISITE_COURSES": True,
                 # "ENABLE_PROCTORED_EXAMS": True,
                 # "INDIVIDUAL_DUE_DATES": True,
-                # "MILESTONES_APP": True,
             },
 
             # Gunicorn workers


### PR DESCRIPTION
This PR [enables prereqeusite subsections feature](https://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/latest/configuration/enable_prerequisites.html#enable-course-prerequisites)

**Testing instructions**:
1. Checkout this branch on your Ocim devstack.
1. Configure Ocim with the `.env` used for development.
1. Run Ocim Shell and create a new instance:
    ```
    from instance.factories import production_instance_factory
    production_instance_factory(name='123', sub_domain='bb1576-test')
    ```
1. Run Ocim with `make run.dev` and spawn a new appserver. Check that the `Configuration` section has these two lines under `EDXAPP_FEATURES`:
    ```
    MILESTONES_APP: true
    ENABLE_PREREQUISITE_COURSES: true
    ```

Make sure you clean up the instance afterwards.