### PR TITLE
[BB-1604] Add delete_archived management command

### DIFF
--- a/README.md
+++ b/README.md
@@ -858,6 +858,15 @@ before the redeployment command. For example:
 
     HUEY_QUEUE_NAME=opencraft_low_priority make manage "instance_redeploy ..."
 
+**`delete_archived`**: Deletes archived instances older than the given number
+of months. For example, to delete instances archived more than one year ago:
+
+    make manage "delete_archived 12"
+
+This command will actually check when the InstanceReference model was last
+modified, so it might miss archived instances that were modified after being
+archived.
+
 Databases
 ---------
 

--- a/instance/management/commands/delete_archived.py
+++ b/instance/management/commands/delete_archived.py
@@ -53,7 +53,7 @@ class Command(BaseCommand):
         Finds old archived instances
         """
         self.log('Starting delete_archived')
-        yes = options.get('yes', False)
+        self.yes = options.get('yes', False)
         months = options.get('months')
         cutoff = timezone.now() - relativedelta(months=months)
 
@@ -75,7 +75,7 @@ class Command(BaseCommand):
             self.log('- {}: {}'.format(ref.name[:30], ref.instance.internal_lms_domain))
 
         # Get user confirmation and deletes archived instances
-        if yes or self.confirm('Are you absolutely sure you want to delete these instances?'):
+        if self.yes or self.confirm('Are you absolutely sure you want to delete these instances?'):
             archived_count = 0
             for ref in refs:
                 self.log('Deleting {}...'.format(ref.instance.internal_lms_domain))
@@ -101,6 +101,9 @@ class Command(BaseCommand):
             LOG.exception(message)
             self.log(self.style.ERROR(message))
             self.stdout.write(self.style.ERROR(tb))
+            if self.yes:
+                # When running on automated mode, also logs to stderr
+                self.stderr.write(message)
             return False
         return True
 

--- a/instance/management/commands/delete_archived.py
+++ b/instance/management/commands/delete_archived.py
@@ -37,6 +37,10 @@ class Command(BaseCommand):
     """
     help = 'Deletes instances archived more than X months ago.'
 
+    def __init__(self):
+        super().__init__()
+        self.yes = None
+
     def add_arguments(self, parser):
         """
         Adds optional and required command options.

--- a/instance/management/commands/delete_archived.py
+++ b/instance/management/commands/delete_archived.py
@@ -94,8 +94,6 @@ class Command(BaseCommand):
         the exception and log it so other the instances can proceed.
         """
         try:
-            # TODO Remove dry-run
-            assert False
             instance.delete()
         except Exception:  # noqa
             tb = traceback.format_exc()

--- a/instance/management/commands/delete_archived.py
+++ b/instance/management/commands/delete_archived.py
@@ -94,9 +94,8 @@ class Command(BaseCommand):
         """
         try:
             # TODO Remove dry-run
-            self.log('instance.delete()')
             assert False
-            return True
+            instance.delete()
         except Exception:  # noqa
             tb = traceback.format_exc()
             message = 'Failed to delete {}.'.format(instance.internal_lms_domain)
@@ -104,6 +103,7 @@ class Command(BaseCommand):
             self.log(self.style.ERROR(message))
             self.stdout.write(self.style.ERROR(tb))
             return False
+        return True
 
     def confirm(self, message):
         """

--- a/instance/management/commands/delete_archived.py
+++ b/instance/management/commands/delete_archived.py
@@ -22,9 +22,10 @@ Management command to delete old archived instances
 
 import logging
 import traceback
-from datetime import datetime as dt
+
 from dateutil.relativedelta import relativedelta
 from django.core.management.base import BaseCommand
+from django.utils import timezone
 from instance.models.instance import InstanceReference
 
 LOG = logging.getLogger(__name__)
@@ -54,7 +55,7 @@ class Command(BaseCommand):
         self.log('Starting delete_archived')
         yes = options.get('yes', False)
         months = options.get('months')
-        cutoff = dt.now() - relativedelta(months=months)
+        cutoff = timezone.now() - relativedelta(months=months)
 
         refs = InstanceReference.objects.filter(
             is_archived=True,
@@ -118,6 +119,6 @@ class Command(BaseCommand):
         Shortcut to log messages with date and time
         """
         self.stdout.write('{} | {}'.format(
-            dt.now().strftime('%Y-%m-%d %H:%M:%S'),
+            timezone.now().strftime('%Y-%m-%d %H:%M:%S'),
             message
         ))

--- a/instance/management/commands/delete_archived.py
+++ b/instance/management/commands/delete_archived.py
@@ -1,0 +1,123 @@
+# -*- coding: utf-8 -*-
+#
+# OpenCraft -- tools to aid developing and hosting free software projects
+# Copyright (C) 2015-2019 OpenCraft <contact@opencraft.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+"""
+Management command to delete old archived instances
+"""
+
+import logging
+import traceback
+from datetime import datetime as dt
+from dateutil.relativedelta import relativedelta
+from django.core.management.base import BaseCommand
+from instance.models.instance import InstanceReference
+
+LOG = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    """
+    delete_archives management command class
+    """
+    help = 'Deletes instances archived more than X months ago.'
+
+    def add_arguments(self, parser):
+        """
+        Adds optional and required command options.
+        """
+        parser.add_argument(
+            'months', type=int, help='Number of months a instance must have been archived to be deleted.'
+        )
+        parser.add_argument(
+            '-y', '--yes', action='store_true', help='No confirmation required. BE EXTRA CAREFUL.'
+        )
+
+    def handle(self, *args, **options):
+        """
+        Finds old archived instances
+        """
+        self.log('Starting delete_archived')
+        yes = options.get('yes', False)
+        months = options.get('months')
+        cutoff = dt.now() - relativedelta(months=months)
+
+        refs = InstanceReference.objects.filter(
+            is_archived=True,
+            modified__lte=cutoff
+        ).order_by(
+            'modified'
+        )
+
+        instance_count = refs.count()
+
+        if not instance_count:
+            self.log('No archived instances older than {} months found.'.format(months))
+            return
+
+        self.log('Found {} archived instances older than {} months...'.format(instance_count, months))
+        for ref in refs:
+            self.log('- {}: {}'.format(ref.name[:30], ref.instance.internal_lms_domain))
+
+        # Get user confirmation and deletes archived instances
+        if yes or self.confirm('Are you absolutely sure you want to delete these instances?'):
+            archived_count = 0
+            for ref in refs:
+                self.log('Deleting {}...'.format(ref.instance.internal_lms_domain))
+                if self.delete_instance(ref.instance):
+                    archived_count += 1
+            self.log(
+                'Deleted {} archived instances older than {} months.'.format(
+                    archived_count, months)
+            )
+        else:
+            self.log('Cancelled')
+
+    def delete_instance(self, instance):
+        """
+        Deletes a single OpenEdXInstance. If it fails for any reason, handle
+        the exception and log it so other the instances can proceed.
+        """
+        try:
+            # TODO Remove dry-run
+            self.log('instance.delete()')
+            assert False
+            return True
+        except Exception:  # noqa
+            tb = traceback.format_exc()
+            message = 'Failed to delete {}.'.format(instance.internal_lms_domain)
+            LOG.exception(message)
+            self.log(self.style.ERROR(message))
+            self.stdout.write(self.style.ERROR(tb))
+            return False
+
+    def confirm(self, message):
+        """
+        Get user confirmation.
+        """
+        self.stdout.write('{} [y/N]'.format(message))
+        answer = input()
+        return answer.lower().startswith('y')
+
+    def log(self, message):
+        """
+        Shortcut to log messages with date and time
+        """
+        self.stdout.write('{} | {}'.format(
+            dt.now().strftime('%Y-%m-%d %H:%M:%S'),
+            message
+        ))

--- a/instance/tests/management/test_delete_archived.py
+++ b/instance/tests/management/test_delete_archived.py
@@ -101,17 +101,21 @@ class DeleteArchivedTestCase(TestCase):
         Verify '-y' skips confirmation and errors are logged
         """
         out = StringIO()
-        call_command('delete_archived', '-y', '3', stdout=out)
+        err = StringIO()
+        call_command('delete_archived', '-y', '3', stdout=out, stderr=err)
         self.assertTrue('Found 1 archived instances older than 3 months' in out.getvalue())
 
         self.assertTrue('Deleting old.example.com' in out.getvalue())
-        self.assertTrue('Failed to delete old.example.com' in out.getvalue())
-
         self.assertTrue('Deleting new.example.com' not in out.getvalue())
-        self.assertTrue('Failed to delete new.example.com' not in out.getvalue())
-
         self.assertTrue('Deleting newer.example.com' not in out.getvalue())
-        self.assertTrue('Failed to delete newer.example.com' not in out.getvalue())
 
+        self.assertTrue('Failed to delete old.example.com' in out.getvalue())
+        self.assertTrue('Failed to delete new.example.com' not in out.getvalue())
+        self.assertTrue('Failed to delete newer.example.com' not in out.getvalue())
         self.assertTrue('Traceback' in out.getvalue())
+
         self.assertTrue('Deleted 0 archived instances older than 3 months' in out.getvalue())
+
+        self.assertTrue('Failed to delete old.example.com' in err.getvalue())
+        self.assertTrue('Failed to delete new.example.com' not in err.getvalue())
+        self.assertTrue('Failed to delete newer.example.com' not in err.getvalue())

--- a/instance/tests/management/test_delete_archived.py
+++ b/instance/tests/management/test_delete_archived.py
@@ -1,0 +1,117 @@
+# -*- coding: utf-8 -*-
+#
+# OpenCraft -- tools to aid developing and hosting free software projects
+# Copyright (C) 2015-2019 OpenCraft <contact@opencraft.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+"""
+delete_archived management command unit tests
+"""
+
+from datetime import timedelta
+from unittest.mock import patch, MagicMock
+
+import ddt
+from django.core.management import call_command
+from django.utils.six import StringIO
+from django.test import TestCase
+
+from instance.models.openedx_instance import OpenEdXInstance
+
+
+@ddt.ddt
+class DeleteArchivedTestCase(TestCase):
+    """
+    Test cases for the `delete_archived` management command.
+    """
+    def setUp(self):
+        """
+        Set up properties used to verify captured logs
+        """
+        super().setUp()
+        self.cmd_module = 'instance.management.commands.archive_instances'
+        self.log_level = 'INFO'
+
+        # Instances name and days since modified
+        instances = [
+            ('newest', 1),
+            ('new', 60),
+            ('old', 200),
+        ]
+
+        for name, days in instances:
+            instance = OpenEdXInstance.objects.create(
+                sub_domain=name,
+                openedx_release='z.1',
+                successfully_provisioned=True
+            )
+            instance.ref.is_archived = True
+            instance.ref.modified -= timedelta(days=days)
+            instance.ref.save(update_modified=False)
+
+    def test_zero_instances_deleted(self):
+        """
+        Verify that if no archived instances is old enough, the command exits
+        without prompting.
+        """
+        out = StringIO()
+        call_command('delete_archived', '24', stdout=out)
+        self.assertTrue('No archived instances older than 24 months found.' in out.getvalue())
+
+    @patch('instance.management.commands.delete_archived.input', MagicMock(return_value='no'))
+    def test_cancel_deletion(self):
+        """
+        Verify that the user can cancel the deletion by answering "no"
+        """
+        out = StringIO()
+        call_command('delete_archived', '0', stdout=out)
+        self.assertTrue('Cancelled' in out.getvalue())
+
+    @patch('instance.management.commands.delete_archived.input', MagicMock(return_value='yes'))
+    @patch('instance.models.openedx_instance.OpenEdXInstance.delete')
+    def test_confirm_deletion(self, mock_delete):
+        """
+        Verify deletion proceeds by answering "yes"
+        """
+        out = StringIO()
+        call_command('delete_archived', '1', stdout=out)
+        self.assertTrue('Found 2 archived instances older than 1 months' in out.getvalue())
+        self.assertTrue('Deleting old.example.com' in out.getvalue())
+        self.assertTrue('Deleting new.example.com' in out.getvalue())
+        self.assertTrue('Deleted 2 archived instances older than 1 months' in out.getvalue())
+        self.assertTrue('Deleting newer.example.com' not in out.getvalue())
+        self.assertTrue('Failed to delete' not in out.getvalue())
+        self.assertEqual(mock_delete.call_count, 2)
+
+    @patch('instance.models.openedx_instance.OpenEdXInstance.delete', MagicMock(side_effect=Exception('error')))
+    def test_deletion_fails(self):
+        """
+        Verify '-y' skips confirmation and errors are logged
+        """
+        out = StringIO()
+        call_command('delete_archived', '-y', '3', stdout=out)
+        self.assertTrue('Found 1 archived instances older than 3 months' in out.getvalue())
+
+        self.assertTrue('Deleting old.example.com' in out.getvalue())
+        self.assertTrue('Failed to delete old.example.com' in out.getvalue())
+
+        self.assertTrue('Deleting new.example.com' not in out.getvalue())
+        self.assertTrue('Failed to delete new.example.com' not in out.getvalue())
+
+        self.assertTrue('Deleting newer.example.com' not in out.getvalue())
+        self.assertTrue('Failed to delete newer.example.com' not in out.getvalue())
+
+        self.assertTrue('Traceback' in out.getvalue())
+        self.assertTrue('Deleted 0 archived instances older than 3 months' in out.getvalue())


### PR DESCRIPTION
Description
=========

This pull requests adds a `delete_archived` management command.

The command will fetch all archived instances older than the given number of months, and after user confirmation, delete these instances.

Testing
----------

1. Create a couple instances in your devstack and archive them:
```
from instance.factories import instance_factory
instance = instance_factory(name="Sandbox instance", sub_domain="sandbox")
instance.ref.is_archived = True
instance.ref.save()
```
2. Modify the `modified` attribute of one of the instance references:
```
from datetime import timedelta as td
instance.ref.modified -= td(days=365)
instance.ref.save(update_modified=False)
```
3. Run the management command and check it finds the correct instances
```
$ honcho run python manage.py delete_archived 0
$ honcho run python manage.py delete_archived 1
$ honcho run python manage.py delete_archived 24
(etc)
```