### PR TITLE
SE-1463 revert changes to EDXAPP_WORKERS

### DIFF
--- a/instance/models/mixins/openedx_config.py
+++ b/instance/models/mixins/openedx_config.py
@@ -223,15 +223,12 @@ class OpenEdXConfigMixin(ConfigMixinBase):
                 # "INDIVIDUAL_DUE_DATES": True,
             },
 
-            # Gunicorn workers
-            # By default, the number of workers is num_cores*4 for LMS, num_cores*2 for CMS,
-            # which turns out to be too much.
-            # 06/2019 update: We've done some testing and realized using 14 workers is OK
-            # and it helps to support more concurrent requests as well as a more efficient
-            # use of the server's resources.
+            # Gunicorn workers - safe defaults for a 1 CPU, 4GB RAM instance.
+            # This should be changed to use worker_core_mult to scale num
+            # workers with cpu count.
             "EDXAPP_WORKERS": {
-                "lms": 14,
-                "cms": 7,
+                "lms": 3,
+                "cms": 2,
             },
 
             # Restart workers regularly to work around a memory leaks.
@@ -240,16 +237,7 @@ class OpenEdXConfigMixin(ConfigMixinBase):
             # e.g if the instance receives an average of around 20000 requests per day,
             # with 10% for static assets, restarting after 10000 requests means
             # restarting each of the 3 LMS workers about every .8 days.
-            # 06/2019 Update: By incrementing the workers number we have more concurrent
-            # processes helping out with the requests. We can lower this number to have
-            # the workers "refresh" the memory more often.
-            # Note: There's also an `EDXAPP_LMS_MAX_REQUEST_JITTER` variable which will make
-            # gunicorn use a random number between 0 and the given value to restart each
-            # worker process/thread. By using jitter vs a fixed number of requests
-            # we avoid potentially restarting every worker process/thread at the same time.
-            # Jitter only works on gunicorn 9.2+. By default EDXAPP_LMS_MAX_REQ will be used
-            # until explicitly set to null.
-            "EDXAPP_LMS_MAX_REQ": 1000,
+            "EDXAPP_LMS_MAX_REQ": 5000,
 
             # Studio/CMS handles ~5% of the LMS requests with only 2 workers.
             # Restart them every 1-2 days.


### PR DESCRIPTION
14 and 7 were way too high to use as safe defaults, resulting in small
 instances locking up.

The changes that we're reverting were introduced in https://github.com/open-craft/opencraft/pull/437

**Reviewer**:

- [ ] @viadanna 