### PR TITLE
[BB-1604] Handle InstanceReferences without a proper Instance

### DIFF
--- a/instance/management/commands/delete_archived.py
+++ b/instance/management/commands/delete_archived.py
@@ -86,12 +86,13 @@ class Command(BaseCommand):
         if self.yes or self.confirm('Are you absolutely sure you want to delete these instances?'):
             archived_count = 0
             for ref in refs:
-                if not ref.instance:
-                    continue
-                self.log('Deleting {}...'.format(ref.instance.internal_lms_domain))
+                if ref.instance:
+                    self.log('Deleting {}...'.format(ref.instance.internal_lms_domain))
+                else:
+                    ref.delete()
                 if ref.instance and self.delete_instance(ref.instance):
                     archived_count += 1
-            refs.delete()
+                    ref.delete()
             self.log(
                 'Deleted {} archived instances older than {} months.'.format(
                     archived_count, months)

--- a/instance/management/commands/delete_archived.py
+++ b/instance/management/commands/delete_archived.py
@@ -88,10 +88,10 @@ class Command(BaseCommand):
             for ref in refs:
                 if ref.instance:
                     self.log('Deleting {}...'.format(ref.instance.internal_lms_domain))
+                    if self.delete_instance(ref.instance):
+                        archived_count += 1
                 else:
-                    ref.delete()
-                if ref.instance and self.delete_instance(ref.instance):
-                    archived_count += 1
+                    ref.delete(ref_already_deleted=True)
             self.log(
                 'Deleted {} archived instances older than {} months.'.format(
                     archived_count, months)

--- a/instance/management/commands/delete_archived.py
+++ b/instance/management/commands/delete_archived.py
@@ -92,7 +92,6 @@ class Command(BaseCommand):
                     ref.delete()
                 if ref.instance and self.delete_instance(ref.instance):
                     archived_count += 1
-                    ref.delete()
             self.log(
                 'Deleted {} archived instances older than {} months.'.format(
                     archived_count, months)

--- a/instance/management/commands/delete_archived.py
+++ b/instance/management/commands/delete_archived.py
@@ -91,7 +91,8 @@ class Command(BaseCommand):
                     if self.delete_instance(ref.instance):
                         archived_count += 1
                 else:
-                    ref.delete(ref_already_deleted=True)
+                    ref.delete(instance_already_deleted=True)
+
             self.log(
                 'Deleted {} archived instances older than {} months.'.format(
                     archived_count, months)

--- a/instance/management/commands/delete_archived.py
+++ b/instance/management/commands/delete_archived.py
@@ -76,15 +76,22 @@ class Command(BaseCommand):
 
         self.log('Found {} archived instances older than {} months...'.format(instance_count, months))
         for ref in refs:
-            self.log('- {}: {}'.format(ref.name[:30], ref.instance.internal_lms_domain))
+            try:
+                self.log('- {}: {}'.format(ref.name[:30], ref.instance.internal_lms_domain))
+            except AttributeError:
+                # InstanceRef does not point to instance
+                self.log('- {}: No instance associated'.format(ref.name[:30]))
 
         # Get user confirmation and deletes archived instances
         if self.yes or self.confirm('Are you absolutely sure you want to delete these instances?'):
             archived_count = 0
             for ref in refs:
+                if not ref.instance:
+                    continue
                 self.log('Deleting {}...'.format(ref.instance.internal_lms_domain))
-                if self.delete_instance(ref.instance):
+                if ref.instance and self.delete_instance(ref.instance):
                     archived_count += 1
+            refs.delete()
             self.log(
                 'Deleted {} archived instances older than {} months.'.format(
                     archived_count, months)

--- a/instance/management/commands/delete_archived.py
+++ b/instance/management/commands/delete_archived.py
@@ -84,18 +84,19 @@ class Command(BaseCommand):
 
         # Get user confirmation and deletes archived instances
         if self.yes or self.confirm('Are you absolutely sure you want to delete these instances?'):
-            archived_count = 0
+            deleted_count = 0
             for ref in refs:
                 if ref.instance:
                     self.log('Deleting {}...'.format(ref.instance.internal_lms_domain))
                     if self.delete_instance(ref.instance):
-                        archived_count += 1
+                        deleted_count += 1
                 else:
                     ref.delete(instance_already_deleted=True)
+                    deleted_count += 1
 
             self.log(
                 'Deleted {} archived instances older than {} months.'.format(
-                    archived_count, months)
+                    deleted_count, months)
             )
         else:
             self.log('Cancelled')

--- a/instance/management/commands/delete_archived.py
+++ b/instance/management/commands/delete_archived.py
@@ -84,13 +84,9 @@ class Command(BaseCommand):
 
         # Get user confirmation and deletes archived instances
         if self.yes or self.confirm('Are you absolutely sure you want to delete these instances?'):
-            deleted_count = 0
-            for ref in refs:
-                if ref.instance:
-                    self.log('Deleting {}...'.format(ref.instance.internal_lms_domain))
-                if self.delete_instance_reference(ref):
-                    deleted_count += 1
-
+            deleted_count = sum([
+                1 for ref in refs if self.delete_instance_reference(ref)
+            ])
             self.log(
                 'Deleted {} archived instances older than {} months.'.format(deleted_count, months)
             )
@@ -104,6 +100,7 @@ class Command(BaseCommand):
         so other the instances can proceed.
         """
         try:
+            self.log('Deleting {}...'.format(ref.instance.internal_lms_domain if ref.instance else ref.name))
             ref.delete(instance_already_deleted=ref.instance is None)
         except Exception:  # noqa
             tb = traceback.format_exc()

--- a/instance/tests/management/test_delete_archived.py
+++ b/instance/tests/management/test_delete_archived.py
@@ -96,9 +96,8 @@ class DeleteArchivedTestCase(TestCase):
         self.assertTrue('Failed to delete' not in out.getvalue())
         self.assertEqual(mock_delete.call_count, 2)
 
-    @patch('instance.models.openedx_instance.OpenEdXInstance.delete', MagicMock(side_effect=Exception('error')))
-    @patch('instance.models.instance.InstanceReference.delete')
-    def test_deletion_fails(self, mock_ref_delete):
+    @patch('instance.models.instance.InstanceReference.delete', MagicMock(side_effect=Exception('error')))
+    def test_deletion_fails(self):
         """
         Verify '-y' skips confirmation and errors are logged
         """
@@ -111,16 +110,10 @@ class DeleteArchivedTestCase(TestCase):
         self.assertTrue('Deleting new.example.com' not in out.getvalue())
         self.assertTrue('Deleting newer.example.com' not in out.getvalue())
 
-        self.assertTrue('Failed to delete old.example.com' in out.getvalue())
-        self.assertTrue('Failed to delete new.example.com' not in out.getvalue())
-        self.assertTrue('Failed to delete newer.example.com' not in out.getvalue())
+        self.assertTrue('Failed to delete Instance' in out.getvalue())
+        self.assertTrue('Failed to delete Instance' in err.getvalue())
         self.assertTrue('Traceback' in out.getvalue())
-
         self.assertTrue('Deleted 0 archived instances older than 3 months' in out.getvalue())
-
-        self.assertTrue('Failed to delete old.example.com' in err.getvalue())
-        self.assertTrue('Failed to delete new.example.com' not in err.getvalue())
-        self.assertTrue('Failed to delete newer.example.com' not in err.getvalue())
 
     @patch('instance.management.commands.delete_archived.input', MagicMock(return_value='yes'))
     @patch('instance.models.instance.InstanceReference.delete')
@@ -143,6 +136,6 @@ class DeleteArchivedTestCase(TestCase):
         # Check only the InstanceReference queryset gets deleted
         self.assertTrue('Found 1 archived instances older than 10 months' in out.getvalue())
         self.assertTrue('Instanceless: No instance associated' in out.getvalue())
-        self.assertTrue('Deleted 0 archived instances older than 10 months' in out.getvalue())
+        self.assertTrue('Deleted 1 archived instances older than 10 months' in out.getvalue())
         self.assertEqual(mock_delete.call_count, 0)
         self.assertEqual(mock_ref_delete.call_count, 1)

--- a/instance/tests/management/test_delete_archived.py
+++ b/instance/tests/management/test_delete_archived.py
@@ -82,7 +82,6 @@ class DeleteArchivedTestCase(TestCase):
 
     @patch('instance.management.commands.delete_archived.input', MagicMock(return_value='yes'))
     @patch('instance.models.instance.InstanceReference.delete')
-    @patch('instance.models.openedx_instance.OpenEdXInstance.delete')
     def test_confirm_deletion(self, mock_delete, mock_ref_delete):
         """
         Verify deletion proceeds by answering "yes"
@@ -96,7 +95,6 @@ class DeleteArchivedTestCase(TestCase):
         self.assertTrue('Deleting newer.example.com' not in out.getvalue())
         self.assertTrue('Failed to delete' not in out.getvalue())
         self.assertEqual(mock_delete.call_count, 2)
-        self.assertEqual(mock_ref_delete.call_count, 2)
 
     @patch('instance.models.openedx_instance.OpenEdXInstance.delete', MagicMock(side_effect=Exception('error')))
     @patch('instance.models.instance.InstanceReference.delete')

--- a/instance/tests/management/test_delete_archived.py
+++ b/instance/tests/management/test_delete_archived.py
@@ -81,8 +81,9 @@ class DeleteArchivedTestCase(TestCase):
         self.assertTrue('Cancelled' in out.getvalue())
 
     @patch('instance.management.commands.delete_archived.input', MagicMock(return_value='yes'))
+    @patch('instance.models.instance.InstanceReference.delete')
     @patch('instance.models.openedx_instance.OpenEdXInstance.delete')
-    def test_confirm_deletion(self, mock_delete):
+    def test_confirm_deletion(self, mock_delete, mock_ref_delete):
         """
         Verify deletion proceeds by answering "yes"
         """
@@ -95,9 +96,11 @@ class DeleteArchivedTestCase(TestCase):
         self.assertTrue('Deleting newer.example.com' not in out.getvalue())
         self.assertTrue('Failed to delete' not in out.getvalue())
         self.assertEqual(mock_delete.call_count, 2)
+        self.assertEqual(mock_ref_delete.call_count, 2)
 
     @patch('instance.models.openedx_instance.OpenEdXInstance.delete', MagicMock(side_effect=Exception('error')))
-    def test_deletion_fails(self):
+    @patch('instance.models.instance.InstanceReference.delete')
+    def test_deletion_fails(self, mock_ref_delete):
         """
         Verify '-y' skips confirmation and errors are logged
         """
@@ -122,7 +125,7 @@ class DeleteArchivedTestCase(TestCase):
         self.assertTrue('Failed to delete newer.example.com' not in err.getvalue())
 
     @patch('instance.management.commands.delete_archived.input', MagicMock(return_value='yes'))
-    @patch('django.db.models.query.QuerySet.delete')
+    @patch('instance.models.instance.InstanceReference.delete')
     @patch('instance.models.openedx_instance.OpenEdXInstance.delete')
     def test_ref_without_instance(self, mock_delete, mock_ref_delete):
         """

--- a/instance/tests/management/test_delete_archived.py
+++ b/instance/tests/management/test_delete_archived.py
@@ -81,8 +81,8 @@ class DeleteArchivedTestCase(TestCase):
         self.assertTrue('Cancelled' in out.getvalue())
 
     @patch('instance.management.commands.delete_archived.input', MagicMock(return_value='yes'))
-    @patch('instance.models.instance.InstanceReference.delete')
-    def test_confirm_deletion(self, mock_delete, mock_ref_delete):
+    @patch('instance.models.openedx_instance.OpenEdXInstance.delete')
+    def test_confirm_deletion(self, mock_delete):
         """
         Verify deletion proceeds by answering "yes"
         """


### PR DESCRIPTION
Description
=========

This is a followup to #458 due to the unexpected situation of an InstanceReference existing without being linked to an Instance.

This will remove the InstanceReference.

Testing
----------

1. In Stage, create an InstanceReference without an associated instance:
```
from dateutil.relativedelta import relativedelta
ref = InstanceReference.objects.create(name='instanceless', instance_id=9000000, instance_type_id=13)
ref.modified -= relativedelta(months=90)
ref.is_archived = True
ref.save(update_modified=False)
```

2. Run the command to remove the instanceless:
```
$ honcho run python manage.py delete_archived 80
```

3. Make sure the process succeeds and the InstanceReference is removed:
```
$ honcho run python manage.py delete_archived 80
(...) No archived instances older than 80 months found.
```
