### PR TITLE
BB-1651: Pass S3 regional endpoint to instance instead of generic one

### DIFF
--- a/instance/models/mixins/storage.py
+++ b/instance/models/mixins/storage.py
@@ -255,7 +255,12 @@ class S3BucketInstanceMixin(models.Model):
         """
         The custom domain name built based on the bucket name.
         """
-        return "{}.s3.amazonaws.com".format(self.s3_bucket_name)
+        # If s3_region is empty, boto3 will use S3 default region 'N. Virginia (us-east-1)'
+        # Reference: https://docs.aws.amazon.com/general/latest/gr/rande.html
+        return "{}.s3.{}.amazonaws.com".format(
+            self.s3_bucket_name,
+            self.s3_region or 'us-east-1'
+        )
 
     @property
     def iam(self):

--- a/instance/tests/models/test_openedx_storage_mixins.py
+++ b/instance/tests/models/test_openedx_storage_mixins.py
@@ -126,7 +126,10 @@ def get_s3_settings(instance):
         "EDXAPP_AWS_ACCESS_KEY_ID": instance.s3_access_key,
         "EDXAPP_AWS_SECRET_ACCESS_KEY": instance.s3_secret_access_key,
         "EDXAPP_AUTH_EXTRA": '\n  AWS_STORAGE_BUCKET_NAME: test\nEDXAPP_AWS_ACCESS_KEY_ID: test',
-        "EDXAPP_AWS_S3_CUSTOM_DOMAIN": "{}.s3.amazonaws.com".format(instance.s3_bucket_name),
+        "EDXAPP_AWS_S3_CUSTOM_DOMAIN": "{}.s3.{}.amazonaws.com".format(
+            instance.s3_bucket_name,
+            instance.s3_region or 'us-east-1'
+        ),
         "EDXAPP_IMPORT_EXPORT_BUCKET": instance.s3_bucket_name,
         "EDXAPP_FILE_UPLOAD_BUCKET_NAME": instance.s3_bucket_name,
         "EDXAPP_FILE_UPLOAD_STORAGE_PREFIX": '{}/{}'.format(


### PR DESCRIPTION
This PR introduces a small change in configuration passed to the edX instance: passing the s3 regional endpoint instead of the generic ***.s3.amazonaws.com**.

Files aren't affected, and old links still work, this is mainly to future proof our deployment after some recent issues.

**Testing instructions:**

**Part 1:** checking url interoperability.
1. Use [this instance](https://stage.console.opencraft.com/instance/4220/).
- Appserver 1 has the old Ocim behaviour
- Appserver 4 has the new S3 bucket url set up
2. Check that images, reports and forum attachments can be correctly accessed by both appservers using the the and old appserver url.
3. Create an grade report and check that it can be download from the two appservers and check that on the newest appserver the regional endpoint is being used.

**Part 2:** checking Ocim code.
1. Deploy this on your devstack.
2. Create a new instance, spawn an appserver. 
3. Check that `EDXAPP_AWS_S3_CUSTOM_DOMAIN` is being set to the regional endpoint.
4. (Optional) Deploy and test this change on Ocim Stage.
- Pick a test instance, and spawn a new appserver, and under `configuration_storage_settings`, check that the regional endpoint was set.

**Reviewer:**
- [ ] @lgp171188 