### PR TITLE
BB-1683 Allow ignoring Gandi error when deleting dns

### DIFF
--- a/instance/management/commands/delete_archived.py
+++ b/instance/management/commands/delete_archived.py
@@ -102,8 +102,10 @@ class Command(BaseCommand):
         try:
             self.log('Deleting {}...'.format(ref.instance.internal_lms_domain if ref.instance else ref.name))
             if ref.instance:
-                # Gandi domain not found error is ignored
-                ref.instance.delete(ignore_dns_errors=True)
+                ref.instance.delete(
+                    ignore_dns_errors=True,  # # Gandi domain not found error is ignored
+                    ref_already_deleted=True  # Manually removing it afterwards
+                )
             ref.delete(instance_already_deleted=True)
         except Exception:  # noqa
             tb = traceback.format_exc()

--- a/instance/management/commands/delete_archived.py
+++ b/instance/management/commands/delete_archived.py
@@ -97,11 +97,14 @@ class Command(BaseCommand):
         """
         Deletes a single InstanceReference and associated OpenEdXInstance, if
         it exists. If it fails for any reason, handle the exception and log it
-        so other the instances can proceed.
+        so the deletion of other instances can proceed.
         """
         try:
             self.log('Deleting {}...'.format(ref.instance.internal_lms_domain if ref.instance else ref.name))
-            ref.delete(instance_already_deleted=ref.instance is None)
+            if ref.instance:
+                # Gandi domain not found error is ignored
+                ref.instance.delete(ignore_dns_errors=True)
+            ref.delete(instance_already_deleted=True)
         except Exception:  # noqa
             tb = traceback.format_exc()
             message = 'Failed to delete {}.'.format(ref.name)

--- a/instance/management/commands/delete_archived.py
+++ b/instance/management/commands/delete_archived.py
@@ -103,7 +103,7 @@ class Command(BaseCommand):
             self.log('Deleting {}...'.format(ref.instance.internal_lms_domain if ref.instance else ref.name))
             if ref.instance:
                 ref.instance.delete(
-                    ignore_dns_errors=True,  # # Gandi domain not found error is ignored
+                    ignore_archive_errors=True,  # Instance already archived
                     ref_already_deleted=True  # Manually removing it afterwards
                 )
             ref.delete(instance_already_deleted=True)

--- a/instance/models/instance.py
+++ b/instance/models/instance.py
@@ -250,7 +250,7 @@ class Instance(ValidateModelMixin, models.Model):
         # TODO: Filter out log entries for which the user doesn't have view rights
         return reversed(list(entries[:limit]))
 
-    def archive(self):
+    def archive(self, **kwargs):
         """
         Mark this instance as archived.
         Subclasses should override this to shut down any active resources being used by this instance.

--- a/instance/models/mixins/load_balanced.py
+++ b/instance/models/mixins/load_balanced.py
@@ -60,13 +60,17 @@ class LoadBalancedInstance(models.Model):
         for domain in self.get_managed_domains():
             gandi.api.set_dns_record(domain, type="CNAME", value=load_balancer_domain)
 
-    def remove_dns_records(self):
+    def remove_dns_records(self, ignore_errors=False):
         """
         Delete the DNS records for this instance.
         """
         for domain in self.get_managed_domains():
             self.logger.info('Removing domain "%s" from DNS Records.', domain)
-            gandi.api.remove_dns_record(domain)
+            try:
+                gandi.api.remove_dns_record(domain)
+            except ValueError:
+                if not ignore_errors:
+                    raise
 
     def reconfigure_load_balancer(self, load_balancing_server=None):
         """

--- a/instance/models/openedx_instance.py
+++ b/instance/models/openedx_instance.py
@@ -393,14 +393,16 @@ class OpenEdXInstance(
                 elif sufficient_time_passed(appserver.created, now, days):
                     appserver.terminate_vm()
 
-    def archive(self):
+    def archive(self, **kwargs):
         """
         Shut down this instance's app servers, mark it as archived and
         remove its metadata from Consul.
         """
+        ignore_errors = kwargs.pop('ignore_errors', False)
+
         self.logger.info('Archiving instance started.')
         self.disable_monitoring()
-        self.remove_dns_records()
+        self.remove_dns_records(ignore_errors=kwargs.pop('ignore_dns_errors', ignore_errors))
         if self.load_balancing_server is not None:
             load_balancer = self.load_balancing_server
             self.load_balancing_server = None
@@ -442,7 +444,7 @@ class OpenEdXInstance(
 
         ignore_errors = kwargs.pop('ignore_errors', False)
 
-        self.archive()
+        self.archive(**kwargs)
         self.deprovision_mysql(ignore_errors=kwargs.pop('ignore_mysql_errors', ignore_errors))
         self.deprovision_mongo(ignore_errors=kwargs.pop('ignore_mongo_errors', ignore_errors))
         self.deprovision_swift()

--- a/instance/models/openedx_instance.py
+++ b/instance/models/openedx_instance.py
@@ -398,11 +398,11 @@ class OpenEdXInstance(
         Shut down this instance's app servers, mark it as archived and
         remove its metadata from Consul.
         """
-        ignore_errors = kwargs.pop('ignore_errors', False)
+        ignore_errors = kwargs.pop('ignore_archive_errors', False)
 
         self.logger.info('Archiving instance started.')
         self.disable_monitoring()
-        self.remove_dns_records(ignore_errors=kwargs.pop('ignore_dns_errors', ignore_errors))
+        self.remove_dns_records(ignore_errors=ignore_errors)
         if self.load_balancing_server is not None:
             load_balancer = self.load_balancing_server
             self.load_balancing_server = None
@@ -444,7 +444,7 @@ class OpenEdXInstance(
 
         ignore_errors = kwargs.pop('ignore_errors', False)
 
-        self.archive(**kwargs)
+        self.archive(ignore_errors=kwargs.pop('ignore_archive_errors', ignore_errors))
         self.deprovision_mysql(ignore_errors=kwargs.pop('ignore_mysql_errors', ignore_errors))
         self.deprovision_mongo(ignore_errors=kwargs.pop('ignore_mongo_errors', ignore_errors))
         self.deprovision_swift()

--- a/instance/models/openedx_instance.py
+++ b/instance/models/openedx_instance.py
@@ -398,7 +398,7 @@ class OpenEdXInstance(
         Shut down this instance's app servers, mark it as archived and
         remove its metadata from Consul.
         """
-        ignore_errors = kwargs.pop('ignore_archive_errors', False)
+        ignore_errors = kwargs.pop('ignore_errors', False)
 
         self.logger.info('Archiving instance started.')
         self.disable_monitoring()


### PR DESCRIPTION
Description
========

This PR makes it possible to ignore errors when removing dns entries from Gandi. This is required when archiving an OpenEdxInstance whenever the Gandi account does not contain the domain for the instance any longer.

The original behaviour was kept and it's possible to enable this by passing `ignore_errors` or `ignore_dns_errors` to both `.archive()` and `.delete()`.

Testing
-------

1. Create an instance in the Stage environment using the shell:
```
from instance.factories import production_instance_factory
i = production_instance_factory(name="Deletion Test", sub_domain="deletiontest")
i.archive()
```
2. Make sure the instance has a DNS that isn't managed by Gandi:
```
i.internal_lms_domain = 'deletiontest.sandbox.com'
i.save()
```
3. Update it to be removed by the delete_archived script:
```
from datetime import datetime as dt
i.ref.modified = dt.fromtimestamp(0)
i.ref.save(update_modified=False)
```
4. Test it isn't possible to delete the instance due to DNS issues:
```
i.delete()
(...)
ValueError: The given domain name "deletiontest.sandbox.com" does not match any domain registered in the Gandi account.
```
5. Leave the shell, run the management command and make sure the instance is deleted:
```
$ honcho run ./manage.py delete_archived 12
2019-10-01 21:43:23 | Starting delete_archived
2019-10-01 21:43:23 | Found 1 archived instances older than 12 months...
2019-10-01 21:43:23 | - Instance: deletiontest.sandbox.com
Are you absolutely sure you want to delete these instances? [y/N]
y
2019-10-01 21:43:27 | Deleting deletiontest.sandbox.com...
(...)
2019-10-01 21:43:30 | Deleted 1 archived instances older than 12 months.
```