### PR TITLE
SE-1577 Conditionally add djangoapps.heartbeat

### DIFF
--- a/instance/models/mixins/openedx_config.py
+++ b/instance/models/mixins/openedx_config.py
@@ -57,14 +57,14 @@ class OpenEdXConfigMixin(ConfigMixinBase):
             # EDXAPP_ENV_EXTRA as the other two overwrite this.
             "EDXAPP_CMS_ENV_EXTRA": {
                 "ADDL_INSTALLED_APPS": [
-                    "openedx.core.djangoapps.heartbeat",
                 ],
             },
             "EDXAPP_LMS_ENV_EXTRA": {
                 "ADDL_INSTALLED_APPS": [
-                    "openedx.core.djangoapps.heartbeat",
                 ],
                 "HEARTBEAT_EXTENDED_CHECKS": [
+                    # celery check is default, but we need to include it here
+                    # because we also add other extended checks
                     "openedx.core.djangoapps.heartbeat.default_checks.check_celery",
                 ],
             },
@@ -414,6 +414,14 @@ class OpenEdXConfigMixin(ConfigMixinBase):
         else:
             forum_hb_path = "lms.lib.comment_client.utils.check_forum_heartbeat"
         template["EDXAPP_LMS_ENV_EXTRA"]["HEARTBEAT_EXTENDED_CHECKS"].append(forum_hb_path)
+
+        # master has djangoapps.heartbeat installed by default now.
+        # openedx <= ironwood requires this if celery check is included in
+        # heartbeat extended checks (which we add by default above)
+        if self.openedx_release != 'master':
+            hb_app = "openedx.core.djangoapps.heartbeat"
+            template["EDXAPP_CMS_ENV_EXTRA"]["ADDL_INSTALLED_APPS"].append(hb_app)
+            template["EDXAPP_LMS_ENV_EXTRA"]["ADDL_INSTALLED_APPS"].append(hb_app)
 
         return template
 


### PR DESCRIPTION
This prevents the djangoapps.heartbeats app from being added on master openedx
instances by default. Since https://github.com/edx/edx-platform/pull/21633 was
merged, djangoapps.heartbeats is installed by default. Attempting to add again
will result in an error from django about adding duplicate apps.

The only reason this isn't already causing master sandboxes to fail is because
https://github.com/edx/configuration/pull/5400 hasn't been merged yet (at time
of writing); currently the `EDXAPP_*_ENV_EXTRA` blocks aren't being picked up
by the configuration so our defaults aren't being applied on master anyway.

**Dependencies**: None

**Merge deadline**: ASAP - let's avoid more broken master sandboxes

**Testing instructions**:

1. deploy ocim with this branch
2. launch a master openedx sandbox with the configuration branch from
   https://github.com/edx/configuration/pull/5400 (or master if this has
   already been merged).
3. verify that provisioning works (no duplicate app error)
4. verify that lms extended heartbeat url returns celery and forum heartbeats
   successfully and studio extended heartbeat returns celery successfully
5. deploy an ironwood openedx sandbox
6. verify that the lms and studio extended heartbeats url successfully shows
   celery (for both) and forum (lms only) heartbeats


**Reviewers**
- [x] @SSPJ 

