### PR TITLE
[SE-1603] Mock Consul for unit tests

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -20,3 +20,5 @@ DEFAULT_LOAD_BALANCING_SERVER='ubuntu@haproxy-test.fake.domain'
 LOAD_BALANCER_FRAGMENT_NAME_PREFIX='opencraft-'
 DEFAULT_RABBITMQ_API_URL='https://admin:password@rabbitmq.example.com:15671'
 DEFAULT_INSTANCE_RABBITMQ_URL='amqps://rabbitmq.example.com:5671'
+CONSUL_ENABLED: false
+DISABLE_LOAD_BALANCER_CONFIGURATION: false

--- a/instance/models/openedx_instance.py
+++ b/instance/models/openedx_instance.py
@@ -156,7 +156,7 @@ class OpenEdXInstance(
                 'Direct load balancer reconfiguration disabled. No haproxy '
                 'configuration fragment and backend map will be generated.'
             )
-            return "", ""
+            return [], []
 
         active_appservers = self.get_active_appservers()
         if not active_appservers.exists():

--- a/instance/tests/management/test_delete_archived.py
+++ b/instance/tests/management/test_delete_archived.py
@@ -52,15 +52,19 @@ class DeleteArchivedTestCase(TestCase):
             ('old', 200),
         ]
 
-        for name, days in instances:
-            instance = OpenEdXInstance.objects.create(
-                sub_domain=name,
-                openedx_release='z.1',
-                successfully_provisioned=True
-            )
-            instance.ref.is_archived = True
-            instance.ref.modified -= timedelta(days=days)
-            instance.ref.save(update_modified=False)
+        with patch(
+                'instance.models.openedx_instance.OpenEdXInstance._write_metadata_to_consul',
+                return_value=(1, True)
+        ):
+            for name, days in instances:
+                instance = OpenEdXInstance.objects.create(
+                    sub_domain=name,
+                    openedx_release='z.1',
+                    successfully_provisioned=True
+                )
+                instance.ref.is_archived = True
+                instance.ref.modified -= timedelta(days=days)
+                instance.ref.save(update_modified=False)
 
     def test_zero_instances_deleted(self):
         """

--- a/instance/tests/management/test_reprovision_buckets.py
+++ b/instance/tests/management/test_reprovision_buckets.py
@@ -48,6 +48,10 @@ class ReprovisionBucketsTestCase(TestCase):
             'Found "0" active instances',
             [l[2] for l in captured_logs.actual()])
 
+    @patch(
+        'instance.models.openedx_instance.OpenEdXInstance._write_metadata_to_consul',
+        return_value=(1, True)
+    )
     @patch('instance.models.mixins.storage.S3BucketInstanceMixin._enable_bucket_versioning')
     @patch('instance.models.mixins.storage.S3BucketInstanceMixin._update_bucket_lifecycle')
     @patch('instance.models.mixins.storage.S3BucketInstanceMixin._update_bucket_cors')
@@ -60,7 +64,8 @@ class ReprovisionBucketsTestCase(TestCase):
                      mock_create_bucket,
                      mock_update_cors,
                      mock_update_lifecycle,
-                     mock_enable_versioning):
+                     mock_enable_versioning,
+                     mock_consul):
         """
         Verify that the command correctly reprovision the bucket for an instance.
         """

--- a/instance/tests/models/test_load_balancer.py
+++ b/instance/tests/models/test_load_balancer.py
@@ -60,6 +60,7 @@ def mock_instances():
     ]
 
 
+@override_settings(DISABLE_LOAD_BALANCER_CONFIGURATION=False)
 class LoadBalancingServerTest(TestCase):
     """
     Test cases for the LoadBalancingServer model.
@@ -69,6 +70,7 @@ class LoadBalancingServerTest(TestCase):
         self.load_balancer = LoadBalancingServerFactory()
 
     @patch('instance.models.load_balancer.LoadBalancingServer.get_instances', return_value=mock_instances())
+    @override_settings(DISABLE_LOAD_BALANCER_CONFIGURATION=False)
     def test_get_configuration(self, mock_get_instances):
         """
         Test that the configuration gets rendered correctly.
@@ -106,6 +108,7 @@ class LoadBalancingServerTest(TestCase):
     @patch("instance.ansible.poll_streams")
     @patch("instance.ansible.run_playbook")
     @patch('instance.models.load_balancer.LoadBalancingServer.get_instances', return_value=mock_instances())
+    @override_settings(DISABLE_LOAD_BALANCER_CONFIGURATION=False)
     def test_reconfigure_fails(self, mock_get_instances, mock_run_playbook, mock_poll_streams):
         """
         Test that the reconfigure() method gives us a dirty LB if the playbook fails.
@@ -119,6 +122,7 @@ class LoadBalancingServerTest(TestCase):
     @patch("instance.ansible.poll_streams")
     @patch("instance.ansible.run_playbook")
     @patch('instance.models.load_balancer.LoadBalancingServer.get_instances', return_value=mock_instances())
+    @override_settings(DISABLE_LOAD_BALANCER_CONFIGURATION=False)
     def test_deconfigure(self, mock_get_instances, mock_run_playbook, mock_poll_streams):
         """
         Test that the deconfigure() method triggers a playbook run.
@@ -132,7 +136,10 @@ class LoadBalancingServerManager(TestCase):
     """
     Tests for LoadBalancingServerManager.
     """
-    @override_settings(DEFAULT_LOAD_BALANCING_SERVER=None)
+    @override_settings(
+        DEFAULT_LOAD_BALANCING_SERVER=None,
+        DISABLE_LOAD_BALANCER_CONFIGURATION=False
+    )
     def test_no_load_balancer_available(self):
         """
         Test that get_random() raises an exception when no load balancers are available.
@@ -140,7 +147,10 @@ class LoadBalancingServerManager(TestCase):
         with self.assertRaises(LoadBalancingServer.DoesNotExist):
             LoadBalancingServer.objects.select_random()
 
-    @override_settings(DEFAULT_LOAD_BALANCING_SERVER="domain.without.username")
+    @override_settings(
+        DEFAULT_LOAD_BALANCING_SERVER="domain.without.username",
+        DISABLE_LOAD_BALANCER_CONFIGURATION=False
+    )
     def test_invalid_default_load_balancer(self):
         """
         Verify that an exception gets raised when the username is missing from the setting for the

--- a/instance/tests/models/test_openedx_ansible_mixins.py
+++ b/instance/tests/models/test_openedx_ansible_mixins.py
@@ -38,12 +38,16 @@ from instance.tests.utils import patch_services
 
 
 @ddt.ddt
+@patch(
+    'instance.tests.models.factories.openedx_instance.OpenEdXInstance._write_metadata_to_consul',
+    return_value=(1, True)
+)
 class AnsibleAppServerTestCase(TestCase):
     """
     Test cases for AnsibleAppServerMixin models
     """
     @patch_services
-    def test_inventory_str(self, mocks):
+    def test_inventory_str(self, mocks, mock_consul):
         """
         Ansible inventory string - should contain the public IP of the AppServer's VM
         """
@@ -61,7 +65,7 @@ class AnsibleAppServerTestCase(TestCase):
         )
 
     @patch_services
-    def test_inventory_str_no_server(self, mocks):
+    def test_inventory_str_no_server(self, mocks, mock_consul):
         """
         Ansible inventory string - should raise an exception if the server has no public IP
         """
@@ -92,7 +96,8 @@ class AnsibleAppServerTestCase(TestCase):
             mock_open_repo,
             mock_inventory,
             mock_run_playbook,
-            mock_poll_streams
+            mock_poll_streams,
+            mock_consul
     ):
         """
         The appserver gets provisioned with the appropriate playbooks.
@@ -130,7 +135,7 @@ class AnsibleAppServerTestCase(TestCase):
 
     @patch('instance.models.mixins.ansible.ansible.run_playbook')
     @patch('instance.models.mixins.ansible.AnsibleAppServerMixin.inventory_str')
-    def test_run_playbook_logging(self, mock_inventory_str, mock_run_playbook):
+    def test_run_playbook_logging(self, mock_inventory_str, mock_run_playbook, mock_consul):
         """
         Ensure logging routines are working on _run_playbook method
         """

--- a/instance/tests/models/test_openedx_database_mixins.py
+++ b/instance/tests/models/test_openedx_database_mixins.py
@@ -50,6 +50,10 @@ from instance.tests.utils import patch_services
 
 # Tests #######################################################################
 
+@patch(
+    'instance.tests.models.factories.openedx_instance.OpenEdXInstance._write_metadata_to_consul',
+    return_value=(1, True)
+)
 class MySQLInstanceTestCase(TestCase):
     """
     Test cases for MySQLInstanceMixin and OpenEdXDatabaseMixin
@@ -60,7 +64,11 @@ class MySQLInstanceTestCase(TestCase):
 
     def tearDown(self):
         if self.instance:
-            self.instance.deprovision_mysql()
+            with patch(
+                    'instance.tests.models.factories.openedx_instance.OpenEdXInstance._write_metadata_to_consul',
+                    return_value=(1, True)
+            ):
+                self.instance.deprovision_mysql()
         super().tearDown()
 
     def _assert_privileges(self, database):
@@ -133,7 +141,7 @@ class MySQLInstanceTestCase(TestCase):
             var_name = prefix + var_name
             self.assertEqual(db_vars[var_name], value)
 
-    def test__get_mysql_database_name(self):
+    def test__get_mysql_database_name(self, mock_consul):
         """
         Test that _get_mysql_database_name correctly builds database names.
         """
@@ -150,7 +158,7 @@ class MySQLInstanceTestCase(TestCase):
         with self.assertRaises(AssertionError):
             self.instance._get_mysql_database_name(suffix)
 
-    def test__get_mysql_user_name(self):
+    def test__get_mysql_user_name(self, mock_consul):
         """
         Test that _get_mysql_user_name correctly builds user names.
         """
@@ -167,7 +175,7 @@ class MySQLInstanceTestCase(TestCase):
         with self.assertRaises(AssertionError):
             self.instance._get_mysql_user_name(suffix)
 
-    def test__get_mysql_pass(self):
+    def test__get_mysql_pass(self, mock_consul):
         """
         Test behavior of _get_mysql_pass.
 
@@ -189,7 +197,7 @@ class MySQLInstanceTestCase(TestCase):
         self.assertEqual(pass1, self.instance._get_mysql_pass(user1))
         self.assertEqual(pass2, self.instance._get_mysql_pass(user2))
 
-    def test__get_mysql_pass_from_dbname(self):
+    def test__get_mysql_pass_from_dbname(self, mock_consul):
         """
         Test that _get_mysql_pass_from_dbname meets the same criteria as _get_mysql_pass
         """
@@ -204,7 +212,7 @@ class MySQLInstanceTestCase(TestCase):
         self.assertEqual(pass1, self.instance._get_mysql_pass_from_dbname(database1))
         self.assertEqual(pass2, self.instance._get_mysql_pass_from_dbname(database2))
 
-    def test_provision_mysql(self):
+    def test_provision_mysql(self, mock_consul):
         """
         Provision mysql database
         """
@@ -212,7 +220,7 @@ class MySQLInstanceTestCase(TestCase):
         self.instance.provision_mysql()
         self.check_mysql()
 
-    def test_provision_mysql_weird_domain(self):
+    def test_provision_mysql_weird_domain(self, mock_consul):
         """
         Make sure that database names are escaped correctly
         """
@@ -223,7 +231,7 @@ class MySQLInstanceTestCase(TestCase):
         self.instance.provision_mysql()
         self.check_mysql()
 
-    def test_provision_mysql_again(self):
+    def test_provision_mysql_again(self, mock_consul):
         """
         Only create the database once
         """
@@ -238,7 +246,7 @@ class MySQLInstanceTestCase(TestCase):
         self.assertEqual(self.instance.mysql_pass, mysql_pass)
         self.check_mysql()
 
-    def test_provision_mysql_no_mysql_server(self):
+    def test_provision_mysql_no_mysql_server(self, mock_consul):
         """
         Don't provision a mysql database if instance has no MySQL server
         """
@@ -252,7 +260,7 @@ class MySQLInstanceTestCase(TestCase):
 
     @patch_services
     @override_settings(DEFAULT_INSTANCE_MYSQL_URL='mysql://user:pass@mysql.opencraft.com')
-    def test_ansible_settings_mysql(self, mocks):
+    def test_ansible_settings_mysql(self, mocks, mock_consul):
         """
         Test that get_database_settings produces correct settings for MySQL databases
         """
@@ -366,7 +374,7 @@ class MySQLInstanceTestCase(TestCase):
             else:
                 self.check_vars(self.instance, db_vars, group_prefix, values=values)
 
-    def test_ansible_settings_no_mysql_server(self):
+    def test_ansible_settings_no_mysql_server(self, mock_consul):
         """
         Don't add mysql ansible vars if instance has no MySQL server
         """
@@ -378,7 +386,7 @@ class MySQLInstanceTestCase(TestCase):
     @patch('instance.models.mixins.database._get_mysql_cursor', return_value=Mock())
     @patch('instance.models.mixins.database._drop_database')
     @patch('instance.models.mixins.database._drop_user')
-    def test_deprovision_mysql(self, mock_drop_user, mock_drop_database, mock_get_cursor):
+    def test_deprovision_mysql(self, mock_drop_user, mock_drop_database, mock_get_cursor, mock_consul):
         """
         Test deprovision_mysql does correct calls.
         """
@@ -394,7 +402,7 @@ class MySQLInstanceTestCase(TestCase):
     @patch('instance.models.mixins.database._get_mysql_cursor', return_value=Mock())
     @patch('instance.models.mixins.database._drop_database', side_effect=MySQLError())
     @patch('instance.models.mixins.database._drop_user')
-    def test_ignore_errors_deprovision_mysql(self, mock_drop_user, mock_drop_database, mock_get_cursor):
+    def test_ignore_errors_deprovision_mysql(self, mock_drop_user, mock_drop_database, mock_get_cursor, mock_consul):
         """
         Test mysql is set as deprovision when ignoring errors.
         """
@@ -405,6 +413,10 @@ class MySQLInstanceTestCase(TestCase):
 
 
 @ddt.ddt
+@patch(
+    'instance.tests.models.factories.openedx_instance.OpenEdXInstance._write_metadata_to_consul',
+    return_value=(1, True)
+)
 class MongoDBInstanceTestCase(TestCase):
     """
     Test cases for MongoDBInstanceMixin and OpenEdXDatabaseMixin
@@ -415,7 +427,11 @@ class MongoDBInstanceTestCase(TestCase):
 
     def tearDown(self):
         if self.instance:
-            self.instance.deprovision_mongo()
+            with patch(
+                    'instance.tests.models.factories.openedx_instance.OpenEdXInstance._write_metadata_to_consul',
+                    return_value=(1, True)
+            ):
+                self.instance.deprovision_mongo()
         super().tearDown()
 
     def check_mongo(self):
@@ -463,7 +479,7 @@ class MongoDBInstanceTestCase(TestCase):
         self.assertIn('FORUM_MONGO_PORT: {0}'.format(MONGODB_SERVER_DEFAULT_PORT), ansible_vars)
         self.assertIn('FORUM_MONGO_DATABASE: {0}'.format(self.instance.forum_database_name), ansible_vars)
 
-    def test_provision_mongo(self):
+    def test_provision_mongo(self, mock_consul):
         """
         Provision mongo databases
         """
@@ -471,7 +487,7 @@ class MongoDBInstanceTestCase(TestCase):
         self.instance.provision_mongo()
         self.check_mongo()
 
-    def test_provision_mongo_again(self):
+    def test_provision_mongo_again(self, mock_consul):
         """
         Only create the databases once
         """
@@ -486,7 +502,7 @@ class MongoDBInstanceTestCase(TestCase):
         self.assertEqual(self.instance.mongo_pass, mongo_pass)
         self.check_mongo()
 
-    def test_provision_mongo_no_mongodb_server(self):
+    def test_provision_mongo_no_mongodb_server(self, mock_consul):
         """
         Don't provision a mongo database if instance has no MongoDB server
         """
@@ -500,7 +516,7 @@ class MongoDBInstanceTestCase(TestCase):
             self.assertNotIn(database, databases)
 
     @override_settings(DEFAULT_INSTANCE_MONGO_URL='mongodb://user:pass@mongo.opencraft.com')
-    def test_ansible_settings_mongo(self):
+    def test_ansible_settings_mongo(self, mock_consul):
         """
         Add mongo ansible vars if instance has a MongoDB server
         """
@@ -525,7 +541,7 @@ class MongoDBInstanceTestCase(TestCase):
         ('open-release/ginkgo', 'open-release/ginkgo'),
     )
     @ddt.unpack
-    def test_ansible_settings_no_replica_set(self, openedx_release, configuration_version):
+    def test_ansible_settings_no_replica_set(self, openedx_release, configuration_version, mock_consul):
         """
         Prior to Hawthorn, edx configuration does not support MongoDB replica sets,
         and the mongo hosts must be a single host, provided as a list of strings.
@@ -552,7 +568,7 @@ class MongoDBInstanceTestCase(TestCase):
         (settings.DEFAULT_OPENEDX_RELEASE, settings.DEFAULT_CONFIGURATION_VERSION),
     )
     @ddt.unpack
-    def test_ansible_settings_use_replica_set(self, openedx_release, configuration_version):
+    def test_ansible_settings_use_replica_set(self, openedx_release, configuration_version, mock_consul):
         """
         Add mongo ansible vars if instance has a MongoDB replica set
         Also, the mongo hosts are provied as a comma-separated string.
@@ -569,7 +585,7 @@ class MongoDBInstanceTestCase(TestCase):
                                                  r'test\d?.opencraft.hosting',
                                   expected_replica_set='test_name')
 
-    def test_ansible_settings_no_mongo_server(self):
+    def test_ansible_settings_no_mongo_server(self, mock_consul):
         """
         Don't add mongo ansible vars if instance has no MongoDB server
         """
@@ -587,7 +603,7 @@ class MongoDBInstanceTestCase(TestCase):
         DEFAULT_MONGO_REPLICA_SET_PRIMARY="test.opencraft.hosting",
         DEFAULT_MONGO_REPLICA_SET_HOSTS="test.opencraft.hosting,test1.opencraft.hosting,test2.opencraft.hosting"
     )
-    def test__get_main_database_url(self):
+    def test__get_main_database_url(self, mock_consul):
         """
         Main database url should be extracted from primary replica set MongoDBServer
         """
@@ -599,7 +615,7 @@ class MongoDBInstanceTestCase(TestCase):
 
     @patch('instance.models.mixins.database.MongoDBInstanceMixin._get_main_database_url')
     @patch('instance.models.mixins.database.pymongo.MongoClient', autospec=True)
-    def test_deprovision_mongo(self, mock_mongo_client_cls, mock_get_main_db_url):
+    def test_deprovision_mongo(self, mock_mongo_client_cls, mock_get_main_db_url, mock_consul):
         """
         Test deprovision_mongo calls drop_database.
         """
@@ -623,13 +639,21 @@ class MongoDBInstanceTestCase(TestCase):
 
 
 @ddt.ddt
+@patch(
+    'instance.tests.models.factories.openedx_instance.OpenEdXInstance._write_metadata_to_consul',
+    return_value=(1, True)
+)
 class RabbitMQInstanceTestCase(TestCase):
     """
     Test cases for RabbitMQInstanceMixin
     """
     def setUp(self):
         super().setUp()
-        self.instance = OpenEdXInstanceFactory()
+        with patch(
+                'instance.tests.models.factories.openedx_instance.OpenEdXInstance._write_metadata_to_consul',
+                return_value=(1, True)
+        ):
+            self.instance = OpenEdXInstanceFactory()
 
     @responses.activate
     @ddt.data(
@@ -638,7 +662,7 @@ class RabbitMQInstanceTestCase(TestCase):
         ('DELETE', ['permissions', '/some_vhost', 'testuser'], '/api/permissions/%2Fsome_vhost/testuser')
     )
     @ddt.unpack
-    def test_rabbitmq_request(self, method, url_parts, expected_url):
+    def test_rabbitmq_request(self, method, url_parts, expected_url, mock_consul):
         """
         Test to make sure the _rabbitmq_request parameters form the correct URLs
         """
@@ -648,11 +672,15 @@ class RabbitMQInstanceTestCase(TestCase):
         )
         expected_body = {'info': 'This is a mocked request to URL {url}'.format(url=url)}
 
-        # Mock the URL with a uniquely identifying body so that we can verify that the
-        # correct URL is formed and called.
-        responses.add(method, url, json=expected_body)
-        self.instance = OpenEdXInstanceFactory()
-        response = self.instance._rabbitmq_request(method.lower(), *url_parts)
+        with patch(
+                'instance.tests.models.factories.openedx_instance.OpenEdXInstance._write_metadata_to_consul',
+                return_value=(1, True)
+        ):
+            # Mock the URL with a uniquely identifying body so that we can verify that the
+            # correct URL is formed and called.
+            responses.add(method, url, json=expected_body)
+            self.instance = OpenEdXInstanceFactory()
+            response = self.instance._rabbitmq_request(method.lower(), *url_parts)
 
         self.assertDictEqual(
             response.json(),
@@ -660,10 +688,10 @@ class RabbitMQInstanceTestCase(TestCase):
         )
 
     @responses.activate
-    def test_provision_rabbitmq(self):
+    def test_provision_rabbitmq(self, mock_consul):
         """
         Record the calls to the RabbitMQ API and make sure a new vhost along with
-        two new users are created during provision and deleted during deprobision.
+        two new users are created during provision and deleted during deprovision.
 
         The use of `responses.RequestsMock` raises an exception during context deconstruction
         if any of the URLs added to the `responses` object aren't ever called. Also,
@@ -712,7 +740,7 @@ class RabbitMQInstanceTestCase(TestCase):
             self.instance.deprovision_rabbitmq()
 
     @responses.activate
-    def test_rabbitmq_api_error(self):
+    def test_rabbitmq_api_error(self, mock_consul):
         """
         Test that RabbitMQAPIError is thrown during auth issues
         """
@@ -733,7 +761,7 @@ class RabbitMQInstanceTestCase(TestCase):
         ({'name': 'test', 'description': 'test description'}, 'test (test description)')
     )
     @ddt.unpack
-    def test_string_representation(self, fields, representation):
+    def test_string_representation(self, fields, representation, mock_consul):
         """
         Test that the str method returns the appropriate values.
         """
@@ -744,7 +772,7 @@ class RabbitMQInstanceTestCase(TestCase):
         self.assertEqual(str(rabbitmq), representation)
 
     @patch('instance.models.mixins.rabbitmq.RabbitMQInstanceMixin._rabbitmq_request')
-    def test_deprovision_rabbitmq(self, mock_rabbitmq_request):
+    def test_deprovision_rabbitmq(self, mock_rabbitmq_request, mock_consul):
         """
         Test deprovision_rabbitmq does correct calls.
         """
@@ -755,7 +783,7 @@ class RabbitMQInstanceTestCase(TestCase):
         mock_rabbitmq_request.assert_any_call('delete', 'users', self.instance.rabbitmq_provider_user.username)
 
     @patch('instance.models.mixins.rabbitmq.RabbitMQInstanceMixin._rabbitmq_request', side_effect=RabbitMQAPIError())
-    def test_ignore_errors_deprovision_rabbitmq(self, mock_rabbitmq_request):
+    def test_ignore_errors_deprovision_rabbitmq(self, mock_rabbitmq_request, mock_consul):
         """
         Test rabbitmq is set as deprovision when ignoring errors.
         """
@@ -764,12 +792,16 @@ class RabbitMQInstanceTestCase(TestCase):
         self.assertFalse(self.instance.rabbitmq_provisioned)
 
 
+@patch(
+    'instance.tests.models.factories.openedx_instance.OpenEdXInstance._write_metadata_to_consul',
+    return_value=(1, True)
+)
 class RabbitMQServerManagerTestCase(TestCase):
     """
     Tests for RabbitMQServerManager.
     """
     @override_settings(DEFAULT_RABBITMQ_API_URL=None)
-    def test_no_rabbitmq_server_available(self):
+    def test_no_rabbitmq_server_available(self, mock_consul):
         """
         Test that get_random() raises an exception when no rabbitmq servers are available.
         """
@@ -778,7 +810,7 @@ class RabbitMQServerManagerTestCase(TestCase):
             RabbitMQServer.objects.select_random()
 
     @override_settings(DEFAULT_RABBITMQ_API_URL="http://doesnotexist.example.com:12345")
-    def test_invalid_rabbitmq_server(self):
+    def test_invalid_rabbitmq_server(self, mock_consul):
         """
         Verify that an exception gets raised when the credentials are missing from from the
         setting for the default rabbitmq API url server.
@@ -787,7 +819,7 @@ class RabbitMQServerManagerTestCase(TestCase):
             RabbitMQServer.objects.select_random()
 
     @patch('instance.models.rabbitmq_server.logger')
-    def test_mismatch_warning(self, mock_logger):
+    def test_mismatch_warning(self, mock_logger, mock_consul):
         """
         Test that a warning is logged when trying to spawn the default, but a default already
         and contains mismatching parameters with the given settings.

--- a/instance/tests/models/test_openedx_instance.py
+++ b/instance/tests/models/test_openedx_instance.py
@@ -53,6 +53,10 @@ from instance.tests.utils import patch_services, skip_unless_consul_running
 # Tests #######################################################################
 
 @ddt.ddt
+@patch(
+    'instance.tests.models.factories.openedx_instance.OpenEdXInstance._write_metadata_to_consul',
+    return_value=(1, True)
+)
 class OpenEdXInstanceTestCase(TestCase):
     """
     Test cases for OpenEdXInstance models
@@ -92,7 +96,7 @@ class OpenEdXInstanceTestCase(TestCase):
         self.assertTrue(instance.rabbitmq_consumer_user)
         self.assertTrue(instance.rabbitmq_provider_user)
 
-    def test_create_defaults(self):
+    def test_create_defaults(self, mock_consul):
         """
         Create an instance without specifying additional fields,
         leaving it up to the create method to set them
@@ -100,7 +104,7 @@ class OpenEdXInstanceTestCase(TestCase):
         instance = OpenEdXInstance.objects.create(sub_domain='sandbox.defaults')
         self._assert_defaults(instance)
 
-    def test_id_different_from_ref_id(self):
+    def test_id_different_from_ref_id(self, mock_consul):
         """
         Check that InstanceReference IDs are always multiples of 10, and OpenEdXInstance IDs
         usually are different from the InstanceReference ID. This is established by the
@@ -123,7 +127,7 @@ class OpenEdXInstanceTestCase(TestCase):
             (instance1.id != instance1.ref.id) or (instance2.id != instance2.ref.id)
         )
 
-    def test_domain_url(self):
+    def test_domain_url(self, mock_consul):
         """
         Domain and URL attributes
         """
@@ -197,7 +201,7 @@ class OpenEdXInstanceTestCase(TestCase):
     @ddt.data('http://example.com/default-test-spawn-privacy', '')
     @patch_services
     @patch('instance.models.openedx_appserver.OpenEdXAppServer.provision', return_value=True)
-    def test_spawn_appserver(self, mocks, privacy_policy_url, mock_provision):
+    def test_spawn_appserver(self, mocks, privacy_policy_url, mock_consul, mock_provision):
         """
         Run spawn_appserver() sequence
         """
@@ -259,7 +263,7 @@ class OpenEdXInstanceTestCase(TestCase):
     @override_settings(NEWRELIC_LICENSE_KEY='newrelic-key')
     @patch_services
     @patch('instance.models.openedx_appserver.OpenEdXAppServer.provision', return_value=True)
-    def test_newrelic_configuration(self, mocks, mock_provision):
+    def test_newrelic_configuration(self, mocks, mock_provision, mock_consul):
         """
         Check that newrelic ansible vars are set correctly
         """
@@ -275,7 +279,7 @@ class OpenEdXInstanceTestCase(TestCase):
 
     @patch_services
     @patch('instance.models.openedx_appserver.OpenEdXAppServer.provision', return_value=True)
-    def test_appserver_services_disabled(self, mocks, mock_provision):
+    def test_appserver_services_disabled(self, mocks, mock_provision, mock_consul):
         """
         Check that appservers are deployed with only the minimum services by default
         """
@@ -291,7 +295,7 @@ class OpenEdXInstanceTestCase(TestCase):
 
     @patch_services
     @patch('instance.models.openedx_appserver.OpenEdXAppServer.provision', return_value=True)
-    def test_spawn_appserver_with_external_domains(self, mocks, mock_provision):
+    def test_spawn_appserver_with_external_domains(self, mocks, mock_provision, mock_consul):
         """
         Test that relevant configuration variables use external domains when provisioning a new app server.
         """
@@ -312,7 +316,7 @@ class OpenEdXInstanceTestCase(TestCase):
 
     @patch_services
     @patch('instance.models.openedx_appserver.OpenEdXAppServer.provision', return_value=True)
-    def test_spawn_appserver_names(self, mocks, mock_provision):
+    def test_spawn_appserver_names(self, mocks, mock_provision, mock_consul):
         """
         Run spawn_appserver() sequence multiple times and check names of resulting app servers
         """
@@ -332,7 +336,7 @@ class OpenEdXInstanceTestCase(TestCase):
 
     @patch_services
     @patch('instance.models.openedx_appserver.OpenEdXAppServer.provision', return_value=True)
-    def test_spawn_appserver_with_lms_users(self, mocks, mock_provision):
+    def test_spawn_appserver_with_lms_users(self, mocks, mock_provision, mock_consul):
         """
         Provision an AppServer with a user added to lms_users.
         """
@@ -346,7 +350,7 @@ class OpenEdXInstanceTestCase(TestCase):
         self.assertTrue(appserver.lms_user_settings)
 
     @patch_services
-    def test_spawn_appserver_detailed(self, mocks):
+    def test_spawn_appserver_detailed(self, mocks, mock_consul):
         """
         Test spawning an AppServer in more detail; this is partially an integration test
 
@@ -375,7 +379,7 @@ class OpenEdXInstanceTestCase(TestCase):
         self.assertEqual(appserver.server.status, Server.Status.Ready)
 
     @patch_services
-    def test_spawn_appserver_failed(self, mocks):
+    def test_spawn_appserver_failed(self, mocks, mock_consul):
         """
         Test what happens when unable to completely spawn an AppServer.
         """
@@ -397,7 +401,7 @@ class OpenEdXInstanceTestCase(TestCase):
 
     @patch_services
     @patch('instance.models.openedx_appserver.OpenEdXAppServer.provision', return_value=True)
-    def test_spawn_appserver_with_external_databases(self, mocks, mock_provision):
+    def test_spawn_appserver_with_external_databases(self, mocks, mock_provision, mock_consul):
         """
         Run spawn_appserver() sequence, with external databases
         """
@@ -417,7 +421,7 @@ class OpenEdXInstanceTestCase(TestCase):
 
     @patch_services
     @patch('instance.models.openedx_appserver.OpenEdXAppServer.provision', return_value=True)
-    def test_forum_api_key(self, mocks, mock_provision):
+    def test_forum_api_key(self, mocks, mock_provision, mock_consul):
         """
         Ensure the FORUM_API_KEY matches EDXAPP_COMMENTS_SERVICE_KEY
         """
@@ -454,9 +458,10 @@ class OpenEdXInstanceTestCase(TestCase):
         self.assertIn('be-redirect-edxins', backend)
         self.assertIn(expected_config, config_str)
 
+    @override_settings(DISABLE_LOAD_BALANCER_CONFIGURATION=False)
     @ddt.data(False, True)
     @patch_services
-    def test_get_load_balancer_configuration(self, mocks, enable_prefix_domains_redirect):
+    def test_get_load_balancer_configuration(self, mocks, enable_prefix_domains_redirect, mock_consul):
         """
         Test that the load balancer configuration gets generated correctly.
         """
@@ -503,9 +508,10 @@ class OpenEdXInstanceTestCase(TestCase):
             appserver.server.save()
             self.assertRaises(WrongStateException, instance.get_load_balancer_configuration)
 
+    @override_settings(DISABLE_LOAD_BALANCER_CONFIGURATION=False)
     @ddt.data(False, True)
     @patch_services
-    def test_get_load_balancer_config_ext_domains(self, mocks, enable_prefix_domains_redirect):
+    def test_get_load_balancer_config_ext_domains(self, mocks, enable_prefix_domains_redirect, mock_consul):
         """
         Test the load balancer configuration when external domains are set.
         """
@@ -576,6 +582,8 @@ class OpenEdXInstanceTestCase(TestCase):
         instance = OpenEdXInstanceFactory(sub_domain='test.deletion')
         instance_ref = instance.ref
         appserver = OpenEdXAppServer.objects.get(pk=instance.spawn_appserver())
+
+        mock_methods = list(mock_methods).pop()  # Remove mock_consul
 
         for method in mock_methods:
             self.assertEqual(
@@ -648,7 +656,7 @@ class OpenEdXInstanceTestCase(TestCase):
             server = OpenStackServer.objects.get(id=appserver.server.pk)
             self.assertEqual(server.status, expected_server_status)
 
-    def test_first_activated(self):
+    def test_first_activated(self, mock_consul):
         """
         Test that the ``first_activated`` property correctly fetches the ``last_activated``
         time for the first ``AppServer`` to activate.
@@ -692,10 +700,12 @@ class OpenEdXInstanceTestCase(TestCase):
         appserver_2._status_to_terminated()
         self.assertEqual(instance.first_activated, appserver_2.last_activated)
 
+    @override_settings(DISABLE_LOAD_BALANCER_CONFIGURATION=False)
+    @patch('instance.tests.models.factories.openedx_instance.OpenEdXInstance.purge_consul_metadata')
     @patch('instance.models.mixins.load_balanced.LoadBalancedInstance.remove_dns_records')
     @patch('instance.models.mixins.openedx_monitoring.OpenEdXMonitoringMixin.disable_monitoring')
     @patch('instance.models.load_balancer.LoadBalancingServer.reconfigure')
-    def test_archive(self, mock_reconfigure, mock_disable_monitoring, mock_remove_dns_records):
+    def test_archive(self, mock_reconfigure, mock_disable_monitoring, mock_remove_dns_records, *mock):
         """
         Test that `archive` method terminates all app servers belonging to an instance
         and disables monitoring.
@@ -762,10 +772,18 @@ class OpenEdXInstanceTestCase(TestCase):
             (newer_appserver_failed, AppServerStatus.ConfigurationFailed, ServerStatus.Terminated),
         ])
 
+    @override_settings(DISABLE_LOAD_BALANCER_CONFIGURATION=False)
+    @patch('instance.tests.models.factories.openedx_instance.OpenEdXInstance.purge_consul_metadata')
     @patch('instance.models.mixins.load_balanced.LoadBalancedInstance.remove_dns_records')
     @patch('instance.models.mixins.openedx_monitoring.OpenEdXMonitoringMixin.disable_monitoring')
     @patch('instance.models.load_balancer.LoadBalancingServer.reconfigure')
-    def test_archive_no_active_appserver(self, mock_reconfigure, mock_disable_monitoring, mock_remove_dns_records):
+    def test_archive_no_active_appserver(
+            self,
+            mock_reconfigure,
+            mock_disable_monitoring,
+            mock_remove_dns_records,
+            mock_consul2,
+            mock_consul):
         """
         Test that the archive method works correctly if no appserver is active.
         """
@@ -785,7 +803,7 @@ class OpenEdXInstanceTestCase(TestCase):
     @patch('instance.models.server.OpenStackServer.public_ip')
     @ddt.data(2, 5, 10)
     @patch_services
-    def test_terminate_obsolete_appservers(self, mock_services, days, mock_public_ip):
+    def test_terminate_obsolete_appservers(self, mock_services, days, mock_public_ip, mock_consul):
         """
         When there is an active appserver, test that `terminate_obsolete_appservers`
         correctly identifies and terminates app servers created more than `days` before now, except:
@@ -875,7 +893,7 @@ class OpenEdXInstanceTestCase(TestCase):
 
     @ddt.data(2, 5, 10)
     @patch_services
-    def test_terminate_obsolete_appservers_no_active(self, mock_services, days):
+    def test_terminate_obsolete_appservers_no_active(self, mock_services, days, mock_consul):
         """
         When there is NO active appserver, test that `terminate_obsolete_appservers`
         correctly identifies and terminates app servers created more than `days` before now,
@@ -925,7 +943,7 @@ class OpenEdXInstanceTestCase(TestCase):
             (rc_appserver_failed, AppServerStatus.ConfigurationFailed, ServerStatus.Terminated),
         ])
 
-    def test_shut_down_reminder(self):
+    def test_shut_down_reminder(self, mock_consul):
         """
         Test that if developers run the shut_down() method on the console, they see a warning
         """
@@ -1134,7 +1152,11 @@ class OpenEdXInstanceDNSTestCase(TestCase):
         self.assertEqual(vm_indices, set(range(1, len(vm_indices) + 1)))
 
     @patch_services
-    def test_active_vm_dns_records(self, mocks):
+    @patch(
+        'instance.tests.models.factories.openedx_instance.OpenEdXInstance._write_metadata_to_consul',
+        return_value=(1, True)
+    )
+    def test_active_vm_dns_records(self, mocks, mock_consul):
         """
         Test that DNS records for active app servers get set.
         """

--- a/instance/tests/models/test_openedx_theme_mixins.py
+++ b/instance/tests/models/test_openedx_theme_mixins.py
@@ -21,6 +21,9 @@ OpenEdXInstance Theme Mixins - Tests
 """
 
 # Imports #####################################################################
+
+from unittest.mock import patch
+
 import ddt
 import yaml
 from django.contrib.auth import get_user_model
@@ -70,11 +73,15 @@ class OpenEdXThemeMixinTestCase(TestCase):
         ansible variables match those colors and images.
         """
         # Create objects
-        OpenEdXInstanceFactory(name='Integration - test_colors_applied', deploy_simpletheme=True)
-        instance = OpenEdXInstance.objects.get()
-        user = get_user_model().objects.create_user('betatestuser', 'betatest@example.com')
-        self.make_test_application(instance, user)
-        appserver = make_test_appserver(instance)
+        with patch(
+                'instance.tests.models.factories.openedx_instance.OpenEdXInstance._write_metadata_to_consul',
+                return_value=(1, True)
+        ):
+            OpenEdXInstanceFactory(name='Integration - test_colors_applied', deploy_simpletheme=True)
+            instance = OpenEdXInstance.objects.get()
+            user = get_user_model().objects.create_user('betatestuser', 'betatest@example.com')
+            self.make_test_application(instance, user)
+            appserver = make_test_appserver(instance)
 
         # Test the results
         self.assertTrue(instance.deploy_simpletheme)
@@ -122,7 +129,11 @@ class OpenEdXThemeMixinTestCase(TestCase):
             self.assertIn('opencraft_logo_small.png', logo['url'])
             self.assertIn('favicon.ico', favicon['url'])
 
-    def test_simpletheme_optout(self):
+    @patch(
+        'instance.tests.models.factories.openedx_instance.OpenEdXInstance._write_metadata_to_consul',
+        return_value=(1, True)
+    )
+    def test_simpletheme_optout(self, mock_consul):
         """
         Test that opting out from simple_theme deployment produces no theme-related ansible vars.
         This feature is used by instances prior to simple_theme, so that they keep using the default
@@ -157,7 +168,11 @@ class OpenEdXThemeMixinTestCase(TestCase):
         ('#1f365b', '#ffffff'),    # dark blue, white
         ('#7c702f', '#ffffff'),    # dark gold, white
     )
-    def test_get_contrasting_font_color(self, test_colors):
+    @patch(
+        'instance.tests.models.factories.openedx_instance.OpenEdXInstance._write_metadata_to_consul',
+        return_value=(1, True)
+    )
+    def test_get_contrasting_font_color(self, test_colors, mock_consul):
         """
         Tests if the automatic font color selection is working properly
         """

--- a/instance/tests/test_factories.py
+++ b/instance/tests/test_factories.py
@@ -22,6 +22,8 @@ Factories module - Tests
 
 # Imports #####################################################################
 
+from unittest.mock import patch
+
 from django.conf import settings
 from django.test import override_settings
 import yaml
@@ -82,7 +84,11 @@ class FactoriesTestCase(TestCase):
         expected_extra_settings = yaml.load(configuration_extra_settings, Loader=yaml.SafeLoader)
         self.assertEqual(extra_settings, expected_extra_settings)
 
-    def test_instance_factory(self):
+    @patch(
+        'instance.models.openedx_instance.OpenEdXInstance._write_metadata_to_consul',
+        return_value=(1, True)
+    )
+    def test_instance_factory(self, mock_consul):
         """
         Test that factory function for creating instances produces expected results
         """
@@ -102,8 +108,12 @@ class FactoriesTestCase(TestCase):
         with self.assertRaises(AssertionError):
             instance_factory()
 
+    @patch(
+        'instance.models.openedx_instance.OpenEdXInstance._write_metadata_to_consul',
+        return_value=(1, True)
+    )
     @override_settings(PROD_APPSERVER_FAIL_EMAILS=['appserverfail@localhost'])
-    def test_production_instance_factory(self):
+    def test_production_instance_factory(self, mock_consul):
         """
         Test that factory function for creating production instances produces expected results
         """

--- a/pr_watch/tests/test_models.py
+++ b/pr_watch/tests/test_models.py
@@ -141,7 +141,11 @@ class WatchedPullRequestTestCase(TestCase):
         DEFAULT_LMS_PREVIEW_DOMAIN_PREFIX='lms-preview.',
         DEFAULT_STUDIO_DOMAIN_PREFIX='studio-'
     )
-    def test_create_from_pr(self):
+    @patch(
+        'instance.models.openedx_instance.OpenEdXInstance._write_metadata_to_consul',
+        return_value=(1, True)
+    )
+    def test_create_from_pr(self, mock_consul):
         """
         Create an instance from a pull request
         """
@@ -163,7 +167,6 @@ class WatchedPullRequestTestCase(TestCase):
         self.assertEqual(instance.internal_studio_domain, 'studio-{}'.format(internal_lms_domain))
         self.assertRegex(instance.name, r'^PR')
         self.assertEqual(instance.edx_platform_commit, '9' * 40)
-
         same_instance, created = WatchedPullRequest.objects.get_or_create_from_pr(pr, watched_fork)
         self.assertEqual(instance, same_instance)
         self.assertFalse(created)
@@ -184,7 +187,11 @@ class WatchedPullRequestTestCase(TestCase):
                 """),
             openedx_release='ginkgo.8',
         )
-        instance, created = WatchedPullRequest.objects.get_or_create_from_pr(pr, watched_fork)
+        with patch(
+                'instance.models.openedx_instance.OpenEdXInstance._write_metadata_to_consul',
+                return_value=(1, True)
+        ):
+            instance, created = WatchedPullRequest.objects.get_or_create_from_pr(pr, watched_fork)
         self.assertTrue(created)
 
         self.assertEqual(instance.configuration_source_repo_url,

--- a/registration/tests/test_provision.py
+++ b/registration/tests/test_provision.py
@@ -53,7 +53,11 @@ class ApprovalTestCase(TestCase):
                 accepted_privacy_policy=accepted_time
             )
         EmailAddress.objects.create_unconfirmed(user.email, user)
-        with mock.patch('registration.provision.spawn_appserver') as mock_spawn_appserver:
+        with mock.patch('registration.provision.spawn_appserver') as mock_spawn_appserver, \
+            mock.patch(
+                    'instance.models.openedx_instance.OpenEdXInstance._write_metadata_to_consul',
+                    return_value=(1, True)
+            ):
             # Confirm email address.  This triggers provisioning the instance.
             EmailAddress.objects.confirm(user.email_address_set.get().key)
             self.assertTrue(mock_spawn_appserver.called)

--- a/registration/tests/test_views.py
+++ b/registration/tests/test_views.py
@@ -297,7 +297,11 @@ class BetaTestApplicationViewTestMixin:
             'subdomain': ['This domain name is not publicly available.'],
         })
 
-    def test_instance_subdomain(self):
+    @patch(
+        'instance.tests.models.factories.openedx_instance.OpenEdXInstance._write_metadata_to_consul',
+        return_value=(1, True)
+    )
+    def test_instance_subdomain(self, mock_consul):
         """
         Subdomain used by an existing instance.
         """

--- a/reports/tests.py
+++ b/reports/tests.py
@@ -170,7 +170,11 @@ class ReportsHelpersTestCase(TestCase):
     """
 
     def setUp(self):
-        self.appserver = make_test_appserver()
+        with mock.patch(
+                'instance.tests.models.factories.openedx_instance.OpenEdXInstance._write_metadata_to_consul',
+                return_value=(1, True)
+        ):
+            self.appserver = make_test_appserver()
         self.organization = OrganizationFactory.create(
             name='Organization Name',
             github_handle='organization_github_handle'
@@ -333,7 +337,11 @@ class ReportsHelpersTestCase(TestCase):
             'charge': settings.BILLING_RATE * expected_days,
         })
 
-    def get_instance_charges_future_month(self):
+    @mock.patch(
+        'instance.tests.models.factories.openedx_instance.OpenEdXInstance._write_metadata_to_consul',
+        return_value=(1, True)
+    )
+    def get_instance_charges_future_month(self, mock_consul):
         """
         Test that the instance will return empty charges and 0 total for its
         AppServers if the invoice month is in future.
@@ -343,8 +351,12 @@ class ReportsHelpersTestCase(TestCase):
         self.assertEqual(appservers_charges, [])
         self.assertEqual(appservers_total, 0)
 
+    @mock.patch(
+        'instance.tests.models.factories.openedx_instance.OpenEdXInstance._write_metadata_to_consul',
+        return_value=(1, True)
+    )
     @mock.patch('reports.helpers.generate_charge_details')
-    def test_get_instance_charges(self, charges_details_mock):
+    def test_get_instance_charges(self, charges_details_mock, mock_consul):
         """
         Test that an instance is going to generate charges for all of its
         terminated and running appservers only and make sure that servers
@@ -403,8 +415,12 @@ class ReportsHelpersTestCase(TestCase):
         self.assertIsInstance(watched_forks[fork3], list)
         self.assertEqual(len(watched_forks[fork3]), 0)
 
+    @mock.patch(
+        'instance.tests.models.factories.openedx_instance.OpenEdXInstance._write_metadata_to_consul',
+        return_value=(1, True)
+    )
     @mock.patch('reports.helpers.get_instance_charges')
-    def test_generate_charges(self, instance_charges_mock):
+    def test_generate_charges(self, instance_charges_mock, mock_consul):
         """
         Make sure that we're able to generate charges for all of the appservers
         that belong to any fork under a given organization.
@@ -454,9 +470,13 @@ class ReportsHelpersTestCase(TestCase):
             organization=self.organization
         )
 
-        instance1 = OpenEdXInstanceFactory()
-        instance2 = OpenEdXInstanceFactory()
-        instance3 = OpenEdXInstanceFactory()
+        with mock.patch(
+                'instance.tests.models.factories.openedx_instance.OpenEdXInstance._write_metadata_to_consul',
+                return_value=(1, True)
+        ):
+            instance1 = OpenEdXInstanceFactory()
+            instance2 = OpenEdXInstanceFactory()
+            instance3 = OpenEdXInstanceFactory()
 
         WatchedPullRequest.objects.create(
             fork_name=watched_fork1.fork,


### PR DESCRIPTION
**Testing Instructions**

Use this in `.env.test`:

```
CONSUL_SERVERS=fake-consul-dns.name
DEFAULT_LOAD_BALANCING_SERVER=ubuntu@fake-load-balancer
CONSUL_ENABLED=true
DISABLE_LOAD_BALANCER_CONFIGURATION=true
```

And run `make test.unit` inside the `opencraft` directory in a vagrant machine.

**Author's notes and concerns**

`pr_watch.tests.test_tasks.TasksTestCase` has failing tests for me locally, even on master, I suspect because I have something misconfigured.