### PR TITLE
[BB-1375] Re-add real-time updates to Ocim (with websockets through Django Channels)

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,4 +1,5 @@
 web: gunicorn opencraft.wsgi --timeout 60 --workers 4 --log-file -
+websocket: daphne -p 2001 opencraft.asgi:application
 worker: python3 manage.py run_huey --no-periodic
 worker_low_priority: HUEY_QUEUE_NAME=opencraft_low_priority python3 manage.py run_huey --no-periodic
 periodic: python3 manage.py run_huey --workers=0

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,3 +1,3 @@
-web: python3 manage.py runserver_plus
+web: python3 manage.py runserver 0.0.0.0:8000
 worker: python3 manage.py run_huey --no-periodic
 worker_low_priority: HUEY_QUEUE_NAME=opencraft_low_priority python3 manage.py run_huey --no-periodic

--- a/circle.yml
+++ b/circle.yml
@@ -2,7 +2,7 @@ version: 2.1
 jobs:
   build:
     docker:
-      - image: circleci/python:3.5-stretch-node-browsers
+      - image: circleci/python:3.6-stretch-node-browsers
         environment:
           DEBUG: 'true'
           DEFAULT_FORK: 'open-craft/edx-platform'
@@ -89,7 +89,7 @@ jobs:
               - coverage
   coverage:
     docker:
-      - image: circleci/python:3.5-stretch-node
+      - image: circleci/python:3.6-stretch-node
     steps:
       - checkout
       - restore_cache:
@@ -121,7 +121,7 @@ jobs:
               if [ -e /tmp/workspace/coverage/text/coverage.txt ]; then cat /tmp/workspace/coverage/text/coverage.txt; fi
   cleanup:
     docker:
-      - image: circleci/python:3.5-stretch
+      - image: circleci/python:3.6-stretch
         environment:
           LOAD_BALANCER_FRAGMENT_NAME_PREFIX: 'integration-'
           DJANGO_SETTINGS_MODULE: 'opencraft.settings'

--- a/documentation/installation.md
+++ b/documentation/installation.md
@@ -64,12 +64,22 @@ server at http://localhost:5000/ using your web browser.
 
 If you prefer not to use Vagrant, you can install OpenCraft Instance Manager manually.
 Refer to the [Ansible playbooks](https://github.com/open-craft/ansible-opencraft) used
-by Vagrant for an example. Instructions based on Ubuntu 16.04.
+by Vagrant for an example. Ocim requires Python 3.6 or a newer version. The instructions
+here are based on Ubuntu 16.04. Since Ubuntu 16.04 ships with Python 3.5, we will use `pyenv`
+to install a newer, supported version on it. This is not required when a supported version of
+Python is available. All the `pyenv` commands can be then ignored and the built-in `venv` module
+can be used to create a virtualenv environment.
 
-Install the system package dependencies & virtualenv:
+Install [pyenv](https://github.com/pyenv/pyenv) by following the [pyenv documentation](https://github.com/pyenv/pyenv#installation).
+Also install [pyenv-virtualenv](https://github.com/pyenv/pyenv-virtualenv#installation) by following its [documentation](https://github.com/pyenv/pyenv-virtualenv#installation).
+
+Install a supported version of Python and create a virtualenv environment. We will be using Python 3.6.9 as an example.
+
+    pyenv install 3.6.9
+
+Install the system package dependencies:
 
     make install_system_dependencies
-    pip3 install --user virtualenv
 
 You might also need to install PostgreSQL, MySQL and MongoDB:
 
@@ -78,10 +88,10 @@ You might also need to install PostgreSQL, MySQL and MongoDB:
 Note that the tests expect to be able to access MySQL on localhost using the
 default port, connecting as the root user without a password.
 
-Create a virtualenv, source it, and install the python requirements:
+Create a virtualenv, activate it, and install the python requirements:
 
-    virtualenv -p python3 venv
-    source venv/bin/activate
+    pyenv virtualenv 3.6.9 opencraft
+    pyenv activate opencraft
     pip install -r requirements.txt
 
 You will need to create a database user to run the tests:
@@ -133,14 +143,14 @@ server:
 Process description
 -------------------
 
-This runs three processes via Honcho, which reads `Procfile` or `Procfile.dev`
+This runs multiple processes via Honcho, which reads `Procfile` or `Procfile.dev`
 and loads the environment from the `.env` file:
 
-* *web*: the main HTTP server (Django + Werkzeug debugger in dev, gunicorn in prod)
-* *worker*: runs asynchronous jobs (Huey)
+* *web*: runs an ASGI server supporting HTTP and Websockets in dev and a WSGI HTTP server using gunicorn in productino.
+* *websocket*: runs an ASGI websocket server in production.
+* *worker\**: runs asynchronous jobs (Huey).
+* *periodic*: runs periodic, asynchronous jobs in production (Huey).
 
-Important: the Werkzeug debugger started by the development server allows remote
-execution of Python commands. It should *not* be run in production.
 
 Static assets collection
 ------------------------

--- a/instance/consumers.py
+++ b/instance/consumers.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+#
+# OpenCraft -- tools to aid developing and hosting free software projects
+# Copyright (C) 2015-2019 OpenCraft <contact@opencraft.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+"""
+Websocket consumers
+"""
+
+import json
+
+from asgiref.sync import async_to_sync
+from channels.generic.websocket import WebsocketConsumer
+
+from instance.models.instance import InstanceReference
+
+
+class WebSocketListener(WebsocketConsumer):
+    """
+    A websocket consumer for sending notifications.
+    """
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.channel_group_name = 'ws'
+
+    def connect(self):
+        user = self.scope['user']
+        if not user.is_authenticated or not InstanceReference.can_manage(user):
+            self.close()
+
+        async_to_sync(self.channel_layer.group_add)(
+            self.channel_group_name,
+            self.channel_name
+        )
+        self.accept()
+
+    def disconnect(self, close_code):  # pylint: disable=arguments-differ
+        async_to_sync(self.channel_layer.group_discard)(
+            self.channel_group_name,
+            self.channel_name
+        )
+
+    def notification(self, event):
+        """
+        Handles the messages of type 'notification' sent to the self.channel_group_name group.
+        """
+        self.send(text_data=json.dumps(event))

--- a/instance/logging.py
+++ b/instance/logging.py
@@ -29,6 +29,8 @@ import traceback
 from django.apps import apps
 from django.db import connection, models, ProgrammingError
 
+from instance.serializers.logentry import LogEntrySerializer
+from instance.utils import publish_data
 
 # Logging #####################################################################
 
@@ -72,13 +74,26 @@ class DBHandler(logging.Handler):
             object_id = obj.pk
 
         try:
-            apps.get_model('instance', 'LogEntry').objects.create(
+            log_entry = apps.get_model('instance', 'LogEntry').objects.create(
                 level=record.levelname, text=self.format(record), content_type=content_type, object_id=object_id
             )
         except ProgrammingError:
             # This can occur if django tries to log something before migrations have created the log table.
             # Make sure that is actually what happened:
             assert 'instance_logentry' not in connection.introspection.table_names()
+
+        # Send notice of entries related to any resource. Skip generic log entries that occur
+        # in debug mode, like "GET /static/img/favicon/favicon-96x96.png":
+        if content_type:
+            log_event = {
+                'type': 'object_log_line',
+                'log_entry': LogEntrySerializer(log_entry).data
+            }
+            if hasattr(obj, 'event_context'):
+                log_event.update(obj.event_context)
+            # TODO: Filter out log entries for which the user doesn't have view rights
+            # TODO: More targetted events - only emit events for what the user is looking at
+            publish_data(log_event)
 
 
 class ModelLoggerAdapter(logging.LoggerAdapter):

--- a/instance/models/instance.py
+++ b/instance/models/instance.py
@@ -36,6 +36,7 @@ from userprofile.models import UserProfile, Organization
 from instance.models.log_entry import LogEntry
 from instance.models.utils import default_setting
 from instance.logging import ModelLoggerAdapter
+from instance.utils import publish_data
 from .utils import ValidateModelMixin
 
 
@@ -89,6 +90,16 @@ class InstanceReference(TimeStampedModel):
         if not kwargs.pop('instance_already_deleted', False):
             self.instance.delete(ref_already_deleted=True, **kwargs)
         super().delete(**kwargs)
+
+    def save(self, *args, **kwargs):  # pylint: disable=arguments-differ
+        """
+        Save this InstanceReference.
+        """
+        super().save(*args, **kwargs)
+        publish_data({
+            'type': 'instance_update',
+            'instance_id': self.pk,
+        })
 
     @classmethod
     def can_manage(cls, user):

--- a/instance/models/openedx_appserver.py
+++ b/instance/models/openedx_appserver.py
@@ -38,6 +38,7 @@ from instance.models.mixins.utilities import EmailMixin
 from instance.models.mixins.openedx_config import OpenEdXConfigMixin
 from instance.models.utils import default_setting, format_help_text, get_base_playbook_name
 from instance.openstack_utils import get_openstack_connection, sync_security_group_rules, SecurityGroupRuleDefinition
+from instance.utils import publish_data
 from userprofile.models import UserProfile
 
 # Constants ###################################################################
@@ -533,3 +534,8 @@ class OpenEdXAppServer(AppServer, OpenEdXAppConfiguration, AnsibleAppServerMixin
         if not self.pk:
             self.configuration_settings = self.create_configuration_settings()
         super().save(*args, **kwargs)
+        publish_data({
+            'type': 'openedx_appserver_update',
+            'appserver_id': self.pk,
+            'instance_id': self.owner.pk,
+        })

--- a/instance/models/server.py
+++ b/instance/models/server.py
@@ -37,7 +37,7 @@ from instance.logging import ModelLoggerAdapter
 from instance.models.utils import (
     ValidateModelMixin, ResourceState, ModelResourceStateDescriptor, SteadyStateException, default_setting
 )
-from instance.utils import is_port_open, to_json
+from instance.utils import is_port_open, to_json, publish_data
 
 
 # Logging #####################################################################
@@ -243,6 +243,16 @@ class Server(ValidateModelMixin, TimeStampedModel):
             "Waited {minutes:.2f} minutes to reach appropriate status, and got nowhere. "
             "Aborting with a status of {status}.".format(minutes=initial_timeout / 60, status=self.status.name)
         )
+
+    def save(self, *args, **kwargs):  # pylint: disable=arguments-differ
+        """
+        Save this server.
+        """
+        super().save(*args, **kwargs)
+        publish_data({
+            'type': 'server_update',
+            'server_pk': self.pk,
+        })
 
     def update_status(self):
         """

--- a/instance/routing.py
+++ b/instance/routing.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+#
+# OpenCraft -- tools to aid developing and hosting free software projects
+# Copyright (C) 2015-2019 OpenCraft <contact@opencraft.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+"""
+Routes for the websocket connections.
+"""
+from django.urls import re_path
+
+from . import consumers
+
+
+websocket_urlpatterns = [
+    re_path(r'ws/$', consumers.WebSocketListener)
+]

--- a/instance/static/html/instance/details.html
+++ b/instance/static/html/instance/details.html
@@ -34,7 +34,7 @@
       <div class="large-3 columns">
         <h4>App Servers</h4>
         <button class="small" ng-click="spawn_appserver()" ng-disabled="is_spawning_appserver">
-          {{is_spawning_appserver ? "AppServer launching. Please refresh after some seconds to see the new server." : "Launch new AppServer"}}
+          <i class="fa fa-plus" ng-class="{'fa-spin': is_spawning_appserver}"></i> Launch new AppServer
         </button>
         <ul class="side-nav appserver-list">
           <li ng-if="instance.appservers.length < instance.appserver_count">

--- a/instance/static/js/src/instance.js
+++ b/instance/static/js/src/instance.js
@@ -70,8 +70,8 @@ app.factory('OpenCraftAPI', function(Restangular) {
 });
 
 app.factory('WebSocketClient', function() {
-    var protocol = (window.location.protocol == 'https') ? 'wss' : 'ws';
-    return new WebSocket(protocol + '://' + window.location.host + '/ws/');
+    var protocol = (window.location.protocol == 'https:') ? 'wss:' : 'ws:';
+    return new WebSocket(protocol + '//' + window.location.host + '/ws/');
 });
 
 // Controllers ////////////////////////////////////////////////////////////////

--- a/instance/static/js/src/openedx_appserver.js
+++ b/instance/static/js/src/openedx_appserver.js
@@ -111,6 +111,25 @@ app.controller("OpenEdXAppServerDetails", ['$scope', '$state', '$stateParams', '
                               'alert');
             });
         };
+        $scope.$on("websocket:object_log_line", function(event, data){
+            if (!$scope.appserverLogs) {
+                return;
+            }
+
+            if (data.appserver_id == $scope.appserver.id || ($scope.appserver.server && data.server_id == $scope.appserver.server.id)) {
+                if (data.log_entry.level == 'ERROR' || data.log_entry.level == 'CRITICAL') {
+                    $scope.appserverLogs.log_error_entries.push(data.log_entry);
+                }
+                $scope.appserverLogs.log_entries.push(data.log_entry);
+                $scope.$apply();
+            }
+        });
+
+        $scope.$on("websocket:openedx_appserver_update", function(event, data){
+           if (data.appserver_id == $scope.appserver.id) {
+               $scope.refresh();
+           }
+        });
 
         $scope.init();
     }

--- a/instance/tests/models/test_server.py
+++ b/instance/tests/models/test_server.py
@@ -41,6 +41,7 @@ from instance.tests.models.factories.server import (
     BuildFailedOpenStackServerFactory,
     ReadyOpenStackServerFactory,
 )
+from instance.tests.utils import patch_publish_data
 
 
 # Tests #######################################################################
@@ -140,6 +141,7 @@ class OpenStackServerTestCase(TestCase):
         'accepts_ssh_commands',
         'vm_available',
     )
+    @patch_publish_data
     @patch('instance.models.server.OpenStackServer.update_status')
     @patch('instance.models.server.time.sleep')
     def test_sleep_until_condition_already_fulfilled(self, condition, mock_sleep, mock_update_status):
@@ -181,6 +183,7 @@ class OpenStackServerTestCase(TestCase):
             'expected_status': ServerStatus.Booting,
         },
     )
+    @patch_publish_data
     @patch('instance.models.server.OpenStackServer.update_status')
     @patch('instance.models.server.time.sleep')
     def test_sleep_until_state_changes(self, condition, mock_sleep, mock_update_status):
@@ -233,6 +236,7 @@ class OpenStackServerTestCase(TestCase):
             # if server can not reach desired status because transition logic is broken:
             server.sleep_until(lambda: server.status.accepts_ssh_commands, timeout=5)
 
+    @patch_publish_data
     @patch('instance.models.server.OpenStackServer.update_status')
     @patch('instance.models.server.time.sleep')
     def test_sleep_until_timeout(self, mock_sleep, mock_update_status):
@@ -262,6 +266,7 @@ class OpenStackServerTestCase(TestCase):
             with self.assertRaises(AssertionError):
                 server.sleep_until(lambda: server.status.accepts_ssh_commands, timeout=value)
 
+    @patch_publish_data
     @patch('instance.models.server.time.sleep')
     def test_reboot_booting_server(self, mock_sleep):
         """
@@ -273,6 +278,7 @@ class OpenStackServerTestCase(TestCase):
         server.os_server.reboot.assert_not_called()
         mock_sleep.assert_not_called()
 
+    @patch_publish_data
     @patch('instance.models.server.time.sleep')
     def test_reboot_ready_server(self, mock_sleep):
         """

--- a/instance/utils.py
+++ b/instance/utils.py
@@ -31,6 +31,8 @@ import time
 from unittest.mock import Mock
 
 import requests
+import channels.layers
+from asgiref.sync import async_to_sync
 
 
 # Logging #####################################################################
@@ -146,3 +148,11 @@ def sufficient_time_passed(earlier_date, later_date, expected_days_since):
     """
     days_passed = (later_date - earlier_date).days
     return days_passed >= expected_days_since
+
+
+def publish_data(data):
+    """
+    Publish the data to the 'ws' group.
+    """
+    channel_layer = channels.layers.get_channel_layer()
+    async_to_sync(channel_layer.group_send)('ws', {'type': 'notification', 'message': data})

--- a/opencraft/asgi.py
+++ b/opencraft/asgi.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+#
+# OpenCraft -- tools to aid developing and hosting free software projects
+# Copyright (C) 2015-2019 OpenCraft <contact@opencraft.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+"""
+ASGI entrypoint. Configures Django and then runs the application
+defined in the ASGI_APPLICATION setting.
+"""
+
+import os
+import django
+from channels.routing import get_default_application
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "opencraft.settings")
+django.setup()
+application = get_default_application()

--- a/opencraft/routing.py
+++ b/opencraft/routing.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+#
+# OpenCraft -- tools to aid developing and hosting free software projects
+# Copyright (C) 2015-2019 OpenCraft <contact@opencraft.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+"""
+Routes for the ASGI application.
+"""
+from channels.auth import AuthMiddlewareStack
+from channels.routing import ProtocolTypeRouter, URLRouter
+from channels.security.websocket import AllowedHostsOriginValidator
+
+from instance.routing import websocket_urlpatterns
+
+
+application = ProtocolTypeRouter({
+    'websocket': AllowedHostsOriginValidator(
+        AuthMiddlewareStack(
+            URLRouter(
+                websocket_urlpatterns
+            )
+        )
+    ),
+})

--- a/opencraft/settings.py
+++ b/opencraft/settings.py
@@ -104,6 +104,7 @@ INSTALLED_APPS = (
     'rest_framework',
     'huey.contrib.djhuey',
     'simple_email_confirmation',
+    'channels',
 ) + LOCAL_APPS
 
 MIDDLEWARE = (
@@ -753,3 +754,14 @@ S3_VERSION_EXPIRATION = env.json('S3_VERSION_EXPIRATION', default=30)
 
 # Default Privacy Policy URL
 DEFAULT_PRIVACY_POLICY_URL = env('DEFAULT_PRIVACY_POLICY_URL', default='')
+
+ASGI_APPLICATION = 'opencraft.routing.application'
+
+CHANNEL_LAYERS = {
+    'default': {
+        'BACKEND': 'channels_redis.core.RedisChannelLayer',
+        'CONFIG': {
+            'hosts': [REDIS_URL],
+        },
+    },
+}

--- a/requirements.in
+++ b/requirements.in
@@ -4,12 +4,14 @@
 beautifulsoup4==4.7.1
 boto==2.48.0
 boto3==1.9.174
+channels==2.3.0
+channels_redis==2.4.0
 CherryPy==18.1.1
 colour==0.1.5
 cookies==2.2.1
 coverage==4.5.3
 ddt==1.2.1
-Django==2.2.4
+Django==2.2.6
 # using the latest django-angular (2.2 or later) requires a heavy rewrite of the registration form, so we use the old 1.0.0 version patched to work under Django 2
 -e git+https://github.com/open-craft/django-angular.git@v1-with-django2-support#egg=django_angular
 django-compressor==2.3
@@ -78,6 +80,7 @@ requests-file==1.4.3
 responses==0.10.6
 rfc3986==1.3.2
 selenium==2.53.6
+service_identity==18.1.0
 six==1.12.0
 testfixtures==6.10.0
 urllib3==1.25.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,10 +5,15 @@
 #    pip-compile
 #
 -e git+https://github.com/open-craft/django-angular.git@v1-with-django2-support#egg=django_angular
+aioredis==1.3.0           # via channels-redis
 appdirs==1.4.3            # via openstacksdk
+asgiref==3.2.2            # via channels, channels-redis, daphne
 asn1crypto==0.24.0        # via cryptography
 astroid==2.1.0            # via pylint, pylint-celery, requirements-detector
-attrs==19.1.0             # via cmd2, jsonschema
+async-timeout==3.0.1      # via aioredis
+attrs==19.1.0             # via automat, cmd2, jsonschema, service-identity, twisted
+autobahn==19.10.1         # via daphne
+automat==0.7.0            # via twisted
 babel==2.7.0              # via osc-lib, oslo.i18n, python-cinderclient, python-novaclient, python-openstackclient
 backcall==0.1.0           # via ipython
 backports.functools-lru-cache==1.5  # via cheroot
@@ -18,6 +23,8 @@ boto==2.48.0
 botocore==1.12.212        # via boto3, s3transfer
 certifi==2019.6.16        # via requests
 cffi==1.12.3              # via cryptography
+channels==2.3.0
+channels_redis==2.4.0
 chardet==3.0.4            # via requests
 cheroot==6.5.6            # via cherrypy
 cherrypy==18.1.1
@@ -26,9 +33,11 @@ cliff==2.15.0             # via osc-lib, python-openstackclient
 cmd2==0.9.16              # via cliff
 colorama==0.4.1           # via cmd2
 colour==0.1.5
+constantly==15.1.0        # via twisted
 cookies==2.2.1
 coverage==4.5.3
-cryptography==2.7         # via openstacksdk, pyopenssl
+cryptography==2.7         # via autobahn, openstacksdk, pyopenssl, service-identity
+daphne==2.3.0             # via channels
 ddt==1.2.1
 debtcollector==1.21.0     # via oslo.config, oslo.utils, python-keystoneclient
 decorator==4.4.0          # via dogpile.cache, ipython, openstacksdk, traitlets
@@ -44,7 +53,7 @@ django-simple-email-confirmation==0.60
 django-storage-swift==1.2.19
 django-storages==1.7.1
 django-zurb-foundation==5.5.0
-django==2.2.4
+django==2.2.6
 djangorestframework==3.9.4
 docutils==0.14
 dodgy==0.1.9
@@ -60,9 +69,12 @@ futures==3.1.1
 gitdb2==2.0.5             # via gitpython
 gitpython==2.1.11
 gunicorn==19.9.0
+hiredis==1.0.0            # via aioredis
 honcho==1.0.1
 huey==2.1.0
+hyperlink==19.0.0         # via twisted
 idna==2.8
+incremental==17.5.0       # via twisted
 ipdb==0.12
 ipython-genutils==0.2.0   # via traitlets
 ipython==7.5.0
@@ -79,7 +91,7 @@ lazy-object-proxy==1.4.1  # via astroid
 libsass==0.19.2           # via django-libsass
 mccabe==0.6.1
 more-itertools==7.2.0     # via cheroot, cherrypy, jaraco.functools
-msgpack==0.6.1            # via oslo.serialization
+msgpack==0.6.1            # via channels-redis, oslo.serialization
 munch==2.3.2              # via openstacksdk
 mysqlclient==1.4.2.post1
 netaddr==0.7.19           # via oslo.config, oslo.utils
@@ -107,12 +119,15 @@ prompt-toolkit==2.0.9     # via ipython
 prospector==1.1.4
 psycopg2==2.8.3
 ptyprocess==0.6.0         # via pexpect
+pyasn1-modules==0.2.7     # via service-identity
+pyasn1==0.4.7             # via pyasn1-modules, service-identity
 pycodestyle==2.3.1
 pycparser==2.19           # via cffi
 pycryptodomex==3.8.2      # via pyjwkest
 pydocstyle==4.0.1         # via prospector
 pyflakes==1.6.0
 pygments==2.4.2           # via ipython
+pyhamcrest==1.9.0         # via twisted
 pyjwkest==1.4.0
 pylint-celery==0.3
 pylint-common==0.2.5
@@ -146,6 +161,7 @@ rfc3986==1.3.2
 rjsmin==1.1.0             # via django-compressor
 s3transfer==0.2.1         # via boto3
 selenium==2.53.6
+service_identity==18.1.0
 setoptconf==0.2.0         # via prospector
 simplejson==3.16.0        # via osc-lib, python-cinderclient, python-novaclient
 six==1.12.0
@@ -158,6 +174,8 @@ tempora==1.14.1           # via portend
 testfixtures==6.10.0
 text-unidecode==1.2       # via faker
 traitlets==4.3.2          # via ipython
+twisted==19.7.0           # via daphne
+txaio==18.8.1             # via autobahn
 typed-ast==1.4.0          # via astroid
 urllib3==1.25.3
 virtualenv==16.6.1
@@ -166,3 +184,4 @@ wcwidth==0.1.7            # via cmd2, prompt-toolkit
 werkzeug==0.15.4
 wrapt==1.11.2             # via astroid, debtcollector, python-glanceclient
 zc.lockfile==2.0          # via cherrypy
+zope.interface==4.6.0     # via twisted


### PR DESCRIPTION
Adds real-time updates to Ocim using Django channels.

**Testing instructions**:

The instructions given below are for testing in the vagrant environment and will require some changes to test in other environments.

* The `channels_redis` library used as the channel layer for `channels` requires Python 3.6 or above, but the version of Python available on Ubuntu 16.04 (used in production and on vagrant) only supports 3.5.x. So to test this PR, install `pyenv` and `pyenv-virtualenv` plugin. Install Python 3.6.9 (the latest Python 3.6 release), create a virtualenv using `pyenv-virtualenv`, activate it and install all the requirements in `requirements.txt.`,
* Setup the configuration in `.env` using the file in the private documentation repository. It is missing some configuration related to AWS - `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`. So add those variables with appropriate values.
* Run the unit test suite by running `make test.unit` from the top-level directory of this repository inside the vagrant VM to ensure that the environment is setup okay.
* Create a local superuser account if it doesn't exist already.
* Start the local Ocim instance by running `make run.dev`.
* Navigate to http://localhost:8000 and log in to the site using the super user credentials.
* Check the browser console to confirm that there are no errors.
* Create an instance using one of the factory methods.
* Verify that the instance automatically shows up in the Ocim interface.
* Click on the instance and launch an appserver. Immediately click on the `Logs` tab to check if the logs are updated in real time there.
* Also verify that there is a green circle near the instance name on the left side bar indicating that the instance is being provisioned. Later, check that the icon turns to red in real-time if the appserver fails to provision.
* Verify that after a few seconds, a new appserver shows up automatically under the instance.
* Click on the logs section of the appserver and verify that the logs are updated in real-time.
* Verify that there no JS errors in the browser console.
* Open the local Ocim website on a separate, isolated browser session where the user is unauthenticated. Open the browser JavaScript console and try creating a WebSocket client using the following code in the console.
  ```javascript
  var ws = new WebSocket('ws://localhost:8000/ws/');
  ```
  Verify that an error is thrown and the connection is rejected and that the websocket connections are allowed only for authenticated users.
* Check and test any other things of your choice related to real-time updates and verify that those work.

**Author notes and concerns**:
* All authenticated users are allowed to connect to the WebSocket endpoint `/ws/` and will receive all the websocket messages. The users with `manage_own` permission will also see the effects of the notifications for their instances alone. This mirrors the functionality in the removed swampdragon code. As a workaround, it might be better to allow only the superusers and the users with `manage_own` permissions to connect to the websocket endpoint. Any further changes to fix this issue will probably have to be done in a separate PR as a part of a separate ticket.