### PR TITLE
SE-1682 deactivate old appservers periodic builds

### DIFF
--- a/instance/tasks.py
+++ b/instance/tasks.py
@@ -69,6 +69,10 @@ def spawn_appserver(
     logger.info('Retrieving instance: ID=%s', instance_ref_id)
     instance = OpenEdXInstance.objects.get(ref_set__pk=instance_ref_id)
 
+    # NOTE: this is not async; blocks up to an hour.
+    # The actual appserver model is created fairly quickly though (after
+    # instance-wide provisioning things happen (mysql, dns records, mongo, s3,
+    # rabbitmq, etc.) but before appserver provision happens)
     appserver = instance.spawn_appserver(
         num_attempts=num_attempts,
         success_tag=success_tag,

--- a/periodic_builds/tests/test_tasks.py
+++ b/periodic_builds/tests/test_tasks.py
@@ -69,10 +69,12 @@ class PeriodicBuildsTestCase(TestCase):
             # both enabled instances should have spawned an appserver
             self.assertEqual(mock_spawn_appserver.call_count, 2)
             mock_spawn_appserver.assert_any_call(
-                instance_enabled.ref.pk, num_attempts=1, mark_active_on_success=True
+                instance_enabled.ref.pk, num_attempts=1, mark_active_on_success=True,
+                deactivate_old_appservers=True,
             )
             mock_spawn_appserver.assert_any_call(
-                instance_enabled2.ref.pk, num_attempts=2, mark_active_on_success=True
+                instance_enabled2.ref.pk, num_attempts=2, mark_active_on_success=True,
+                deactivate_old_appservers=True,
             )
 
             # mock both instances now have appservers
@@ -95,7 +97,8 @@ class PeriodicBuildsTestCase(TestCase):
 
             # the shorter interval instance should have spawned a new one
             mock_spawn_appserver.assert_called_once_with(
-                instance_enabled2.ref.pk, num_attempts=2, mark_active_on_success=True
+                instance_enabled2.ref.pk, num_attempts=2, mark_active_on_success=True,
+                deactivate_old_appservers=True,
             )
             # fake that we have a new appserver but it's still configuring
             make_test_appserver(instance_enabled2, status=AppServerStatus.ConfiguringServer)
@@ -108,5 +111,6 @@ class PeriodicBuildsTestCase(TestCase):
             tasks.launch_periodic_builds()
 
             mock_spawn_appserver.assert_called_once_with(
-                instance_enabled.ref.pk, num_attempts=1, mark_active_on_success=True
+                instance_enabled.ref.pk, num_attempts=1, mark_active_on_success=True,
+                deactivate_old_appservers=True,
             )


### PR DESCRIPTION
This deactivates old appservers on successful provisioning of a new appserver when launched from the periodic builds task.

**Testing instructions**:

1. Set up a sandbox for periodic builds
2. wait for at least two appservers to be launched by the periodic builder
3. verify that previous appservers are deactivated and the latest appserver is activated always

Note that this can currently be verified with the [master test](https://stage.console.opencraft.com/instance/4330/) instance on stage.

**Reviewers**
- [ ] @pkulkark 
