### PR TITLE
Wire integration tests to their own load balancer

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -21,4 +21,5 @@ LOAD_BALANCER_FRAGMENT_NAME_PREFIX='opencraft-'
 DEFAULT_RABBITMQ_API_URL='https://admin:password@rabbitmq.example.com:15671'
 DEFAULT_INSTANCE_RABBITMQ_URL='amqps://rabbitmq.example.com:5671'
 CONSUL_ENABLED: false
+CONSUL_SERVERS: haproxy-integration.net.opencraft.hosting
 DISABLE_LOAD_BALANCER_CONFIGURATION: false

--- a/circle.yml
+++ b/circle.yml
@@ -23,10 +23,6 @@ jobs:
         DEBUG: 'true'
         DEFAULT_FORK: 'open-craft/edx-platform'
         LOAD_BALANCER_FRAGMENT_NAME_PREFIX: 'integration-'
-        DEFAULT_LOAD_BALANCING_SERVER: ubuntu@haproxy-integration.net.opencraft.hosting
-        CONSUL_SERVERS: haproxy-integration.net.opencraft.hosting
-        CONSUL_ENABLED: true
-        DISABLE_LOAD_BALANCER_CONFIGURATION: true
     steps:
       - checkout
       - restore_cache:
@@ -130,10 +126,6 @@ jobs:
     environment:
       LOAD_BALANCER_FRAGMENT_NAME_PREFIX: 'integration-'
       DJANGO_SETTINGS_MODULE: 'opencraft.settings'
-      DEFAULT_LOAD_BALANCING_SERVER: ubuntu@haproxy-integration.net.opencraft.hosting
-      CONSUL_SERVERS: haproxy-integration.net.opencraft.hosting
-      CONSUL_ENABLED: true
-      DISABLE_LOAD_BALANCER_CONFIGURATION: true
     steps:
       - checkout
       - restore_cache:

--- a/circle.yml
+++ b/circle.yml
@@ -3,14 +3,6 @@ jobs:
   build:
     docker:
       - image: circleci/python:3.6-stretch-node-browsers
-        environment:
-          DEBUG: 'true'
-          DEFAULT_FORK: 'open-craft/edx-platform'
-          LOAD_BALANCER_FRAGMENT_NAME_PREFIX: 'integration-'
-          DEFAULT_LOAD_BALANCING_SERVER: ubuntu@haproxy-integration.net.opencraft.hosting
-          CONSUL_SERVERS: haproxy-integration.net.opencraft.hosting
-          CONSUL_ENABLED: true
-          DISABLE_LOAD_BALANCER_CONFIGURATION: true
       - image: redis
       - image: mongo:3.2-jessie
       - image: "circleci/mysql:5"
@@ -28,6 +20,13 @@ jobs:
             type: string
     environment:
         TEST_GROUP: <<parameters.tests_group>>
+        DEBUG: 'true'
+        DEFAULT_FORK: 'open-craft/edx-platform'
+        LOAD_BALANCER_FRAGMENT_NAME_PREFIX: 'integration-'
+        DEFAULT_LOAD_BALANCING_SERVER: ubuntu@haproxy-integration.net.opencraft.hosting
+        CONSUL_SERVERS: haproxy-integration.net.opencraft.hosting
+        CONSUL_ENABLED: true
+        DISABLE_LOAD_BALANCER_CONFIGURATION: true
     steps:
       - checkout
       - restore_cache:
@@ -128,13 +127,13 @@ jobs:
   cleanup:
     docker:
       - image: circleci/python:3.6-stretch
-        environment:
-          LOAD_BALANCER_FRAGMENT_NAME_PREFIX: 'integration-'
-          DJANGO_SETTINGS_MODULE: 'opencraft.settings'
-          DEFAULT_LOAD_BALANCING_SERVER: ubuntu@haproxy-integration.net.opencraft.hosting
-          CONSUL_SERVERS: haproxy-integration.net.opencraft.hosting
-          CONSUL_ENABLED: true
-          DISABLE_LOAD_BALANCER_CONFIGURATION: true
+    environment:
+      LOAD_BALANCER_FRAGMENT_NAME_PREFIX: 'integration-'
+      DJANGO_SETTINGS_MODULE: 'opencraft.settings'
+      DEFAULT_LOAD_BALANCING_SERVER: ubuntu@haproxy-integration.net.opencraft.hosting
+      CONSUL_SERVERS: haproxy-integration.net.opencraft.hosting
+      CONSUL_ENABLED: true
+      DISABLE_LOAD_BALANCER_CONFIGURATION: true
     steps:
       - checkout
       - restore_cache:

--- a/circle.yml
+++ b/circle.yml
@@ -3,6 +3,10 @@ jobs:
   build:
     docker:
       - image: circleci/python:3.6-stretch-node-browsers
+        environment:
+          DEBUG: 'true'
+          DEFAULT_FORK: 'open-craft/edx-platform'
+          LOAD_BALANCER_FRAGMENT_NAME_PREFIX: 'integration-'
       - image: redis
       - image: mongo:3.2-jessie
       - image: "circleci/mysql:5"
@@ -20,9 +24,6 @@ jobs:
             type: string
     environment:
         TEST_GROUP: <<parameters.tests_group>>
-        DEBUG: 'true'
-        DEFAULT_FORK: 'open-craft/edx-platform'
-        LOAD_BALANCER_FRAGMENT_NAME_PREFIX: 'integration-'
     steps:
       - checkout
       - restore_cache:
@@ -123,9 +124,9 @@ jobs:
   cleanup:
     docker:
       - image: circleci/python:3.6-stretch
-    environment:
-      LOAD_BALANCER_FRAGMENT_NAME_PREFIX: 'integration-'
-      DJANGO_SETTINGS_MODULE: 'opencraft.settings'
+        environment:
+          LOAD_BALANCER_FRAGMENT_NAME_PREFIX: 'integration-'
+          DJANGO_SETTINGS_MODULE: 'opencraft.settings'
     steps:
       - checkout
       - restore_cache:

--- a/circle.yml
+++ b/circle.yml
@@ -7,6 +7,10 @@ jobs:
           DEBUG: 'true'
           DEFAULT_FORK: 'open-craft/edx-platform'
           LOAD_BALANCER_FRAGMENT_NAME_PREFIX: 'integration-'
+          DEFAULT_LOAD_BALANCING_SERVER: ubuntu@haproxy-integration.net.opencraft.hosting
+          CONSUL_SERVERS: haproxy-integration.net.opencraft.hosting
+          CONSUL_ENABLED: true
+          DISABLE_LOAD_BALANCER_CONFIGURATION: true
       - image: redis
       - image: mongo:3.2-jessie
       - image: "circleci/mysql:5"
@@ -57,9 +61,11 @@ jobs:
       - run:
           name: Run Consul
           command: |
+            echo Running consul agent to connect to the integration consul server
             sudo wget -P /tmp https://releases.hashicorp.com/consul/1.2.1/consul_1.2.1_linux_amd64.zip
             sudo unzip /tmp/consul_1.2.1_linux_amd64.zip -d /usr/local/bin
-            consul agent -dev
+            mkdir -p /tmp/consul-data
+            consul agent -retry-join haproxy-integration.net.opencraft.hosting -data-dir /tmp/consul-data
           background: true
       - save_cache:
           key: dependencies-{{ checksum "requirements.txt" }}
@@ -125,6 +131,10 @@ jobs:
         environment:
           LOAD_BALANCER_FRAGMENT_NAME_PREFIX: 'integration-'
           DJANGO_SETTINGS_MODULE: 'opencraft.settings'
+          DEFAULT_LOAD_BALANCING_SERVER: ubuntu@haproxy-integration.net.opencraft.hosting
+          CONSUL_SERVERS: haproxy-integration.net.opencraft.hosting
+          CONSUL_ENABLED: true
+          DISABLE_LOAD_BALANCER_CONFIGURATION: true
     steps:
       - checkout
       - restore_cache:


### PR DESCRIPTION
A small change (which took a lot of work to get, thanks @clemente !) to not run the consul agent in dev mode but instead to connect it to the Consul server running on `haproxy-integration`.

This means that when integration tests run, they will write instance data to that consul, which will then request certs for them via the cert-manager.

To avoid test failures during DNS propagation, there is a wildcard in Gandi for `*.integration` which points to `haproxy-integration`.

The other change required is setting a few variables in CircleCI config (and updating the entry in Vault).

```
DEFAULT_LOAD_BALANCING_SERVER: ubuntu@haproxy-integration.net.opencraft.hosting
CONSUL_SERVERS: haproxy-integration.net.opencraft.hosting
CONSUL_ENABLED: true
DISABLE_LOAD_BALANCER_CONFIGURATION: true
```

**Testing Instructions**

None.

Note to the reviewer. The vars in `circleci.yml` were set to make the tests pass. I will remove them before merging this.