### PR TITLE
BB-987: Rename variables to keep upstream compatibility

### DIFF
--- a/instance/models/mixins/openedx_config.py
+++ b/instance/models/mixins/openedx_config.py
@@ -325,7 +325,7 @@ class OpenEdXConfigMixin(ConfigMixinBase):
             "EDXAPP_CELERY_HEARTBEAT_ENABLED": settings.EDX_WORKERS_ENABLE_CELERY_HEARTBEATS,
 
             # Set up User Retirement Pipeline
-            # RETIREMENT_SERVICE_SETUP can be removed after the Juniper upgrade
+            # TODO: RETIREMENT_SERVICE_SETUP can be removed after the Juniper upgrade
             # as it's just here for backwards compatibility
             "RETIREMENT_SERVICE_SETUP": True,
             "COMMON_RETIREMENT_SERVICE_SETUP": True,

--- a/instance/models/mixins/openedx_config.py
+++ b/instance/models/mixins/openedx_config.py
@@ -325,7 +325,10 @@ class OpenEdXConfigMixin(ConfigMixinBase):
             "EDXAPP_CELERY_HEARTBEAT_ENABLED": settings.EDX_WORKERS_ENABLE_CELERY_HEARTBEATS,
 
             # Set up User Retirement Pipeline
+            # RETIREMENT_SERVICE_SETUP can be removed after the Juniper upgrade
+            # as it's just here for backwards compatibility
             "RETIREMENT_SERVICE_SETUP": True,
+            "COMMON_RETIREMENT_SERVICE_SETUP": True,
             "RETIREMENT_SERVICE_ENABLE_CRON_JOB": True,
             "RETIREMENT_SERVICE_COOL_OFF_DAYS": 5,
             # Cron job scheduling

--- a/instance/models/mixins/secret_keys.py
+++ b/instance/models/mixins/secret_keys.py
@@ -87,8 +87,8 @@ OPENEDX_SECRET_KEYS = [
     'INSIGHTS_SECRET_KEY',
     'NOTIFIER_LMS_SECRET_KEY',
     'PROGRAMS_SECRET_KEY',
-    'RETIREMENT_SERVICE_OAUTH_CLIENT_ID',
-    'RETIREMENT_SERVICE_OAUTH_CLIENT_SECRET',
+    'RETIREMENT_SERVICE_EDX_OAUTH2_KEY',
+    'RETIREMENT_SERVICE_EDX_OAUTH2_SECRET',
 ]
 
 # Translation table for keys that must match other keys (shared API keys)
@@ -197,6 +197,11 @@ class SecretKeyInstanceMixin(models.Model):
         jwk_key_pair = self.get_jwk_key_pair()
         keys['COMMON_JWT_PUBLIC_SIGNING_JWK_SET'] = jwk_key_pair.public
         keys['EDXAPP_JWT_PRIVATE_SIGNING_JWK'] = jwk_key_pair.private
+
+        # These two lines are here for backwards compatibility for the retirement
+        # service. They can be removed after the Juniper upgrade
+        keys['RETIREMENT_SERVICE_OAUTH_CLIENT_ID'] = keys['RETIREMENT_SERVICE_EDX_OAUTH2_KEY']
+        keys['RETIREMENT_SERVICE_OAUTH_CLIENT_SECRET'] = keys['RETIREMENT_SERVICE_EDX_OAUTH2_SECRET']
 
         return yaml.dump(keys)
 

--- a/instance/models/mixins/secret_keys.py
+++ b/instance/models/mixins/secret_keys.py
@@ -198,7 +198,7 @@ class SecretKeyInstanceMixin(models.Model):
         keys['COMMON_JWT_PUBLIC_SIGNING_JWK_SET'] = jwk_key_pair.public
         keys['EDXAPP_JWT_PRIVATE_SIGNING_JWK'] = jwk_key_pair.private
 
-        # These two lines are here for backwards compatibility for the retirement
+        # TODO: These two lines are here for backwards compatibility for the retirement
         # service. They can be removed after the Juniper upgrade
         keys['RETIREMENT_SERVICE_OAUTH_CLIENT_ID'] = keys['RETIREMENT_SERVICE_EDX_OAUTH2_KEY']
         keys['RETIREMENT_SERVICE_OAUTH_CLIENT_SECRET'] = keys['RETIREMENT_SERVICE_EDX_OAUTH2_SECRET']


### PR DESCRIPTION
This PR adds variables related to the retirement service that were renamed in the upstream PR.

**Testing instructions:**
1. Check that the following variables are set when spawning an appserver:
- `COMMON_RETIREMENT_SERVICE_SETUP`
- `RETIREMENT_SERVICE_SETUP`
-  `RETIREMENT_SERVICE_OAUTH_CLIENT_ID`
-  `RETIREMENT_SERVICE_OAUTH_CLIENT_SECRET`
-  `RETIREMENT_SERVICE_EDX_OAUTH2_KEY`
-  `RETIREMENT_SERVICE_EDX_OAUTH2_SECRET`
2. Check that `RETIREMENT_SERVICE_OAUTH_CLIENT_ID` is equal `RETIREMENT_SERVICE_EDX_OAUTH2_KEY`
3. Check that `RETIREMENT_SERVICE_OAUTH_CLIENT_SECRET` is equal `RETIREMENT_SERVICE_EDX_OAUTH2_SECRET`

**Reviewer:**
- [x] @Agrendalath 