### PR TITLE
SE-1832 Move auto provisioning failure email alerts to registration

### DIFF
--- a/instance/factories.py
+++ b/instance/factories.py
@@ -151,7 +151,6 @@ def production_instance_factory(**kwargs):
         # Allow production instances to use a different OpenStack instance flavor by default.
         # This allows using a larger instance flavor for production instances.
         openstack_server_flavor=settings.OPENSTACK_PRODUCTION_INSTANCE_FLAVOR,
-        provisioning_failure_notification_emails=settings.PROD_APPSERVER_FAIL_EMAILS,
     )
     instance_kwargs.update(kwargs)
 

--- a/instance/tests/test_factories.py
+++ b/instance/tests/test_factories.py
@@ -122,7 +122,8 @@ class FactoriesTestCase(TestCase):
         instance = production_instance_factory(sub_domain=sub_domain)
         instance = OpenEdXInstance.objects.get(pk=instance.pk)
         self._assert_field_values(instance, sub_domain, **self.PRODUCTION_DEFAULTS)
-        self.assertEqual(instance.provisioning_failure_notification_emails, ['appserverfail@localhost'])
+        # standard production instances should not have this set
+        self.assertEqual(instance.provisioning_failure_notification_emails, [])
 
         # Create instance with custom field values
         sub_domain = "production-instance-customized"

--- a/registration/provision.py
+++ b/registration/provision.py
@@ -24,6 +24,7 @@ A Django signal handler to provision a beta tester instance upon successful emai
 
 import logging
 
+from django.conf import settings
 from django.db import transaction
 from django.dispatch import receiver
 from simple_email_confirmation.signals import email_confirmed
@@ -76,5 +77,8 @@ def _provision_instance(sender, **kwargs):
             deploy_simpletheme=True,
         )
         application.instance.lms_users.add(user)
+        if settings.PROD_APPSERVER_FAIL_EMAILS:
+            application.instance.provisioning_failure_notification_emails = settings.PROD_APPSERVER_FAIL_EMAILS
+            application.instance.save()
         application.save()
     spawn_appserver(application.instance.ref.pk, mark_active_on_success=True, num_attempts=2)

--- a/registration/tests/test_provision.py
+++ b/registration/tests/test_provision.py
@@ -24,6 +24,7 @@ Test the provisioning of beta tester instances.
 
 from unittest import mock
 
+from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.test import TestCase
 from freezegun import freeze_time
@@ -67,3 +68,4 @@ class ApprovalTestCase(TestCase):
         self.assertTrue(instance.internal_lms_domain.startswith(application.subdomain))
         self.assertEqual(instance.email, application.public_contact_email)
         self.assertEqual(instance.lms_users.get(), user)
+        self.assertEqual(instance.provisioning_failure_notification_emails, settings.PROD_APPSERVER_FAIL_EMAILS)


### PR DESCRIPTION
This moves the auto-setting of proviosing failure notification emails from production instance factory to the provision instance function that is called when creating an instance for an end user. Doing this because we only want to auto set PROD_APPSERVER_FAIL_EMAILS for end user instances.

**Test instructions**:

- deploy this branch to stage (no migrations and only small changes; easy to switch between this and master)
- register as an end user
- verify that the resulting instance has the settings.PROD_APPSERVER_FAIL_EMAILS address(es) set on provisioning_failure_notification_emails
- launch a new instance via production_instance_factory
- verify that no provisioning_failure_notification_emails are set

**Reviewer**:

- [x] @gr4yscale 