### PR TITLE
[BB-1909] Disable strict host key checking

### DIFF
--- a/instance/models/mixins/ansible.py
+++ b/instance/models/mixins/ansible.py
@@ -54,6 +54,8 @@ class AnsibleAppServerMixin(models.Model):
         help_text='YAML variables for commonly needed services.')
 
     INVENTORY_GROUP = 'generic'
+    # It is possible to get an IP address that has already appeared, so we want to disable strict host key checking.
+    HOST_ARGS = 'ansible_ssh_common_args="-o StrictHostKeyChecking=no"'
 
     class Meta:
         abstract = True
@@ -96,9 +98,9 @@ class AnsibleAppServerMixin(models.Model):
             raise RuntimeError("Cannot prepare to run playbooks when server has no public IP.")
         return (
             '[{group}]\n'
-            '{server_ip}\n'
+            '{server_ip} {host_args}\n'
             '[app:children]\n'
-            '{group}'.format(group=self.INVENTORY_GROUP, server_ip=public_ip)
+            '{group}'.format(group=self.INVENTORY_GROUP, server_ip=public_ip, host_args=self.HOST_ARGS)
         )
 
     def _run_playbook(self, working_dir, playbook):

--- a/instance/tests/models/test_openedx_ansible_mixins.py
+++ b/instance/tests/models/test_openedx_ansible_mixins.py
@@ -59,7 +59,7 @@ class AnsibleAppServerTestCase(TestCase):
         self.assertEqual(
             appserver.inventory_str,
             '[openedx-app]\n'
-            '192.168.100.200\n'
+            '192.168.100.200 ansible_ssh_common_args="-o StrictHostKeyChecking=no"\n'
             '[app:children]\n'
             'openedx-app'
         )


### PR DESCRIPTION
This removes the key checking, which could interfere if we got an IP address that we've already used.