### PR TITLE
BB-1919: Add registration flow

### DIFF
--- a/frontend/.eslintignore
+++ b/frontend/.eslintignore
@@ -1,1 +1,2 @@
 *.spec.*
+serviceWorker.ts

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1332,9 +1332,9 @@
       "dev": true
     },
     "@restart/hooks": {
-      "version": "0.3.15",
-      "resolved": "https://registry.npmjs.org/@restart/hooks/-/hooks-0.3.15.tgz",
-      "integrity": "sha512-rVNba1A2oMzKBg16fCrrHmCf4JjOzFhT9TWR8J+Y8iOcY4zffxtP3ke7mEsakvghHZT+9//uDOPSSeuBDW41GQ==",
+      "version": "0.3.19",
+      "resolved": "https://registry.npmjs.org/@restart/hooks/-/hooks-0.3.19.tgz",
+      "integrity": "sha512-8bskLEkiDvuZztnfGN+vM56q2HQV8dyXS/Eb0nhXPx6fonii3hQLxfNVA2r5NTMbvEkwDo59bAau3idUXaGvww==",
       "dev": true
     },
     "@svgr/babel-plugin-add-jsx-attribute": {
@@ -4620,16 +4620,6 @@
         "sha.js": "^2.4.8"
       }
     },
-    "create-react-context": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/create-react-context/-/create-react-context-0.3.0.tgz",
-      "integrity": "sha512-dNldIoSuNSvlTJ7slIKC/ZFGKexBMBrrcc+TTe1NdmROnaASuLPvqpwj9v4XS4uXZ8+YPu0sNmShX2rXI5LNsw==",
-      "dev": true,
-      "requires": {
-        "gud": "^1.0.0",
-        "warning": "^4.0.3"
-      }
-    },
     "cross-spawn": {
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
@@ -5336,12 +5326,24 @@
       }
     },
     "dom-helpers": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-3.4.0.tgz",
-      "integrity": "sha512-LnuPJ+dwqKDIyotW1VzmOZ5TONUN7CwkCR5hrgawTUbkBGYdeoNLZo6nNfGkCrjtE1nXXaj7iMMpDa8/d9WoIA==",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.1.3.tgz",
+      "integrity": "sha512-nZD1OtwfWGRBWlpANxacBEZrEuLa16o1nh7YopFWeoF68Zt8GGEmzHu6Xv4F3XaFIC+YXtTLrzgqKxFgLEe4jw==",
       "dev": true,
       "requires": {
-        "@babel/runtime": "^7.1.2"
+        "@babel/runtime": "^7.6.3",
+        "csstype": "^2.6.7"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.7.4",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.4.tgz",
+          "integrity": "sha512-r24eVUUr0QqNZa+qrImUk8fn5SPhHq+IfYvIoIMg0do3GdK9sMdiLKP3GYVVaxpPKORgm8KRKaNTEhAjgIpLMw==",
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.13.2"
+          }
+        }
       }
     },
     "dom-serializer": {
@@ -13723,9 +13725,9 @@
       }
     },
     "react-bootstrap": {
-      "version": "1.0.0-beta.14",
-      "resolved": "https://registry.npmjs.org/react-bootstrap/-/react-bootstrap-1.0.0-beta.14.tgz",
-      "integrity": "sha512-UGK5f78FE8wAei1YL/oSwFlJZLqxJ/h4S8DCwHyY8hQjFCrjEW5PoEBTOOhQ6PQL6WOsZe1jkiOJG7L5TZWu+w==",
+      "version": "1.0.0-beta.16",
+      "resolved": "https://registry.npmjs.org/react-bootstrap/-/react-bootstrap-1.0.0-beta.16.tgz",
+      "integrity": "sha512-wjb+3CwviDWAaz4O3gQpd2XMDNqbOiqOOzpLm5aLPcp1wTsQsVRhyM+rTPmO3hYU8auA2eNpTYLz08/fAcMqDA==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.4.2",
@@ -13733,23 +13735,17 @@
         "@restart/hooks": "^0.3.11",
         "@types/react": "^16.8.23",
         "classnames": "^2.2.6",
-        "dom-helpers": "^3.4.0",
+        "dom-helpers": "^5.1.2",
         "invariant": "^2.2.4",
         "keycode": "^2.2.0",
-        "popper.js": "^1.14.7",
+        "popper.js": "^1.16.0",
         "prop-types": "^15.7.2",
         "prop-types-extra": "^1.1.0",
-        "react-overlays": "^1.2.0",
+        "react-overlays": "^2.1.0",
         "react-transition-group": "^4.0.0",
         "uncontrollable": "^7.0.0",
         "warning": "^4.0.3"
       }
-    },
-    "react-context-toolbox": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/react-context-toolbox/-/react-context-toolbox-2.0.2.tgz",
-      "integrity": "sha512-tY4j0imkYC3n5ZlYSgFkaw7fmlCp3IoQQ6DxpqeNHzcD0hf+6V+/HeJxviLUZ1Rv1Yn3N3xyO2EhkkZwHn0m1A==",
-      "dev": true
     },
     "react-dev-utils": {
       "version": "9.1.0",
@@ -13868,45 +13864,18 @@
       "dev": true
     },
     "react-overlays": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/react-overlays/-/react-overlays-1.2.0.tgz",
-      "integrity": "sha512-i/FCV8wR6aRaI+Kz/dpJhOdyx+ah2tN1RhT9InPrexyC4uzf3N4bNayFTGtUeQVacj57j1Mqh1CwV60/5153Iw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/react-overlays/-/react-overlays-2.1.0.tgz",
+      "integrity": "sha512-tHPGTZosbQSo82yb9x4YCsmJJtspKvAPL5kXVnyoB2Z5UoAU3VetIuh2VblfVT408us5nLJd9uDtwI3xWDHS6w==",
       "dev": true,
       "requires": {
-        "classnames": "^2.2.6",
-        "dom-helpers": "^3.4.0",
-        "prop-types": "^15.6.2",
-        "prop-types-extra": "^1.1.0",
-        "react-context-toolbox": "^2.0.2",
-        "react-popper": "^1.3.2",
-        "uncontrollable": "^6.0.0",
-        "warning": "^4.0.2"
-      },
-      "dependencies": {
-        "uncontrollable": {
-          "version": "6.2.3",
-          "resolved": "https://registry.npmjs.org/uncontrollable/-/uncontrollable-6.2.3.tgz",
-          "integrity": "sha512-VgOAoBU2ptCL2bfTG2Mra0I8i1u6Aq84AFonD5tmCAYSfs3hWvr2Rlw0q2ntoxXTHjcQOmZOh3FKaN+UZVyREQ==",
-          "dev": true,
-          "requires": {
-            "@babel/runtime": "^7.4.5",
-            "invariant": "^2.2.4"
-          }
-        }
-      }
-    },
-    "react-popper": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-1.3.4.tgz",
-      "integrity": "sha512-9AcQB29V+WrBKk6X7p0eojd1f25/oJajVdMZkywIoAV6Ag7hzE1Mhyeup2Q1QnvFRtGQFQvtqfhlEoDAPfKAVA==",
-      "dev": true,
-      "requires": {
-        "@babel/runtime": "^7.1.2",
-        "create-react-context": "^0.3.0",
-        "popper.js": "^1.14.4",
-        "prop-types": "^15.6.1",
-        "typed-styles": "^0.0.7",
-        "warning": "^4.0.2"
+        "@babel/runtime": "^7.4.5",
+        "@restart/hooks": "^0.3.12",
+        "dom-helpers": "^5.1.0",
+        "popper.js": "^1.15.0",
+        "prop-types": "^15.7.2",
+        "uncontrollable": "^7.0.0",
+        "warning": "^4.0.3"
       }
     },
     "react-redux": {
@@ -14085,29 +14054,6 @@
         "dom-helpers": "^5.0.1",
         "loose-envify": "^1.4.0",
         "prop-types": "^15.6.2"
-      },
-      "dependencies": {
-        "dom-helpers": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.1.2.tgz",
-          "integrity": "sha512-VrfjMjIzNgn2oB49wKl85fgs12ELjK0npu5Oryaiazyc6WuekO1go0E//0RJ8JvsBlfaAwq+IgX9M0XhwlEENA==",
-          "dev": true,
-          "requires": {
-            "@babel/runtime": "^7.6.3",
-            "csstype": "^2.6.7"
-          },
-          "dependencies": {
-            "@babel/runtime": {
-              "version": "7.6.3",
-              "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.6.3.tgz",
-              "integrity": "sha512-kq6anf9JGjW8Nt5rYfEuGRaEAaH1mkv3Bbu6rYvLOpPh/RusSJXuKPEAoZ7L7gybZkchE8+NV5g9vKF4AGAtsA==",
-              "dev": true,
-              "requires": {
-                "regenerator-runtime": "^0.13.2"
-              }
-            }
-          }
-        }
       }
     },
     "read-pkg": {
@@ -16638,12 +16584,6 @@
         "mime-types": "~2.1.24"
       }
     },
-    "typed-styles": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/typed-styles/-/typed-styles-0.0.7.tgz",
-      "integrity": "sha512-pzP0PWoZUhsECYjABgCGQlRGL1n7tOHsgwYv3oIiEpJwGhFTuty/YNeduxQYzXXa3Ge5BdT6sHYIQYpl4uJ+5Q==",
-      "dev": true
-    },
     "typedarray": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
@@ -16687,14 +16627,36 @@
       "dev": true
     },
     "uncontrollable": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/uncontrollable/-/uncontrollable-7.0.2.tgz",
-      "integrity": "sha512-7fa8OBQ5+X4VAcp0os6BD74bCeUPQSHmr4Rqy75Me98NnlD5kNShCqqx4xWo4OmlAMiT2/YSMklLFC4FCuoGYg==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/uncontrollable/-/uncontrollable-7.1.1.tgz",
+      "integrity": "sha512-EcPYhot3uWTS3w00R32R2+vS8Vr53tttrvMj/yA1uYRhf8hbTG2GyugGqWDY0qIskxn0uTTojVd6wPYW9ZEf8Q==",
       "dev": true,
       "requires": {
-        "@babel/runtime": "^7.4.5",
+        "@babel/runtime": "^7.6.3",
+        "@types/react": "^16.9.11",
         "invariant": "^2.2.4",
         "react-lifecycles-compat": "^3.0.4"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.7.4",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.4.tgz",
+          "integrity": "sha512-r24eVUUr0QqNZa+qrImUk8fn5SPhHq+IfYvIoIMg0do3GdK9sMdiLKP3GYVVaxpPKORgm8KRKaNTEhAjgIpLMw==",
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.13.2"
+          }
+        },
+        "@types/react": {
+          "version": "16.9.13",
+          "resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.13.tgz",
+          "integrity": "sha512-LikzRslbiufJYHyzbHSW0GrAiff8QYLMBFeZmSxzCYGXKxi8m/1PHX+rsVOwhr7mJNq+VIu2Dhf7U6mjFERK6w==",
+          "dev": true,
+          "requires": {
+            "@types/prop-types": "*",
+            "csstype": "^2.2.0"
+          }
+        }
       }
     },
     "unicode-canonical-property-names-ecmascript": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -7920,6 +7920,14 @@
       "integrity": "sha512-O3sR1/opvCDGLEVcvrGTMtLac8GJ5IwZC4puPrLuRj3l7ICKvkmA0vGuU9OW8mV9WIBRnaxp5GJh9IEAaNOoYg==",
       "dev": true
     },
+    "immutability-helper": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/immutability-helper/-/immutability-helper-3.0.1.tgz",
+      "integrity": "sha512-U92ROQQt7XkIwrdqCByUI118TQM1hXdKnRQpvKeA0HRyGSnJipu9IWHe4UD8zCN00O8UnQjQzPCgZ1CC3yBzHA==",
+      "requires": {
+        "invariant": "^2.2.4"
+      }
+    },
     "immutable": {
       "version": "3.8.2",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.2.tgz",
@@ -8194,7 +8202,6 @@
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
       "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
-      "dev": true,
       "requires": {
         "loose-envify": "^1.0.0"
       }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -72,6 +72,7 @@
     ]
   },
   "dependencies": {
-    "history": "^4.10.1"
+    "history": "^4.10.1",
+    "immutability-helper": "^3.0.1"
   }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -32,7 +32,7 @@
     "plop": "^2.5.2",
     "prettier": "1.19.1",
     "react": "^16.11.0",
-    "react-bootstrap": "^1.0.0-beta.14",
+    "react-bootstrap": "^1.0.0-beta.16",
     "react-dom": "^16.11.0",
     "react-intl": "^3.4.0",
     "react-redux": "^7.1.1",

--- a/frontend/src/global/constants.ts
+++ b/frontend/src/global/constants.ts
@@ -8,6 +8,9 @@ export const TOS_LINK = process.env.REACT_APP_TOS_LINK || '/#';
 export const PRIVACY_POLICY_LINK =
   process.env.REACT_APP_PRIVACY_POLICY_LINK || '/#';
 
+export const INTERNAL_DOMAIN_NAME =
+  process.env.REACT_APP_INTERNAL_DOMAIN_NAME || '.opencraft.hosting';
+
 export enum RegistrationSteps {
   FIRST_STEP = 1,
   DOMAIN = 1,

--- a/frontend/src/global/constants.ts
+++ b/frontend/src/global/constants.ts
@@ -4,6 +4,9 @@ export const OCIM_API_BASE =
 export const CONTACT_US_LINK = process.env.REACT_APP_CONTACT_US_LINK || '/#';
 export const ENTERPRISE_COMPARISON_LINK =
   process.env.REACT_APP_ENTERPRISE_COMPARISON_LINK || '/#';
+export const TOS_LINK = process.env.REACT_APP_TOS_LINK || '/#';
+export const PRIVACY_POLICY_LINK =
+  process.env.REACT_APP_PRIVACY_POLICY_LINK || '/#';
 
 export enum RegistrationSteps {
   FIRST_STEP = 1,

--- a/frontend/src/global/constants.ts
+++ b/frontend/src/global/constants.ts
@@ -10,9 +10,8 @@ export enum RegistrationSteps {
   DOMAIN = 1,
   INSTANCE = 2,
   ACCOUNT = 3,
-  THEME = 4,
-  CONGRATS = 5,
-  LAST_STEP = 5
+  CONGRATS = 4,
+  LAST_STEP = 4
 }
 
 export const ROUTES = {
@@ -21,7 +20,6 @@ export const ROUTES = {
     DOMAIN: '/registration/domain',
     INSTANCE: '/registration/instance',
     ACCOUNT: '/registration/account',
-    THEME: '/registration/theme',
     CONGRATS: '/registration/congrats'
   }
 };
@@ -30,6 +28,5 @@ export const REGISTRATION_STEPS = [
   ROUTES.Registration.DOMAIN,
   ROUTES.Registration.INSTANCE,
   ROUTES.Registration.ACCOUNT,
-  ROUTES.Registration.THEME,
   ROUTES.Registration.CONGRATS
 ];

--- a/frontend/src/global/state.ts
+++ b/frontend/src/global/state.ts
@@ -1,9 +1,9 @@
 import { LoginStatusModel } from '../auth/models';
-import { RegistrationModel } from '../registration/models';
+import { RegistrationStateModel } from '../registration/models';
 import { UiStateModel } from '../ui/models';
 
 export interface RootState {
-  readonly registration: Readonly<RegistrationModel>;
+  readonly registration: Readonly<RegistrationStateModel>;
   readonly loginState: Readonly<LoginStatusModel>;
   readonly ui: Readonly<UiStateModel>;
 }

--- a/frontend/src/registration/actions.ts
+++ b/frontend/src/registration/actions.ts
@@ -2,7 +2,7 @@ import { push } from 'connected-react-router';
 import { OcimThunkAction } from 'global/types';
 import { Action } from 'redux';
 import { Types as UIActionTypes } from 'ui/actions';
-import { RegistrationModel, InstanceInfoModel } from './models';
+import { RegistrationModel, InstanceInfoModel, DomainInfoModel } from './models';
 
 export enum Types {
   REGISTRATION_SUBMIT = 'REGISTRATION_SUBMIT',
@@ -30,6 +30,19 @@ export type ActionTypes =
   | RegistrationSuccess
   | RegistrationFailure;
 
+
+export const updateDomainInfoState = (
+  data: DomainInfoModel,
+): OcimThunkAction<void> => async dispatch => {
+  dispatch({ type: Types.REGISTRATION_SUCCESS, data });
+};
+
+export const updateInstanceInfoState = (
+  data: InstanceInfoModel,
+): OcimThunkAction<void> => async dispatch => {
+  dispatch({ type: Types.REGISTRATION_SUCCESS, data });
+};
+
 export const submitRegistration = (
   data: RegistrationModel,
   nextStep?: string
@@ -39,26 +52,28 @@ export const submitRegistration = (
     data
   });
 
-  try {
-    // try submitting form data
-    // TODO
-    if (data.domain === 'existing') {
-      throw Error('Test error');
+  setTimeout(() => {
+    try {
+      // try submitting form data
+      // TODO
+      if (data.domain === 'existing') {
+        throw Error('Test error');
+      }
+      dispatch({ type: Types.REGISTRATION_SUCCESS, data });
+      if (nextStep) {
+        dispatch(push(nextStep));
+      }
+      dispatch({ type: UIActionTypes.NAVIGATE_NEXT_PAGE });
+    } catch (error) {
+      dispatch({
+        type: Types.REGISTRATION_FAILURE,
+        error
+      });
     }
-    dispatch({ type: Types.REGISTRATION_SUCCESS, data });
-    if (nextStep) {
-      dispatch(push(nextStep));
-    }
-    dispatch({ type: UIActionTypes.NAVIGATE_NEXT_PAGE });
-  } catch (error) {
-    dispatch({
-      type: Types.REGISTRATION_FAILURE,
-      error
-    });
-  }
+  }, 800);
 };
 
-export const submitInstanceInfo = (
+export const validateInstanceInfo = (
   data: InstanceInfoModel,
   nextStep?: string
 ): OcimThunkAction<void> => async dispatch => {
@@ -66,22 +81,23 @@ export const submitInstanceInfo = (
     type: Types.REGISTRATION_SUBMIT,
     data
   });
-
-  try {
-    // try submitting form data
-    // TODO
-    if (data.publicContactEmail === 'existing') {
-      throw Error('Test error');
+  setTimeout(() => {
+    try {
+      // try submitting form data
+      // TODO
+      if (data.publicContactEmail === 'existing') {
+        throw Error('Test error');
+      }
+      dispatch({ type: Types.REGISTRATION_SUCCESS, data });
+      if (nextStep) {
+        dispatch(push(nextStep));
+      }
+      dispatch({ type: UIActionTypes.NAVIGATE_NEXT_PAGE });
+    } catch (error) {
+      dispatch({
+        type: Types.REGISTRATION_FAILURE,
+        error
+      });
     }
-    dispatch({ type: Types.REGISTRATION_SUCCESS, data });
-    if (nextStep) {
-      dispatch(push(nextStep));
-    }
-    dispatch({ type: UIActionTypes.NAVIGATE_NEXT_PAGE });
-  } catch (error) {
-    dispatch({
-      type: Types.REGISTRATION_FAILURE,
-      error
-    });
-  }
+  }, 800);
 };

--- a/frontend/src/registration/actions.ts
+++ b/frontend/src/registration/actions.ts
@@ -9,8 +9,8 @@ import {
 } from './models';
 
 export enum Types {
-  // Support action to update root state
-  ROOT_STATE_UPDATE = 'ROOT_STATE_UPDATE',
+  // Support action to update root state and clean error messages when users change fields
+  CLEAR_ERROR_MESSAGE = 'CLEAR_ERROR_MESSAGE',
   // Data validation actions
   REGISTRATION_VALIDATION = 'REGISTRATION_VALIDATION',
   REGISTRATION_VALIDATION_SUCCESS = 'REGISTRATION_VALIDATION_SUCCESS',
@@ -21,9 +21,9 @@ export enum Types {
   REGISTRATION_FAILURE = 'REGISTRATION_FAILURE'
 }
 
-export interface RootStateUpdate extends Action {
-  readonly type: Types.ROOT_STATE_UPDATE;
-  readonly data: RegistrationStateModel;
+export interface FeedbackMessageChange extends Action {
+  readonly type: Types.CLEAR_ERROR_MESSAGE;
+  readonly data: RegistrationFeedbackModel;
 }
 
 export interface RegistrationValidation extends Action {
@@ -32,7 +32,7 @@ export interface RegistrationValidation extends Action {
 
 export interface RegistrationValidationSuccess extends Action {
   readonly type: Types.REGISTRATION_VALIDATION_SUCCESS;
-  readonly data: RegistrationStateModel;
+  readonly data: RegistrationModel;
 }
 
 export interface RegistrationValidationFailure extends Action {
@@ -55,7 +55,7 @@ export interface RegistrationFailure extends Action {
 }
 
 export type ActionTypes =
-  | RootStateUpdate
+  | FeedbackMessageChange
   | RegistrationValidation
   | RegistrationValidationSuccess
   | RegistrationValidationFailure
@@ -63,13 +63,45 @@ export type ActionTypes =
   | RegistrationSuccess
   | RegistrationFailure;
 
-export const updateRootState = (
-  data: RegistrationStateModel
+export const clearErrorMessage = (
+  data: RegistrationFeedbackModel
 ): OcimThunkAction<void> => async dispatch => {
-  dispatch({ type: Types.ROOT_STATE_UPDATE, data });
+  dispatch({ type: Types.CLEAR_ERROR_MESSAGE, data });
 };
 
 export const performValidation = (
+  data: RegistrationModel,
+  nextStep?: string
+): OcimThunkAction<void> => async dispatch => {
+  // Placeholder for form validation method
+  dispatch({
+    type: Types.REGISTRATION_VALIDATION,
+    data
+  });
+  setTimeout(() => {
+    try {
+      // TODO
+      if (data.domain === 'existing') {
+        throw Error('Test error');
+      }
+      dispatch({ type: Types.REGISTRATION_VALIDATION_SUCCESS, data });
+      if (nextStep) {
+        dispatch(push(nextStep));
+      }
+      dispatch({ type: UIActionTypes.NAVIGATE_NEXT_PAGE });
+    } catch (e) {
+      const error = {
+        domain: 'Domain already exists!'
+      };
+      dispatch({
+        type: Types.REGISTRATION_VALIDATION_FAILURE,
+        error
+      });
+    }
+  }, 800);
+};
+
+export const performValidationAndStore = (
   data: RegistrationModel,
   nextStep?: string
 ): OcimThunkAction<void> => async dispatch => {

--- a/frontend/src/registration/actions.ts
+++ b/frontend/src/registration/actions.ts
@@ -23,7 +23,7 @@ export enum Types {
 
 export interface FeedbackMessageChange extends Action {
   readonly type: Types.CLEAR_ERROR_MESSAGE;
-  readonly data: RegistrationFeedbackModel;
+  readonly field: keyof RegistrationStateModel;
 }
 
 export interface RegistrationValidation extends Action {
@@ -63,11 +63,12 @@ export type ActionTypes =
   | RegistrationSuccess
   | RegistrationFailure;
 
-export const clearErrorMessage = (
-  data: RegistrationFeedbackModel
-): OcimThunkAction<void> => async dispatch => {
-  dispatch({ type: Types.CLEAR_ERROR_MESSAGE, data });
-};
+export const clearErrorMessage = (field: keyof RegistrationStateModel) => async (dispatch: any) => {
+  dispatch({
+    type: Types.CLEAR_ERROR_MESSAGE,
+    field: field
+  });
+}
 
 export const performValidation = (
   data: RegistrationModel,

--- a/frontend/src/registration/actions.ts
+++ b/frontend/src/registration/actions.ts
@@ -2,93 +2,117 @@ import { push } from 'connected-react-router';
 import { OcimThunkAction } from 'global/types';
 import { Action } from 'redux';
 import { Types as UIActionTypes } from 'ui/actions';
-import {
-  RegistrationModel,
-  InstanceInfoModel,
-  DomainInfoModel
-} from './models';
+import { RegistrationModel, RegistrationStateModel, RegistrationFeedbackModel } from './models';
 
 export enum Types {
+  // Support action to update root state
+  ROOT_STATE_UPDATE = 'ROOT_STATE_UPDATE',
+  // Data validation actions
+  REGISTRATION_VALIDATION = 'REGISTRATION_VALIDATION',
+  REGISTRATION_VALIDATION_SUCCESS = 'REGISTRATION_VALIDATION_SUCCESS',
+  REGISTRATION_VALIDATION_FAILURE = 'REGISTRATION_VALIDATION_FAILURE',
+  // Account registration
   REGISTRATION_SUBMIT = 'REGISTRATION_SUBMIT',
   REGISTRATION_SUCCESS = 'REGISTRATION_SUCCESS',
   REGISTRATION_FAILURE = 'REGISTRATION_FAILURE'
 }
 
+export interface RootStateUpdate extends Action {
+  readonly type: Types.ROOT_STATE_UPDATE;
+  readonly data: RegistrationStateModel;
+}
+
+export interface RegistrationValidation extends Action {
+  readonly type: Types.REGISTRATION_VALIDATION;
+  readonly data: RegistrationStateModel;
+}
+
+export interface RegistrationValidationSuccess extends Action {
+  readonly type: Types.REGISTRATION_VALIDATION_SUCCESS;
+  readonly data: RegistrationStateModel;
+}
+
+export interface RegistrationValidationFailure extends Action {
+  readonly type: Types.REGISTRATION_VALIDATION_FAILURE;
+  readonly error: RegistrationFeedbackModel;
+}
+
 export interface SubmitRegistration extends Action {
   readonly type: Types.REGISTRATION_SUBMIT;
-  readonly data: RegistrationModel;
+  readonly data: RegistrationStateModel;
 }
 
 export interface RegistrationSuccess extends Action {
   readonly type: Types.REGISTRATION_SUCCESS;
-  readonly data: RegistrationModel;
+  readonly data: RegistrationStateModel;
 }
 
 export interface RegistrationFailure extends Action {
   readonly type: Types.REGISTRATION_FAILURE;
-  readonly error: any;
+  readonly error: RegistrationFeedbackModel;
 }
 
 export type ActionTypes =
+  | RootStateUpdate
+  | RegistrationValidation
+  | RegistrationValidationSuccess
+  | RegistrationValidationFailure
   | SubmitRegistration
   | RegistrationSuccess
   | RegistrationFailure;
 
-export const updateDomainInfoState = (
-  data: DomainInfoModel
+export const updateRootState = (
+  data: RegistrationModel
 ): OcimThunkAction<void> => async dispatch => {
-  dispatch({ type: Types.REGISTRATION_SUCCESS, data });
+  dispatch({ type: Types.ROOT_STATE_UPDATE, data });
 };
 
-export const updateInstanceInfoState = (
-  data: InstanceInfoModel
-): OcimThunkAction<void> => async dispatch => {
-  dispatch({ type: Types.REGISTRATION_SUCCESS, data });
-};
-
-export const submitRegistration = (
+export const performValidation = (
   data: RegistrationModel,
   nextStep?: string
 ): OcimThunkAction<void> => async dispatch => {
+  // Placeholder for form validation method
   dispatch({
-    type: Types.REGISTRATION_SUBMIT,
+    type: Types.REGISTRATION_VALIDATION,
     data
   });
-
   setTimeout(() => {
     try {
-      // try submitting form data
       // TODO
       if (data.domain === 'existing') {
         throw Error('Test error');
       }
-      dispatch({ type: Types.REGISTRATION_SUCCESS, data });
+      dispatch({ type: Types.REGISTRATION_VALIDATION_SUCCESS, data });
       if (nextStep) {
         dispatch(push(nextStep));
       }
       dispatch({ type: UIActionTypes.NAVIGATE_NEXT_PAGE });
-    } catch (error) {
+    } catch (e) {
+      const error = {
+        domain: 'Domain already exists!'
+      };
       dispatch({
-        type: Types.REGISTRATION_FAILURE,
+        type: Types.REGISTRATION_VALIDATION_FAILURE,
         error
       });
     }
   }, 800);
 };
 
-export const validateInstanceInfo = (
-  data: InstanceInfoModel,
+export const submitRegistration = (
+  data: RegistrationModel,
   nextStep?: string
 ): OcimThunkAction<void> => async dispatch => {
+  // Placeholder for form submit method
   dispatch({
     type: Types.REGISTRATION_SUBMIT,
     data
   });
+
   setTimeout(() => {
     try {
-      // try submitting form data
       // TODO
-      if (data.publicContactEmail === 'existing') {
+      if (data.domain === 'existing') {
         throw Error('Test error');
       }
       dispatch({ type: Types.REGISTRATION_SUCCESS, data });

--- a/frontend/src/registration/actions.ts
+++ b/frontend/src/registration/actions.ts
@@ -28,7 +28,6 @@ export interface RootStateUpdate extends Action {
 
 export interface RegistrationValidation extends Action {
   readonly type: Types.REGISTRATION_VALIDATION;
-  readonly data: RegistrationStateModel;
 }
 
 export interface RegistrationValidationSuccess extends Action {
@@ -43,7 +42,6 @@ export interface RegistrationValidationFailure extends Action {
 
 export interface SubmitRegistration extends Action {
   readonly type: Types.REGISTRATION_SUBMIT;
-  readonly data: RegistrationStateModel;
 }
 
 export interface RegistrationSuccess extends Action {
@@ -66,7 +64,7 @@ export type ActionTypes =
   | RegistrationFailure;
 
 export const updateRootState = (
-  data: RegistrationModel
+  data: RegistrationStateModel
 ): OcimThunkAction<void> => async dispatch => {
   dispatch({ type: Types.ROOT_STATE_UPDATE, data });
 };

--- a/frontend/src/registration/actions.ts
+++ b/frontend/src/registration/actions.ts
@@ -63,12 +63,14 @@ export type ActionTypes =
   | RegistrationSuccess
   | RegistrationFailure;
 
-export const clearErrorMessage = (field: keyof RegistrationStateModel) => async (dispatch: any) => {
+export const clearErrorMessage = (
+  field: keyof RegistrationStateModel
+) => async (dispatch: any) => {
   dispatch({
     type: Types.CLEAR_ERROR_MESSAGE,
-    field: field
+    field
   });
-}
+};
 
 export const performValidation = (
   data: RegistrationModel,

--- a/frontend/src/registration/actions.ts
+++ b/frontend/src/registration/actions.ts
@@ -2,7 +2,11 @@ import { push } from 'connected-react-router';
 import { OcimThunkAction } from 'global/types';
 import { Action } from 'redux';
 import { Types as UIActionTypes } from 'ui/actions';
-import { RegistrationModel, InstanceInfoModel, DomainInfoModel } from './models';
+import {
+  RegistrationModel,
+  InstanceInfoModel,
+  DomainInfoModel
+} from './models';
 
 export enum Types {
   REGISTRATION_SUBMIT = 'REGISTRATION_SUBMIT',
@@ -30,15 +34,14 @@ export type ActionTypes =
   | RegistrationSuccess
   | RegistrationFailure;
 
-
 export const updateDomainInfoState = (
-  data: DomainInfoModel,
+  data: DomainInfoModel
 ): OcimThunkAction<void> => async dispatch => {
   dispatch({ type: Types.REGISTRATION_SUCCESS, data });
 };
 
 export const updateInstanceInfoState = (
-  data: InstanceInfoModel,
+  data: InstanceInfoModel
 ): OcimThunkAction<void> => async dispatch => {
   dispatch({ type: Types.REGISTRATION_SUCCESS, data });
 };

--- a/frontend/src/registration/actions.ts
+++ b/frontend/src/registration/actions.ts
@@ -2,7 +2,11 @@ import { push } from 'connected-react-router';
 import { OcimThunkAction } from 'global/types';
 import { Action } from 'redux';
 import { Types as UIActionTypes } from 'ui/actions';
-import { RegistrationModel, RegistrationStateModel, RegistrationFeedbackModel } from './models';
+import {
+  RegistrationModel,
+  RegistrationStateModel,
+  RegistrationFeedbackModel
+} from './models';
 
 export enum Types {
   // Support action to update root state

--- a/frontend/src/registration/actions.ts
+++ b/frontend/src/registration/actions.ts
@@ -2,7 +2,7 @@ import { push } from 'connected-react-router';
 import { OcimThunkAction } from 'global/types';
 import { Action } from 'redux';
 import { Types as UIActionTypes } from 'ui/actions';
-import { RegistrationModel } from './models';
+import { RegistrationModel, InstanceInfoModel } from './models';
 
 export enum Types {
   REGISTRATION_SUBMIT = 'REGISTRATION_SUBMIT',
@@ -43,6 +43,34 @@ export const submitRegistration = (
     // try submitting form data
     // TODO
     if (data.domain === 'existing') {
+      throw Error('Test error');
+    }
+    dispatch({ type: Types.REGISTRATION_SUCCESS, data });
+    if (nextStep) {
+      dispatch(push(nextStep));
+    }
+    dispatch({ type: UIActionTypes.NAVIGATE_NEXT_PAGE });
+  } catch (error) {
+    dispatch({
+      type: Types.REGISTRATION_FAILURE,
+      error
+    });
+  }
+};
+
+export const submitInstanceInfo = (
+  data: InstanceInfoModel,
+  nextStep?: string
+): OcimThunkAction<void> => async dispatch => {
+  dispatch({
+    type: Types.REGISTRATION_SUBMIT,
+    data
+  });
+
+  try {
+    // try submitting form data
+    // TODO
+    if (data.publicContactEmail === 'existing') {
       throw Error('Test error');
     }
     dispatch({ type: Types.REGISTRATION_SUCCESS, data });

--- a/frontend/src/registration/components/AccountSetupPage/AccountSetupPage.spec.tsx
+++ b/frontend/src/registration/components/AccountSetupPage/AccountSetupPage.spec.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import { setupComponentForTesting } from "utils/testing";
+import { AccountSetupPage } from './AccountSetupPage';
+
+it('renders without crashing', () => {
+    const tree = setupComponentForTesting(<AccountSetupPage />).toJSON();
+    expect(tree).toMatchSnapshot();
+});

--- a/frontend/src/registration/components/AccountSetupPage/AccountSetupPage.tsx
+++ b/frontend/src/registration/components/AccountSetupPage/AccountSetupPage.tsx
@@ -78,12 +78,14 @@ export class AccountSetupPage extends React.PureComponent<Props> {
             value={this.props.registrationData.fullName}
             onChange={this.onChange}
             messages={messages}
+            error={this.props.registrationFeedback.fullName}
           />
           <TextInputField
             fieldName="username"
             value={this.props.registrationData.username}
             onChange={this.onChange}
             messages={messages}
+            error={this.props.registrationFeedback.username}
           />
           <TextInputField
             fieldName="emailAddress"
@@ -91,6 +93,7 @@ export class AccountSetupPage extends React.PureComponent<Props> {
             onChange={this.onChange}
             type="email"
             messages={messages}
+            error={this.props.registrationFeedback.emailAddress}
           />
           <TextInputField
             fieldName="password"
@@ -98,6 +101,7 @@ export class AccountSetupPage extends React.PureComponent<Props> {
             onChange={this.onChange}
             type="password"
             messages={messages}
+            error={this.props.registrationFeedback.password}
           />
           <TextInputField
             fieldName="passwordConfirm"
@@ -105,6 +109,7 @@ export class AccountSetupPage extends React.PureComponent<Props> {
             onChange={this.onChange}
             type="password"
             messages={messages}
+            error={this.props.registrationFeedback.passwordConfirm}
           />
           <Form.Check type="checkbox" id="acceptTOS" custom>
             <Form.Check.Input
@@ -121,6 +126,11 @@ export class AccountSetupPage extends React.PureComponent<Props> {
               />
             </Form.Check.Label>
           </Form.Check>
+          {this.props.registrationFeedback.acceptTOS && (
+            <div className="invalid-feedback-checkbox">
+              {this.props.registrationFeedback.acceptTOS}
+            </div>
+          )}
           <Form.Check type="checkbox" id="acceptSupport" custom>
             <Form.Check.Input
               type="checkbox"
@@ -132,6 +142,11 @@ export class AccountSetupPage extends React.PureComponent<Props> {
               <WrappedMessage id="acceptSupport" messages={messages} />
             </Form.Check.Label>
           </Form.Check>
+          {this.props.registrationFeedback.acceptSupport && (
+            <div className="invalid-feedback-checkbox">
+              {this.props.registrationFeedback.acceptSupport}
+            </div>
+          )}
           <Form.Check type="checkbox" id="acceptTipsEmail" custom>
             <Form.Check.Input
               type="checkbox"
@@ -143,6 +158,11 @@ export class AccountSetupPage extends React.PureComponent<Props> {
               <WrappedMessage id="acceptTipsEmail" messages={messages} />
             </Form.Check.Label>
           </Form.Check>
+          {this.props.registrationFeedback.acceptTipsEmail && (
+            <div className="invalid-feedback-checkbox">
+              {this.props.registrationFeedback.acceptTipsEmail}
+            </div>
+          )}
         </Form>
         <RegistrationNavButtons
           loading={this.props.loading}

--- a/frontend/src/registration/components/AccountSetupPage/AccountSetupPage.tsx
+++ b/frontend/src/registration/components/AccountSetupPage/AccountSetupPage.tsx
@@ -80,7 +80,12 @@ export class AccountSetupPage extends React.PureComponent<
 
   private onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const field = e.target.name;
-    const { value } = e.target;
+    let value: boolean | string;
+    if (e.target.type === 'checkbox') {
+      value = e.target.checked;
+    } else {
+      value = e.target.value;
+    }
     this.setState<never>({ [field]: value });
   };
 
@@ -135,7 +140,12 @@ export class AccountSetupPage extends React.PureComponent<
             type="password"
           />
           <Form.Check type="checkbox" id="acceptTOS" custom>
-            <Form.Check.Input type="checkbox" />
+            <Form.Check.Input
+              type="checkbox"
+              name="acceptTOS"
+              checked={this.state.acceptTOS}
+              onChange={this.onChange}
+            />
             <Form.Check.Label>
               <WrappedMessage
                 id="acceptTos"
@@ -145,17 +155,23 @@ export class AccountSetupPage extends React.PureComponent<
             </Form.Check.Label>
           </Form.Check>
           <Form.Check type="checkbox" id="acceptSupport" custom>
-            <Form.Check.Input type="checkbox" />
+            <Form.Check.Input
+              type="checkbox"
+              name="acceptSupport"
+              checked={this.state.acceptSupport}
+              onChange={this.onChange}
+            />
             <Form.Check.Label>
               <WrappedMessage id="acceptSupport" messages={messages} />
             </Form.Check.Label>
           </Form.Check>
-          <Form.Check
-            type="checkbox"
-            id="acceptTipsEmail"
-            custom
-          >
-            <Form.Check.Input type="checkbox" />
+          <Form.Check type="checkbox" id="acceptTipsEmail" custom>
+            <Form.Check.Input
+              type="checkbox"
+              name="acceptTipsEmail"
+              checked={this.state.acceptTipsEmail}
+              onChange={this.onChange}
+            />
             <Form.Check.Label>
               <WrappedMessage id="acceptTipsEmail" messages={messages} />
             </Form.Check.Label>

--- a/frontend/src/registration/components/AccountSetupPage/AccountSetupPage.tsx
+++ b/frontend/src/registration/components/AccountSetupPage/AccountSetupPage.tsx
@@ -7,18 +7,29 @@ import { RegistrationNavButtons } from 'registration/components';
 import { TextInputField } from 'ui/components';
 import { PRIVACY_POLICY_LINK, ROUTES, TOS_LINK } from 'global/constants';
 import { RegistrationStateModel } from 'registration/models';
-import { updateRootState, submitRegistration } from '../../actions';
+import { clearErrorMessage, submitRegistration } from '../../actions';
 import { RegistrationPage } from '../RegistrationPage';
 import messages from './displayMessages';
 import './styles.scss';
 
 interface ActionProps {
   submitRegistration: Function;
-  updateRootState: Function;
+  clearErrorMessage: Function;
+}
+
+interface State {
+  [key: string]: string | boolean;
+  fullName: string;
+  username: string;
+  emailAddress: string;
+  password: string;
+  passwordConfirm: string;
+  acceptTOS: boolean;
+  acceptSupport: boolean;
+  acceptTipsEmail: boolean;
 }
 
 interface StateProps extends RegistrationStateModel {}
-
 interface Props extends StateProps, ActionProps {}
 
 @connect<StateProps, ActionProps, {}, Props, RootState>(
@@ -29,29 +40,65 @@ interface Props extends StateProps, ActionProps {}
   }),
   {
     submitRegistration,
-    updateRootState
+    clearErrorMessage
   }
 )
-export class AccountSetupPage extends React.PureComponent<Props> {
+export class AccountSetupPage extends React.PureComponent<Props, State> {
+  constructor(props: Props, state: State){
+    super(props);
+
+    this.state = {
+      fullName: this.props.registrationData.fullName,
+      username: this.props.registrationData.username,
+      emailAddress: this.props.registrationData.emailAddress,
+      password: this.props.registrationData.password,
+      passwordConfirm: this.props.registrationData.passwordConfirm,
+      acceptTOS: this.props.registrationData.acceptTOS,
+      acceptSupport: this.props.registrationData.acceptSupport,
+      acceptTipsEmail: this.props.registrationData.acceptTipsEmail
+    }
+  }
+
   private onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const field = e.target.name;
-    const { value } = e.target;
+    let value: boolean | string;
 
-    this.props.updateRootState({
-      registrationData: {
-        [field]: value
-      },
-      registrationFeedback: {
-        [field]: ''
-      }
+    if (e.target.type === "checkbox"){
+      value = e.target.checked;
+    } else {
+      value = e.target.value
+    }
+
+    this.setState({
+      [field]: value
     });
+
+    // Clear error message when the user changes field
+    if (this.props.registrationFeedback[field]) {
+      this.props.clearErrorMessage({
+        [field]: ''
+      });
+    };
   };
 
   private submitRegistration = () => {
-    this.props.submitRegistration({}, ROUTES.Registration.CONGRATS);
+    this.props.submitRegistration(
+      {
+        fullName: this.state.fullName,
+        username: this.state.username,
+        emailAddress: this.state.emailAddress,
+        password: this.state.password,
+        passwordConfirm: this.state.passwordConfirm,
+        acceptTOS: this.state.acceptTOS,
+        acceptSupport: this.state.acceptSupport,
+        acceptTipsEmail: this.state.acceptTipsEmail
+      },
+      ROUTES.Registration.CONGRATS
+    );
   };
 
   render() {
+    console.log(this.props.registrationData)
     const checkboxLinks = {
       tos: (
         <a href={PRIVACY_POLICY_LINK}>
@@ -75,21 +122,21 @@ export class AccountSetupPage extends React.PureComponent<Props> {
           </h2>
           <TextInputField
             fieldName="fullName"
-            value={this.props.registrationData.fullName}
+            value={this.state.fullName}
             onChange={this.onChange}
             messages={messages}
             error={this.props.registrationFeedback.fullName}
           />
           <TextInputField
             fieldName="username"
-            value={this.props.registrationData.username}
+            value={this.state.username}
             onChange={this.onChange}
             messages={messages}
             error={this.props.registrationFeedback.username}
           />
           <TextInputField
             fieldName="emailAddress"
-            value={this.props.registrationData.emailAddress}
+            value={this.state.emailAddress}
             onChange={this.onChange}
             type="email"
             messages={messages}
@@ -97,7 +144,7 @@ export class AccountSetupPage extends React.PureComponent<Props> {
           />
           <TextInputField
             fieldName="password"
-            value={this.props.registrationData.password}
+            value={this.state.password}
             onChange={this.onChange}
             type="password"
             messages={messages}
@@ -105,7 +152,7 @@ export class AccountSetupPage extends React.PureComponent<Props> {
           />
           <TextInputField
             fieldName="passwordConfirm"
-            value={this.props.registrationData.passwordConfirm}
+            value={this.state.passwordConfirm}
             onChange={this.onChange}
             type="password"
             messages={messages}
@@ -115,7 +162,7 @@ export class AccountSetupPage extends React.PureComponent<Props> {
             <Form.Check.Input
               type="checkbox"
               name="acceptTOS"
-              checked={this.props.registrationData.acceptTOS}
+              checked={this.state.acceptTOS}
               onChange={this.onChange}
             />
             <Form.Check.Label>
@@ -135,7 +182,7 @@ export class AccountSetupPage extends React.PureComponent<Props> {
             <Form.Check.Input
               type="checkbox"
               name="acceptSupport"
-              checked={this.props.registrationData.acceptSupport}
+              checked={this.state.acceptSupport}
               onChange={this.onChange}
             />
             <Form.Check.Label>
@@ -151,7 +198,7 @@ export class AccountSetupPage extends React.PureComponent<Props> {
             <Form.Check.Input
               type="checkbox"
               name="acceptTipsEmail"
-              checked={this.props.registrationData.acceptTipsEmail}
+              checked={this.state.acceptTipsEmail}
               onChange={this.onChange}
             />
             <Form.Check.Label>

--- a/frontend/src/registration/components/AccountSetupPage/AccountSetupPage.tsx
+++ b/frontend/src/registration/components/AccountSetupPage/AccountSetupPage.tsx
@@ -75,9 +75,7 @@ export class AccountSetupPage extends React.PureComponent<Props, State> {
 
     // Clear error message when the user changes field
     if (this.props.registrationFeedback[field]) {
-      this.props.clearErrorMessage({
-        [field]: ''
-      });
+      this.props.clearErrorMessage(field);
     }
   };
 

--- a/frontend/src/registration/components/AccountSetupPage/AccountSetupPage.tsx
+++ b/frontend/src/registration/components/AccountSetupPage/AccountSetupPage.tsx
@@ -1,43 +1,16 @@
 import { RootState } from 'global/state';
 import * as React from 'react';
 import { connect } from 'react-redux';
-import { Form, FormControl, FormGroup, FormLabel } from 'react-bootstrap';
+import { Form } from 'react-bootstrap';
 import { WrappedMessage } from 'utils/intl';
 import { RegistrationNavButtons } from 'registration/components';
+import { TextInputField } from 'ui/components';
 import { PRIVACY_POLICY_LINK, ROUTES, TOS_LINK } from 'global/constants';
+import { RegistrationStateModel } from 'registration/models';
 import { updateRootState, submitRegistration } from '../../actions';
-// import { getRegistrationData } from '../../selectors';
 import { RegistrationPage } from '../RegistrationPage';
 import messages from './displayMessages';
 import './styles.scss';
-
-import { RegistrationStateModel } from 'registration/models';
-
-interface InputFieldProps {
-  fieldName: string;
-  value: string;
-  onChange: any;
-  type?: string;
-}
-
-const InputField: React.SFC<InputFieldProps> = (props: InputFieldProps) => {
-  return (
-    <FormGroup>
-      <FormLabel>
-        <WrappedMessage id={props.fieldName} messages={messages} />
-      </FormLabel>
-      <FormControl
-        name={props.fieldName}
-        value={props.value}
-        onChange={props.onChange}
-        type={props.type}
-      />
-      <p>
-        <WrappedMessage id={`${props.fieldName}Help`} messages={messages} />
-      </p>
-    </FormGroup>
-  );
-};
 
 interface ActionProps {
   submitRegistration: Function;
@@ -100,33 +73,38 @@ export class AccountSetupPage extends React.PureComponent<Props> {
           <h2>
             <WrappedMessage id="createYourAccount" messages={messages} />
           </h2>
-          <InputField
+          <TextInputField
             fieldName="fullName"
             value={this.props.registrationData.fullName}
             onChange={this.onChange}
+            messages={messages}
           />
-          <InputField
+          <TextInputField
             fieldName="username"
             value={this.props.registrationData.username}
             onChange={this.onChange}
+            messages={messages}
           />
-          <InputField
+          <TextInputField
             fieldName="emailAddress"
             value={this.props.registrationData.emailAddress}
             onChange={this.onChange}
             type="email"
+            messages={messages}
           />
-          <InputField
+          <TextInputField
             fieldName="password"
             value={this.props.registrationData.password}
             onChange={this.onChange}
             type="password"
+            messages={messages}
           />
-          <InputField
+          <TextInputField
             fieldName="passwordConfirm"
             value={this.props.registrationData.passwordConfirm}
             onChange={this.onChange}
             type="password"
+            messages={messages}
           />
           <Form.Check type="checkbox" id="acceptTOS" custom>
             <Form.Check.Input

--- a/frontend/src/registration/components/AccountSetupPage/AccountSetupPage.tsx
+++ b/frontend/src/registration/components/AccountSetupPage/AccountSetupPage.tsx
@@ -11,7 +11,7 @@ import { RegistrationPage } from '../RegistrationPage';
 import messages from './displayMessages';
 import './styles.scss';
 
-import { RegistrationStateModel } from 'registration/models'
+import { RegistrationStateModel } from 'registration/models';
 
 interface InputFieldProps {
   fieldName: string;
@@ -75,10 +75,7 @@ export class AccountSetupPage extends React.PureComponent<Props> {
   };
 
   private submitRegistration = () => {
-    this.props.submitRegistration(
-      {},
-      ROUTES.Registration.CONGRATS
-    );
+    this.props.submitRegistration({}, ROUTES.Registration.CONGRATS);
   };
 
   render() {

--- a/frontend/src/registration/components/AccountSetupPage/AccountSetupPage.tsx
+++ b/frontend/src/registration/components/AccountSetupPage/AccountSetupPage.tsx
@@ -1,0 +1,48 @@
+import { RootState } from 'global/state';
+import * as React from 'react';
+import { connect } from 'react-redux';
+import { RegistrationNavButtons } from 'registration/components';
+import { submitRegistration } from '../../actions';
+import { getRegistrationData } from '../../selectors';
+import { RegistrationPage } from '../RegistrationPage';
+import './styles.scss';
+
+interface ActionProps {
+  submitRegistration: typeof submitRegistration;
+}
+
+interface StateProps {
+  domain: string;
+  domainIsExternal: boolean;
+}
+
+interface Props extends StateProps, ActionProps {}
+
+@connect<StateProps, ActionProps, {}, Props, RootState>(
+  (state: RootState) => ({
+    domain: getRegistrationData(state, 'domain'),
+    domainIsExternal: getRegistrationData(state, 'domainIsExternal')
+  }),
+  {
+    submitRegistration
+  }
+)
+export class AccountSetupPage extends React.PureComponent<Props> {
+  render() {
+    return (
+      <RegistrationPage
+        title="Create your Pro & Teacher Account"
+        currentStep={3}
+      >
+        <div>Account page</div>
+        <RegistrationNavButtons
+          disableNextButton
+          showBackButton
+          showNextButton
+          handleBackClick={() => {}}
+          handleNextClick={() => {}}
+        />
+      </RegistrationPage>
+    );
+  }
+}

--- a/frontend/src/registration/components/AccountSetupPage/AccountSetupPage.tsx
+++ b/frontend/src/registration/components/AccountSetupPage/AccountSetupPage.tsx
@@ -44,7 +44,7 @@ interface Props extends StateProps, ActionProps {}
   }
 )
 export class AccountSetupPage extends React.PureComponent<Props, State> {
-  constructor(props: Props, state: State){
+  constructor(props: Props, state: State) {
     super(props);
 
     this.state = {
@@ -56,17 +56,17 @@ export class AccountSetupPage extends React.PureComponent<Props, State> {
       acceptTOS: this.props.registrationData.acceptTOS,
       acceptSupport: this.props.registrationData.acceptSupport,
       acceptTipsEmail: this.props.registrationData.acceptTipsEmail
-    }
+    };
   }
 
   private onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const field = e.target.name;
     let value: boolean | string;
 
-    if (e.target.type === "checkbox"){
+    if (e.target.type === 'checkbox') {
       value = e.target.checked;
     } else {
-      value = e.target.value
+      value = e.target.value;
     }
 
     this.setState({
@@ -78,7 +78,7 @@ export class AccountSetupPage extends React.PureComponent<Props, State> {
       this.props.clearErrorMessage({
         [field]: ''
       });
-    };
+    }
   };
 
   private submitRegistration = () => {
@@ -98,7 +98,6 @@ export class AccountSetupPage extends React.PureComponent<Props, State> {
   };
 
   render() {
-    console.log(this.props.registrationData)
     const checkboxLinks = {
       tos: (
         <a href={PRIVACY_POLICY_LINK}>

--- a/frontend/src/registration/components/AccountSetupPage/AccountSetupPage.tsx
+++ b/frontend/src/registration/components/AccountSetupPage/AccountSetupPage.tsx
@@ -1,10 +1,14 @@
 import { RootState } from 'global/state';
 import * as React from 'react';
 import { connect } from 'react-redux';
+import { Form, FormControl, FormGroup, FormLabel } from 'react-bootstrap';
+import { WrappedMessage } from 'utils/intl';
 import { RegistrationNavButtons } from 'registration/components';
+import { PRIVACY_POLICY_LINK, TOS_LINK } from 'global/constants';
 import { submitRegistration } from '../../actions';
 import { getRegistrationData } from '../../selectors';
 import { RegistrationPage } from '../RegistrationPage';
+import messages from './displayMessages';
 import './styles.scss';
 
 interface ActionProps {
@@ -29,13 +33,97 @@ interface Props extends StateProps, ActionProps {}
 )
 export class AccountSetupPage extends React.PureComponent<Props> {
   render() {
+    const checkboxLinks = {
+      tos: (
+        <a href={PRIVACY_POLICY_LINK}>
+          <WrappedMessage id="privacyPolicy" messages={messages} />
+        </a>
+      ),
+      privacy_policy: (
+        <a href={TOS_LINK}>
+          <WrappedMessage id="termsOfService" messages={messages} />
+        </a>
+      )
+    };
     return (
       <RegistrationPage
         title="Create your Pro & Teacher Account"
         currentStep={3}
       >
-        <div>Account page</div>
+        <Form className="account-form">
+          <h2>
+            <WrappedMessage id="createYourAccount" messages={messages} />
+          </h2>
+          <FormGroup>
+            <FormLabel>
+              <WrappedMessage id="fullName" messages={messages} />
+            </FormLabel>
+            <FormControl />
+            <p>
+              <WrappedMessage id="fullNameHelp" messages={messages} />
+            </p>
+          </FormGroup>
+          <FormGroup>
+            <FormLabel>
+              <WrappedMessage id="username" messages={messages} />
+            </FormLabel>
+            <FormControl />
+            <p>
+              <WrappedMessage id="usernameHelp" messages={messages} />
+            </p>
+          </FormGroup>
+          <FormGroup>
+            <FormLabel>
+              <WrappedMessage id="email" messages={messages} />
+            </FormLabel>
+            <FormControl type="email" />
+            <p>
+              <WrappedMessage id="emailHelp" messages={messages} />
+            </p>
+          </FormGroup>
+          <FormGroup>
+            <FormLabel>
+              <WrappedMessage id="password" messages={messages} />
+            </FormLabel>
+            <FormControl type="password" />
+            <p>
+              <WrappedMessage id="passwordHelp" messages={messages} />
+            </p>
+          </FormGroup>
+          <FormGroup>
+            <FormLabel>
+              <WrappedMessage id="confirmPassword" messages={messages} />
+            </FormLabel>
+            <FormControl type="password" />
+            <p>
+              <WrappedMessage id="confirmPasswordHelp" messages={messages} />
+            </p>
+          </FormGroup>
+          <Form.Check type="checkbox" id="acceptTos" custom>
+            <Form.Check.Input type="checkbox" />
+            <Form.Check.Label>
+              <WrappedMessage
+                id="acceptTos"
+                messages={messages}
+                values={checkboxLinks}
+              />
+            </Form.Check.Label>
+          </Form.Check>
+          <Form.Check type="checkbox" id="acceptSupport" custom>
+            <Form.Check.Input type="checkbox" />
+            <Form.Check.Label>
+              <WrappedMessage id="acceptSupport" messages={messages} />
+            </Form.Check.Label>
+          </Form.Check>
+          <Form.Check type="checkbox" id="acceptNewsletter" custom>
+            <Form.Check.Input type="checkbox" />
+            <Form.Check.Label>
+              <WrappedMessage id="acceptNewsletter" messages={messages} />
+            </Form.Check.Label>
+          </Form.Check>
+        </Form>
         <RegistrationNavButtons
+          loading={false}
           disableNextButton
           showBackButton
           showNextButton

--- a/frontend/src/registration/components/AccountSetupPage/AccountSetupPage.tsx
+++ b/frontend/src/registration/components/AccountSetupPage/AccountSetupPage.tsx
@@ -7,6 +7,7 @@ import { RegistrationNavButtons } from 'registration/components';
 import { PRIVACY_POLICY_LINK, TOS_LINK } from 'global/constants';
 import { submitRegistration } from '../../actions';
 import { getRegistrationData } from '../../selectors';
+import { AccountInfoModel } from '../../models';
 import { RegistrationPage } from '../RegistrationPage';
 import messages from './displayMessages';
 import './styles.scss';
@@ -15,23 +16,74 @@ interface ActionProps {
   submitRegistration: typeof submitRegistration;
 }
 
-interface StateProps {
-  domain: string;
-  domainIsExternal: boolean;
+interface Props extends AccountInfoModel, ActionProps {}
+
+interface InputFieldProps {
+  fieldName: string;
+  value: string;
+  onChange: any;
+  type?: string;
 }
 
-interface Props extends StateProps, ActionProps {}
+const InputField: React.SFC<InputFieldProps> = (props: InputFieldProps) => {
+  return (
+    <FormGroup>
+      <FormLabel>
+        <WrappedMessage id={props.fieldName} messages={messages} />
+      </FormLabel>
+      <FormControl
+        name={props.fieldName}
+        value={props.value}
+        onChange={props.onChange}
+        type={props.type}
+      />
+      <p>
+        <WrappedMessage id={`${props.fieldName}Help`} messages={messages} />
+      </p>
+    </FormGroup>
+  );
+};
 
-@connect<StateProps, ActionProps, {}, Props, RootState>(
+@connect<AccountInfoModel, ActionProps, {}, Props, RootState>(
   (state: RootState) => ({
-    domain: getRegistrationData(state, 'domain'),
-    domainIsExternal: getRegistrationData(state, 'domainIsExternal')
+    fullName: getRegistrationData(state, 'fullName'),
+    username: getRegistrationData(state, 'username'),
+    emailAddress: getRegistrationData(state, 'emailAddress'),
+    password: getRegistrationData(state, 'password'),
+    passwordConfirm: getRegistrationData(state, 'passwordConfirm'),
+    acceptTOS: getRegistrationData(state, 'acceptTOS'),
+    acceptSupport: getRegistrationData(state, 'acceptSupport'),
+    acceptTipsEmail: getRegistrationData(state, 'acceptTipsEmail')
   }),
   {
     submitRegistration
   }
 )
-export class AccountSetupPage extends React.PureComponent<Props> {
+export class AccountSetupPage extends React.PureComponent<
+  Props,
+  AccountInfoModel
+> {
+  public constructor(props: Props, state: AccountInfoModel) {
+    super(props);
+
+    this.state = {
+      fullName: props.fullName,
+      username: props.username,
+      emailAddress: props.emailAddress,
+      password: props.password,
+      passwordConfirm: props.passwordConfirm,
+      acceptTOS: props.acceptTOS,
+      acceptSupport: props.acceptSupport,
+      acceptTipsEmail: props.acceptTipsEmail
+    };
+  }
+
+  private onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const field = e.target.name;
+    const { value } = e.target;
+    this.setState<never>({ [field]: value });
+  };
+
   render() {
     const checkboxLinks = {
       tos: (
@@ -54,52 +106,35 @@ export class AccountSetupPage extends React.PureComponent<Props> {
           <h2>
             <WrappedMessage id="createYourAccount" messages={messages} />
           </h2>
-          <FormGroup>
-            <FormLabel>
-              <WrappedMessage id="fullName" messages={messages} />
-            </FormLabel>
-            <FormControl />
-            <p>
-              <WrappedMessage id="fullNameHelp" messages={messages} />
-            </p>
-          </FormGroup>
-          <FormGroup>
-            <FormLabel>
-              <WrappedMessage id="username" messages={messages} />
-            </FormLabel>
-            <FormControl />
-            <p>
-              <WrappedMessage id="usernameHelp" messages={messages} />
-            </p>
-          </FormGroup>
-          <FormGroup>
-            <FormLabel>
-              <WrappedMessage id="email" messages={messages} />
-            </FormLabel>
-            <FormControl type="email" />
-            <p>
-              <WrappedMessage id="emailHelp" messages={messages} />
-            </p>
-          </FormGroup>
-          <FormGroup>
-            <FormLabel>
-              <WrappedMessage id="password" messages={messages} />
-            </FormLabel>
-            <FormControl type="password" />
-            <p>
-              <WrappedMessage id="passwordHelp" messages={messages} />
-            </p>
-          </FormGroup>
-          <FormGroup>
-            <FormLabel>
-              <WrappedMessage id="confirmPassword" messages={messages} />
-            </FormLabel>
-            <FormControl type="password" />
-            <p>
-              <WrappedMessage id="confirmPasswordHelp" messages={messages} />
-            </p>
-          </FormGroup>
-          <Form.Check type="checkbox" id="acceptTos" custom>
+          <InputField
+            fieldName="fullName"
+            value={this.state.fullName}
+            onChange={this.onChange}
+          />
+          <InputField
+            fieldName="username"
+            value={this.state.username}
+            onChange={this.onChange}
+          />
+          <InputField
+            fieldName="emailAddress"
+            value={this.state.emailAddress}
+            onChange={this.onChange}
+            type="email"
+          />
+          <InputField
+            fieldName="password"
+            value={this.state.password}
+            onChange={this.onChange}
+            type="password"
+          />
+          <InputField
+            fieldName="passwordConfirm"
+            value={this.state.passwordConfirm}
+            onChange={this.onChange}
+            type="password"
+          />
+          <Form.Check type="checkbox" id="acceptTOS" custom>
             <Form.Check.Input type="checkbox" />
             <Form.Check.Label>
               <WrappedMessage
@@ -115,10 +150,14 @@ export class AccountSetupPage extends React.PureComponent<Props> {
               <WrappedMessage id="acceptSupport" messages={messages} />
             </Form.Check.Label>
           </Form.Check>
-          <Form.Check type="checkbox" id="acceptNewsletter" custom>
+          <Form.Check
+            type="checkbox"
+            id="acceptTipsEmail"
+            custom
+          >
             <Form.Check.Input type="checkbox" />
             <Form.Check.Label>
-              <WrappedMessage id="acceptNewsletter" messages={messages} />
+              <WrappedMessage id="acceptTipsEmail" messages={messages} />
             </Form.Check.Label>
           </Form.Check>
         </Form>

--- a/frontend/src/registration/components/AccountSetupPage/__snapshots__/AccountSetupPage.spec.tsx.snap
+++ b/frontend/src/registration/components/AccountSetupPage/__snapshots__/AccountSetupPage.spec.tsx.snap
@@ -275,7 +275,7 @@ exports[`renders without crashing 1`] = `
           onClick={[Function]}
           type="button"
         >
-          back
+          Back
         </button>
         <button
           className="float-right loading btn btn-primary btn-lg"

--- a/frontend/src/registration/components/AccountSetupPage/__snapshots__/AccountSetupPage.spec.tsx.snap
+++ b/frontend/src/registration/components/AccountSetupPage/__snapshots__/AccountSetupPage.spec.tsx.snap
@@ -1,0 +1,292 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders without crashing 1`] = `
+<div
+  className="registration-page"
+>
+  <h1>
+    Create your Pro & Teacher Account
+  </h1>
+  <div
+    className="d-flex justify-content-center"
+  >
+    <div
+      className="step-bar"
+    >
+      <svg
+        className="step"
+        viewBox="0 0 10 10"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <circle
+          cx={5}
+          cy={5}
+          fill="#6d9cae"
+          r={5}
+        />
+      </svg>
+      <span
+        className="line"
+      />
+      <svg
+        className="step"
+        viewBox="0 0 10 10"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <circle
+          cx={5}
+          cy={5}
+          fill="#6d9cae"
+          r={5}
+        />
+      </svg>
+      <span
+        className="line"
+      />
+      <svg
+        className="circled-number"
+        viewBox="0 0 20 20"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <circle
+          className="outer-circle"
+          cx={10}
+          cy={10}
+          r={10}
+        />
+        <circle
+          className="inner-circle"
+          cx={10}
+          cy={10}
+          r={7}
+          strokeWidth={2}
+        />
+        <text
+          className="circle-text"
+          color="#1e4c59"
+          dy="0.4em"
+          fontSize="10px"
+          strokeWidth="1px"
+          textAnchor="middle"
+          x="50%"
+          y="50%"
+        >
+          3
+        </text>
+      </svg>
+      <span
+        className="line"
+      />
+      <svg
+        className="step"
+        viewBox="0 0 10 10"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <circle
+          cx={5}
+          cy={5}
+          fill="#6d9cae"
+          r={5}
+        />
+      </svg>
+      <span
+        className="line"
+      />
+    </div>
+  </div>
+  <div
+    className="registration-page-container"
+  >
+    <div
+      className="registration-page-content row"
+    >
+      <form
+        className="account-form"
+      >
+        <h2>
+          Create your account
+        </h2>
+        <div
+          className="form-group"
+        >
+          <label
+            className="form-label"
+          >
+            Your full name*
+          </label>
+          <input
+            className="form-control"
+            name="fullName"
+            onChange={[Function]}
+            value=""
+          />
+          <p>
+            Name and surname.
+          </p>
+        </div>
+        <div
+          className="form-group"
+        >
+          <label
+            className="form-label"
+          >
+            Username*
+          </label>
+          <input
+            className="form-control"
+            name="username"
+            onChange={[Function]}
+            value=""
+          />
+          <p>
+            This would also be the username of the administrator account on the Open edX instance.
+          </p>
+        </div>
+        <div
+          className="form-group"
+        >
+          <label
+            className="form-label"
+          >
+            Email address*
+          </label>
+          <input
+            className="form-control"
+            name="emailAddress"
+            onChange={[Function]}
+            type="email"
+            value=""
+          />
+          <p>
+            This is also your account name, and where we will send important notices.
+          </p>
+        </div>
+        <div
+          className="form-group"
+        >
+          <label
+            className="form-label"
+          >
+            Password*
+          </label>
+          <input
+            className="form-control"
+            name="password"
+            onChange={[Function]}
+            type="password"
+            value=""
+          />
+          <p>
+            Password must have 8 characters, 1 number, 1 capital letter and 1 special character.
+          </p>
+        </div>
+        <div
+          className="form-group"
+        >
+          <label
+            className="form-label"
+          >
+            Confirm password*
+          </label>
+          <input
+            className="form-control"
+            name="passwordConfirm"
+            onChange={[Function]}
+            type="password"
+            value=""
+          />
+          <p>
+            Confirm the password in the field above.
+          </p>
+        </div>
+        <div
+          className="custom-control custom-checkbox"
+        >
+          <input
+            checked={false}
+            className="custom-control-input"
+            id="acceptTOS"
+            name="acceptTOS"
+            onChange={[Function]}
+            type="checkbox"
+          />
+          <label
+            className="custom-control-label"
+            htmlFor="acceptTOS"
+          >
+            I accept that this is a free trial, and that the instance is provided without any guarantee. 
+            <a
+              href="/#"
+            >
+              Privacy Policy
+            </a>
+             and 
+            <a
+              href="/#"
+            >
+              Terms of Service
+            </a>
+            .*
+          </label>
+        </div>
+        <div
+          className="custom-control custom-checkbox"
+        >
+          <input
+            checked={false}
+            className="custom-control-input"
+            id="acceptSupport"
+            name="acceptSupport"
+            onChange={[Function]}
+            type="checkbox"
+          />
+          <label
+            className="custom-control-label"
+            htmlFor="acceptSupport"
+          >
+            I understand that I can email OpenCraft with questions and that requests for support are subject to hourly fees.*
+          </label>
+        </div>
+        <div
+          className="custom-control custom-checkbox"
+        >
+          <input
+            checked={false}
+            className="custom-control-input"
+            id="acceptTipsEmail"
+            name="acceptTipsEmail"
+            onChange={[Function]}
+            type="checkbox"
+          />
+          <label
+            className="custom-control-label"
+            htmlFor="acceptTipsEmail"
+          >
+            I want OpenCraft to occasionally email me about important news, tips and new features.
+          </label>
+        </div>
+      </form>
+      <div
+        className="registration-nav"
+      >
+        <button
+          className="float-left btn btn-outline-primary btn-lg"
+          disabled={false}
+          onClick={[Function]}
+          type="button"
+        >
+          back
+        </button>
+        <button
+          className="float-right loading btn btn-primary btn-lg"
+          disabled={false}
+          onClick={[Function]}
+          type="button"
+        >
+          Next
+        </button>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/frontend/src/registration/components/AccountSetupPage/displayMessages.ts
+++ b/frontend/src/registration/components/AccountSetupPage/displayMessages.ts
@@ -1,6 +1,74 @@
 const messages = {
-  messageID: {
-    defaultMessage: 'A translatable string.',
+  createYourAccount: {
+    defaultMessage: 'Create your account',
+    description: 'A description of the translatable string.'
+  },
+  fullName: {
+    defaultMessage: 'Your full name*',
+    description: 'A description of the translatable string.'
+  },
+  fullNameHelp: {
+    defaultMessage: 'Name and surname.',
+    description: 'A description of the translatable string.'
+  },
+  username: {
+    defaultMessage: 'Username*',
+    description: 'A description of the translatable string.'
+  },
+  usernameHelp: {
+    defaultMessage:
+      'This would also be the username of the administrator account on the Open edX instance.',
+    description: 'A description of the translatable string.'
+  },
+  email: {
+    defaultMessage: 'Email address*',
+    description: 'A description of the translatable string.'
+  },
+  emailHelp: {
+    defaultMessage:
+      'This is also your account name, and where we will send important notices.',
+    description: 'A description of the translatable string.'
+  },
+  password: {
+    defaultMessage: 'Password*',
+    description: 'A description of the translatable string.'
+  },
+  passwordHelp: {
+    defaultMessage:
+      'Password must have 8 characters, 1 number, 1 capital letter and 1 special character.',
+    description: 'A description of the translatable string.'
+  },
+  confirmPassword: {
+    defaultMessage: 'Confirm password*',
+    description: 'A description of the translatable string.'
+  },
+  confirmPasswordHelp: {
+    defaultMessage: 'Confirm the password in the field above.',
+    description: 'A description of the translatable string.'
+  },
+  acceptTos: {
+    defaultMessage:
+      'I accept that this is a free trial, and that the instance is ' +
+      'provided without any guarantee. {tos} and {privacy_policy}.*',
+    description: 'A description of the translatable string.'
+  },
+  acceptSupport: {
+    defaultMessage:
+      'I understand that I can email OpenCraft with questions ' +
+      'and that requests for support are subject to hourly fees.*',
+    description: 'A description of the translatable string.'
+  },
+  acceptNewsletter: {
+    defaultMessage:
+      'I want OpenCraft to occasionally email me about important news, tips and new features.',
+    description: 'A description of the translatable string.'
+  },
+  privacyPolicy: {
+    defaultMessage: 'Privacy Policy',
+    description: 'A description of the translatable string.'
+  },
+  termsOfService: {
+    defaultMessage: 'Terms of Service',
     description: 'A description of the translatable string.'
   }
 };

--- a/frontend/src/registration/components/AccountSetupPage/displayMessages.ts
+++ b/frontend/src/registration/components/AccountSetupPage/displayMessages.ts
@@ -1,0 +1,8 @@
+const messages = {
+  messageID: {
+    defaultMessage: 'A translatable string.',
+    description: 'A description of the translatable string.'
+  }
+};
+
+export default messages;

--- a/frontend/src/registration/components/AccountSetupPage/displayMessages.ts
+++ b/frontend/src/registration/components/AccountSetupPage/displayMessages.ts
@@ -38,11 +38,11 @@ const messages = {
       'Password must have 8 characters, 1 number, 1 capital letter and 1 special character.',
     description: 'A description of the translatable string.'
   },
-  confirmPassword: {
+  passwordConfirm: {
     defaultMessage: 'Confirm password*',
     description: 'A description of the translatable string.'
   },
-  confirmPasswordHelp: {
+  passwordConfirmHelp: {
     defaultMessage: 'Confirm the password in the field above.',
     description: 'A description of the translatable string.'
   },
@@ -58,7 +58,7 @@ const messages = {
       'and that requests for support are subject to hourly fees.*',
     description: 'A description of the translatable string.'
   },
-  acceptNewsletter: {
+  acceptTipsEmail: {
     defaultMessage:
       'I want OpenCraft to occasionally email me about important news, tips and new features.',
     description: 'A description of the translatable string.'

--- a/frontend/src/registration/components/AccountSetupPage/displayMessages.ts
+++ b/frontend/src/registration/components/AccountSetupPage/displayMessages.ts
@@ -20,11 +20,11 @@ const messages = {
       'This would also be the username of the administrator account on the Open edX instance.',
     description: 'A description of the translatable string.'
   },
-  email: {
+  emailAddress: {
     defaultMessage: 'Email address*',
     description: 'A description of the translatable string.'
   },
-  emailHelp: {
+  emailAddressHelp: {
     defaultMessage:
       'This is also your account name, and where we will send important notices.',
     description: 'A description of the translatable string.'

--- a/frontend/src/registration/components/AccountSetupPage/index.ts
+++ b/frontend/src/registration/components/AccountSetupPage/index.ts
@@ -1,0 +1,1 @@
+export * from './AccountSetupPage';

--- a/frontend/src/registration/components/AccountSetupPage/styles.scss
+++ b/frontend/src/registration/components/AccountSetupPage/styles.scss
@@ -1,3 +1,5 @@
+@import '~styles/theme';
+
 .account-form {
   width: 100%;
 
@@ -15,4 +17,11 @@
   a {
     text-decoration: underline;
   }
+}
+
+.invalid-feedback-checkbox {
+  font-family: $chivo-font;
+  font-size: 12px;
+  letter-spacing: 0.72px;
+  color: red;
 }

--- a/frontend/src/registration/components/AccountSetupPage/styles.scss
+++ b/frontend/src/registration/components/AccountSetupPage/styles.scss
@@ -1,0 +1,18 @@
+.account-form {
+  width: 100%;
+
+  h2 {
+    font-family: PlayfairDisplay;
+    font-size: 30px;
+    font-weight: bold;
+    font-stretch: normal;
+    font-style: normal;
+    line-height: normal;
+    letter-spacing: 1.8px;
+    color: #1e4c59;
+  }
+
+  a {
+    text-decoration: underline;
+  }
+}

--- a/frontend/src/registration/components/CongratulationsPage/CongratulationsPage.spec.tsx
+++ b/frontend/src/registration/components/CongratulationsPage/CongratulationsPage.spec.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import { setupComponentForTesting } from "utils/testing";
+import { CongratulationsPage } from './CongratulationsPage';
+
+it('renders without crashing', () => {
+    const tree = setupComponentForTesting(<CongratulationsPage />).toJSON();
+    expect(tree).toMatchSnapshot();
+});

--- a/frontend/src/registration/components/CongratulationsPage/CongratulationsPage.tsx
+++ b/frontend/src/registration/components/CongratulationsPage/CongratulationsPage.tsx
@@ -1,0 +1,43 @@
+import { RootState } from 'global/state';
+import * as React from 'react';
+import { connect } from 'react-redux';
+import { WrappedMessage } from 'utils/intl';
+import { submitRegistration } from '../../actions';
+import { RegistrationPage } from '../RegistrationPage';
+import messages from './displayMessages';
+import './styles.scss';
+
+interface ActionProps {
+  submitRegistration: Function;
+}
+
+interface Props extends ActionProps {}
+
+interface State {}
+
+@connect<{}, ActionProps, {}, Props, RootState>((state: RootState) => ({}), {
+  submitRegistration
+})
+export class CongratulationsPage extends React.PureComponent<Props, State> {
+  public constructor(props: Props, state: State) {
+    super(props);
+  }
+
+  public render() {
+    return (
+      <RegistrationPage title="Pro & Teacher Account" currentStep={4}>
+        <div className="congrats-page">
+          <h1>
+            <WrappedMessage messages={messages} id="congrats" />
+          </h1>
+          <p>
+            <WrappedMessage messages={messages} id="congratsMessage" />
+          </p>
+          <p>
+            <WrappedMessage messages={messages} id="congratsMessage2" />
+          </p>
+        </div>
+      </RegistrationPage>
+    );
+  }
+}

--- a/frontend/src/registration/components/CongratulationsPage/__snapshots__/CongratulationsPage.spec.tsx.snap
+++ b/frontend/src/registration/components/CongratulationsPage/__snapshots__/CongratulationsPage.spec.tsx.snap
@@ -1,0 +1,119 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders without crashing 1`] = `
+<div
+  className="registration-page"
+>
+  <h1>
+    Pro & Teacher Account
+  </h1>
+  <div
+    className="d-flex justify-content-center"
+  >
+    <div
+      className="step-bar"
+    >
+      <svg
+        className="step"
+        viewBox="0 0 10 10"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <circle
+          cx={5}
+          cy={5}
+          fill="#6d9cae"
+          r={5}
+        />
+      </svg>
+      <span
+        className="line"
+      />
+      <svg
+        className="step"
+        viewBox="0 0 10 10"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <circle
+          cx={5}
+          cy={5}
+          fill="#6d9cae"
+          r={5}
+        />
+      </svg>
+      <span
+        className="line"
+      />
+      <svg
+        className="step"
+        viewBox="0 0 10 10"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <circle
+          cx={5}
+          cy={5}
+          fill="#6d9cae"
+          r={5}
+        />
+      </svg>
+      <span
+        className="line"
+      />
+      <svg
+        className="circled-number"
+        viewBox="0 0 20 20"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <circle
+          className="outer-circle"
+          cx={10}
+          cy={10}
+          r={10}
+        />
+        <circle
+          className="inner-circle"
+          cx={10}
+          cy={10}
+          r={7}
+          strokeWidth={2}
+        />
+        <text
+          className="circle-text"
+          color="#1e4c59"
+          dy="0.4em"
+          fontSize="10px"
+          strokeWidth="1px"
+          textAnchor="middle"
+          x="50%"
+          y="50%"
+        >
+          4
+        </text>
+      </svg>
+      <span
+        className="line"
+      />
+    </div>
+  </div>
+  <div
+    className="registration-page-container"
+  >
+    <div
+      className="registration-page-content row"
+    >
+      <div
+        className="congrats-page"
+      >
+        <h1>
+          Congratulations!
+        </h1>
+        <p>
+          You have successfully created your OpenCraft account.
+        </p>
+        <p>
+          We have sent you an email to verify your email address. Please follow the link that we emailed you to complete your application process.
+        </p>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/frontend/src/registration/components/CongratulationsPage/displayMessages.ts
+++ b/frontend/src/registration/components/CongratulationsPage/displayMessages.ts
@@ -9,7 +9,7 @@ const messages = {
   },
   congratsMessage2: {
     defaultMessage:
-      'We have sent you an email to verify your email address. Please follow' +
+      'We have sent you an email to verify your email address. Please follow ' +
       'the link that we emailed you to complete your application process.',
     description: 'A description of the translatable string.'
   }

--- a/frontend/src/registration/components/CongratulationsPage/displayMessages.ts
+++ b/frontend/src/registration/components/CongratulationsPage/displayMessages.ts
@@ -1,0 +1,18 @@
+const messages = {
+  congrats: {
+    defaultMessage: 'Congratulations!',
+    description: 'A description of the translatable string.'
+  },
+  congratsMessage: {
+    defaultMessage: 'You have successfully created your OpenCraft account.',
+    description: 'A description of the translatable string.'
+  },
+  congratsMessage2: {
+    defaultMessage:
+      'We have sent you an email to verify your email address. Please follow' +
+      'the link that we emailed you to complete your application process.',
+    description: 'A description of the translatable string.'
+  }
+};
+
+export default messages;

--- a/frontend/src/registration/components/CongratulationsPage/index.ts
+++ b/frontend/src/registration/components/CongratulationsPage/index.ts
@@ -1,0 +1,1 @@
+export * from './CongratulationsPage';

--- a/frontend/src/registration/components/CongratulationsPage/styles.scss
+++ b/frontend/src/registration/components/CongratulationsPage/styles.scss
@@ -1,0 +1,17 @@
+@import '~styles/theme';
+
+.congrats-page {
+  h1 {
+    text-align: left;
+    font-family: $playfair-font;
+    letter-spacing: 1.8px;
+    color: $primary-1;
+    padding-bottom: 36px;
+  }
+
+  p {
+    font-family: $chivo-font;
+    letter-spacing: 0.54px;
+    color: $secondary-1;
+  }
+}

--- a/frontend/src/registration/components/DomainInputPage/DomainInputPage.tsx
+++ b/frontend/src/registration/components/DomainInputPage/DomainInputPage.tsx
@@ -50,9 +50,7 @@ export class DomainInputPage extends React.PureComponent<Props, State> {
     });
     // Clean up error feedback if any
     if (this.props.registrationFeedback.domain) {
-      this.props.clearErrorMessage({
-        domain: ''
-      });
+      this.props.clearErrorMessage('domain');
     }
   };
 

--- a/frontend/src/registration/components/DomainInputPage/DomainInputPage.tsx
+++ b/frontend/src/registration/components/DomainInputPage/DomainInputPage.tsx
@@ -4,60 +4,54 @@ import * as React from 'react';
 import { connect } from 'react-redux';
 import { WrappedMessage } from 'utils/intl';
 import { DomainInput, InstitutionalAccountHero } from 'ui/components';
-import { submitRegistration, updateDomainInfoState } from '../../actions';
+import { performValidation, updateRootState } from '../../actions';
 import { RegistrationPage } from '../RegistrationPage';
-import { getRegistrationData } from '../../selectors';
 import messages from './displayMessages';
 import './styles.scss';
+import { RegistrationStateModel } from 'registration/models'
 
 interface ActionProps {
-  submitRegistration: Function;
-  updateDomainInfoState: Function;
+  performValidation: Function;
+  updateRootState: Function;
 }
 
 interface Props extends ActionProps {}
-
-interface StateProps {
-  domain: string;
-  domainIsExternal: boolean;
-  domainError: string;
-  loading: boolean;
-}
+interface StateProps extends RegistrationStateModel {}
 
 interface Props extends StateProps, ActionProps {}
 
 @connect<{}, ActionProps, {}, Props, RootState>(
   (state: RootState) => ({
-    domain: getRegistrationData(state, 'domain'),
-    domainIsExternal: getRegistrationData(state, 'domainIsExternal'),
-    domainError: getRegistrationData(state, 'domainError'),
-    loading: getRegistrationData(state, 'loading')
+    loading: state.registration.loading,
+    registrationData: state.registration.registrationData,
+    registrationFeedback: state.registration.registrationFeedback
   }),
   {
-    submitRegistration,
-    updateDomainInfoState
+    performValidation,
+    updateRootState
   }
 )
 export class DomainInputPage extends React.PureComponent<Props> {
-  public constructor(props: Props) {
-    super(props);
-  }
-
   private handleDomainChange = (newDomain: string) => {
-    this.props.updateDomainInfoState({
-      domain: newDomain,
-      domainError: ''
+    this.props.updateRootState({
+      registrationData: {
+        domain: newDomain
+      },
+      registrationFeedback: {
+        domain: ''
+      }
     });
   };
 
   private submitDomain = () => {
-    this.props.submitRegistration(
-      { domain: this.props.domain },
+    this.props.performValidation(
+      { domain: this.props.registrationData.domain },
       ROUTES.Registration.INSTANCE
     );
   };
 
   public render() {
+    console.log(this.props)
     return (
       <div className="div-fill">
         <RegistrationPage
@@ -66,8 +60,8 @@ export class DomainInputPage extends React.PureComponent<Props> {
           currentStep={1}
         >
           <DomainInput
-            domainName={this.props.domain}
-            error={this.props.domainError}
+            domainName={this.props.registrationData.domain}
+            error={this.props.registrationFeedback.domain}
             internalDomain
             loading={this.props.loading}
             handleDomainChange={this.handleDomainChange}

--- a/frontend/src/registration/components/DomainInputPage/DomainInputPage.tsx
+++ b/frontend/src/registration/components/DomainInputPage/DomainInputPage.tsx
@@ -53,7 +53,7 @@ export class DomainInputPage extends React.PureComponent<Props, State> {
         >
           <DomainInput
             domainName={this.state.domainName}
-            internalDomain
+            internalDomain={true}
             handleDomainChange={this.handleDomainChange}
             handleSubmitDomain={this.submitDomain}
           />

--- a/frontend/src/registration/components/DomainInputPage/DomainInputPage.tsx
+++ b/frontend/src/registration/components/DomainInputPage/DomainInputPage.tsx
@@ -36,19 +36,20 @@ interface Props extends StateProps, ActionProps {}
   }
 )
 export class DomainInputPage extends React.PureComponent<Props, State> {
-  constructor (props: Props, state: State) {
+  constructor(props: Props, state: State) {
     super(props);
 
     this.state = {
       domain: props.registrationData.domain
-    }
+    };
   }
+
   private handleDomainChange = (newDomain: string) => {
     this.setState({
       domain: newDomain
-    })
+    });
     // Clean up error feedback if any
-    if (this.props.registrationFeedback.domain){
+    if (this.props.registrationFeedback.domain) {
       this.props.clearErrorMessage({
         domain: ''
       });

--- a/frontend/src/registration/components/DomainInputPage/DomainInputPage.tsx
+++ b/frontend/src/registration/components/DomainInputPage/DomainInputPage.tsx
@@ -1,20 +1,13 @@
 import { ROUTES } from 'global/constants';
 import { RootState } from 'global/state';
 import * as React from 'react';
-import {
-  Button,
-  Form,
-  FormControl,
-  FormGroup,
-  FormLabel,
-  InputGroup
-} from 'react-bootstrap';
 import { connect } from 'react-redux';
 import { WrappedMessage } from 'utils/intl';
-import { InstitutionalAccountHero } from 'ui/components';
+import { DomainInput, InstitutionalAccountHero } from 'ui/components';
 import { submitRegistration } from '../../actions';
 import { RegistrationPage } from '../RegistrationPage';
 import messages from './displayMessages';
+import './styles.scss';
 
 interface ActionProps {
   submitRegistration: Function;
@@ -37,13 +30,13 @@ export class DomainInputPage extends React.PureComponent<Props, State> {
     };
   }
 
-  private domainNameChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+  private handleDomainChange = (newDomain: string) => {
     this.setState({
-      domainName: event.target.value || ''
+      domainName: newDomain || ''
     });
   };
 
-  private submitForm = () => {
+  private submitDomain = () => {
     this.props.submitRegistration(
       { domain: this.state.domainName },
       ROUTES.Registration.INSTANCE
@@ -58,34 +51,17 @@ export class DomainInputPage extends React.PureComponent<Props, State> {
           subtitle="Create your own Open edX instance now."
           currentStep={1}
         >
-          <Form>
-            <FormGroup>
-              <FormLabel htmlFor="domainNameInput">
-                <WrappedMessage messages={messages} id="typeDomainNameBelow" />
-              </FormLabel>
-              <InputGroup>
-                <FormControl
-                  id="domainNameInput"
-                  defaultValue=""
-                  placeholder="yourdomain"
-                  onChange={this.domainNameChange}
-                />
-                <InputGroup.Append>
-                  <Button onClick={this.submitForm}>
-                    <WrappedMessage
-                      messages={messages}
-                      id="checkAvailability"
-                    />
-                  </Button>
-                </InputGroup.Append>
-              </InputGroup>
-            </FormGroup>
-            <div className="use-own">
-              <a href="/#">
-                <WrappedMessage messages={messages} id="useOwnDomain" />
-              </a>
-            </div>
-          </Form>
+          <DomainInput
+            domainName={this.state.domainName}
+            internalDomain
+            handleDomainChange={this.handleDomainChange}
+            handleSubmitDomain={this.submitDomain}
+          />
+          <div className="use-own">
+            <a href="/#">
+              <WrappedMessage messages={messages} id="useOwnDomain" />
+            </a>
+          </div>
         </RegistrationPage>
         <InstitutionalAccountHero />
       </div>

--- a/frontend/src/registration/components/DomainInputPage/DomainInputPage.tsx
+++ b/frontend/src/registration/components/DomainInputPage/DomainInputPage.tsx
@@ -53,7 +53,7 @@ export class DomainInputPage extends React.PureComponent<Props, State> {
         >
           <DomainInput
             domainName={this.state.domainName}
-            internalDomain={true}
+            internalDomain
             handleDomainChange={this.handleDomainChange}
             handleSubmitDomain={this.submitDomain}
           />

--- a/frontend/src/registration/components/DomainInputPage/DomainInputPage.tsx
+++ b/frontend/src/registration/components/DomainInputPage/DomainInputPage.tsx
@@ -5,14 +5,18 @@ import { connect } from 'react-redux';
 import { WrappedMessage } from 'utils/intl';
 import { DomainInput, InstitutionalAccountHero } from 'ui/components';
 import { RegistrationStateModel } from 'registration/models';
-import { performValidation, updateRootState } from '../../actions';
+import { performValidationAndStore, clearErrorMessage } from '../../actions';
 import { RegistrationPage } from '../RegistrationPage';
 import messages from './displayMessages';
 import './styles.scss';
 
 interface ActionProps {
-  performValidation: Function;
-  updateRootState: Function;
+  performValidationAndStore: Function;
+  clearErrorMessage: Function;
+}
+
+interface State {
+  domain: string;
 }
 
 interface Props extends ActionProps {}
@@ -27,26 +31,34 @@ interface Props extends StateProps, ActionProps {}
     registrationFeedback: state.registration.registrationFeedback
   }),
   {
-    performValidation,
-    updateRootState
+    performValidationAndStore,
+    clearErrorMessage
   }
 )
-export class DomainInputPage extends React.PureComponent<Props> {
+export class DomainInputPage extends React.PureComponent<Props, State> {
+  constructor (props: Props, state: State) {
+    super(props);
+
+    this.state = {
+      domain: props.registrationData.domain
+    }
+  }
   private handleDomainChange = (newDomain: string) => {
-    this.props.updateRootState({
-      registrationData: {
-        domain: newDomain
-      },
-      registrationFeedback: {
+    this.setState({
+      domain: newDomain
+    })
+    // Clean up error feedback if any
+    if (this.props.registrationFeedback.domain){
+      this.props.clearErrorMessage({
         domain: ''
-      }
-    });
+      });
+    }
   };
 
   private submitDomain = () => {
-    this.props.performValidation(
+    this.props.performValidationAndStore(
       {
-        domain: this.props.registrationData.domain
+        domain: this.state.domain
       },
       ROUTES.Registration.INSTANCE
     );
@@ -61,7 +73,7 @@ export class DomainInputPage extends React.PureComponent<Props> {
           currentStep={1}
         >
           <DomainInput
-            domainName={this.props.registrationData.domain}
+            domainName={this.state.domain}
             error={this.props.registrationFeedback.domain}
             internalDomain
             loading={this.props.loading}

--- a/frontend/src/registration/components/DomainInputPage/DomainInputPage.tsx
+++ b/frontend/src/registration/components/DomainInputPage/DomainInputPage.tsx
@@ -45,8 +45,8 @@ export class DomainInputPage extends React.PureComponent<Props> {
 
   private handleDomainChange = (newDomain: string) => {
     this.props.updateDomainInfoState({
-        domain: newDomain,
-        domainError: ''
+      domain: newDomain,
+      domainError: ''
     });
   };
 

--- a/frontend/src/registration/components/DomainInputPage/DomainInputPage.tsx
+++ b/frontend/src/registration/components/DomainInputPage/DomainInputPage.tsx
@@ -8,7 +8,7 @@ import { performValidation, updateRootState } from '../../actions';
 import { RegistrationPage } from '../RegistrationPage';
 import messages from './displayMessages';
 import './styles.scss';
-import { RegistrationStateModel } from 'registration/models'
+import { RegistrationStateModel } from 'registration/models';
 
 interface ActionProps {
   performValidation: Function;
@@ -51,7 +51,7 @@ export class DomainInputPage extends React.PureComponent<Props> {
   };
 
   public render() {
-    console.log(this.props)
+    console.log(this.props);
     return (
       <div className="div-fill">
         <RegistrationPage

--- a/frontend/src/registration/components/DomainInputPage/DomainInputPage.tsx
+++ b/frontend/src/registration/components/DomainInputPage/DomainInputPage.tsx
@@ -4,11 +4,11 @@ import * as React from 'react';
 import { connect } from 'react-redux';
 import { WrappedMessage } from 'utils/intl';
 import { DomainInput, InstitutionalAccountHero } from 'ui/components';
+import { RegistrationStateModel } from 'registration/models';
 import { performValidation, updateRootState } from '../../actions';
 import { RegistrationPage } from '../RegistrationPage';
 import messages from './displayMessages';
 import './styles.scss';
-import { RegistrationStateModel } from 'registration/models';
 
 interface ActionProps {
   performValidation: Function;
@@ -45,13 +45,14 @@ export class DomainInputPage extends React.PureComponent<Props> {
 
   private submitDomain = () => {
     this.props.performValidation(
-      { domain: this.props.registrationData.domain },
+      {
+        domain: this.props.registrationData.domain
+      },
       ROUTES.Registration.INSTANCE
     );
   };
 
   public render() {
-    console.log(this.props);
     return (
       <div className="div-fill">
         <RegistrationPage

--- a/frontend/src/registration/components/DomainInputPage/DomainInputPage.tsx
+++ b/frontend/src/registration/components/DomainInputPage/DomainInputPage.tsx
@@ -4,7 +4,7 @@ import * as React from 'react';
 import { connect } from 'react-redux';
 import { WrappedMessage } from 'utils/intl';
 import { DomainInput, InstitutionalAccountHero } from 'ui/components';
-import { submitRegistration } from '../../actions';
+import { submitRegistration, updateDomainInfoState } from '../../actions';
 import { RegistrationPage } from '../RegistrationPage';
 import { getRegistrationData } from '../../selectors';
 import messages from './displayMessages';
@@ -12,12 +12,16 @@ import './styles.scss';
 
 interface ActionProps {
   submitRegistration: Function;
+  updateDomainInfoState: Function;
 }
 
 interface Props extends ActionProps {}
 
 interface StateProps {
   domain: string;
+  domainIsExternal: boolean;
+  domainError: string;
+  loading: boolean;
 }
 
 interface Props extends StateProps, ActionProps {}
@@ -25,29 +29,30 @@ interface Props extends StateProps, ActionProps {}
 @connect<{}, ActionProps, {}, Props, RootState>(
   (state: RootState) => ({
     domain: getRegistrationData(state, 'domain'),
-    domainIsExternal: getRegistrationData(state, 'domainIsExternal')
+    domainIsExternal: getRegistrationData(state, 'domainIsExternal'),
+    domainError: getRegistrationData(state, 'domainError'),
+    loading: getRegistrationData(state, 'loading')
   }),
   {
-    submitRegistration
+    submitRegistration,
+    updateDomainInfoState
   }
 )
-export class DomainInputPage extends React.PureComponent<Props, StateProps> {
-  public constructor(props: Props, state: StateProps) {
+export class DomainInputPage extends React.PureComponent<Props> {
+  public constructor(props: Props) {
     super(props);
-    this.state = {
-      domain: props.domain
-    };
   }
 
   private handleDomainChange = (newDomain: string) => {
-    this.setState({
-      domain: newDomain || ''
+    this.props.updateDomainInfoState({
+        domain: newDomain,
+        domainError: ''
     });
   };
 
   private submitDomain = () => {
     this.props.submitRegistration(
-      { domain: this.state.domain },
+      { domain: this.props.domain },
       ROUTES.Registration.INSTANCE
     );
   };
@@ -61,8 +66,10 @@ export class DomainInputPage extends React.PureComponent<Props, StateProps> {
           currentStep={1}
         >
           <DomainInput
-            domainName={this.state.domain}
+            domainName={this.props.domain}
+            error={this.props.domainError}
             internalDomain
+            loading={this.props.loading}
             handleDomainChange={this.handleDomainChange}
             handleSubmitDomain={this.submitDomain}
           />

--- a/frontend/src/registration/components/DomainInputPage/DomainInputPage.tsx
+++ b/frontend/src/registration/components/DomainInputPage/DomainInputPage.tsx
@@ -6,6 +6,7 @@ import { WrappedMessage } from 'utils/intl';
 import { DomainInput, InstitutionalAccountHero } from 'ui/components';
 import { submitRegistration } from '../../actions';
 import { RegistrationPage } from '../RegistrationPage';
+import { getRegistrationData } from '../../selectors';
 import messages from './displayMessages';
 import './styles.scss';
 
@@ -15,30 +16,38 @@ interface ActionProps {
 
 interface Props extends ActionProps {}
 
-interface State {
-  domainName: string;
+interface StateProps {
+  domain: string;
 }
 
-@connect<{}, ActionProps, {}, Props, RootState>((state: RootState) => ({}), {
-  submitRegistration
-})
-export class DomainInputPage extends React.PureComponent<Props, State> {
-  public constructor(props: Props, state: State) {
+interface Props extends StateProps, ActionProps {}
+
+@connect<{}, ActionProps, {}, Props, RootState>(
+  (state: RootState) => ({
+    domain: getRegistrationData(state, 'domain'),
+    domainIsExternal: getRegistrationData(state, 'domainIsExternal')
+  }),
+  {
+    submitRegistration
+  }
+)
+export class DomainInputPage extends React.PureComponent<Props, StateProps> {
+  public constructor(props: Props, state: StateProps) {
     super(props);
     this.state = {
-      domainName: ''
+      domain: props.domain
     };
   }
 
   private handleDomainChange = (newDomain: string) => {
     this.setState({
-      domainName: newDomain || ''
+      domain: newDomain || ''
     });
   };
 
   private submitDomain = () => {
     this.props.submitRegistration(
-      { domain: this.state.domainName },
+      { domain: this.state.domain },
       ROUTES.Registration.INSTANCE
     );
   };
@@ -52,7 +61,7 @@ export class DomainInputPage extends React.PureComponent<Props, State> {
           currentStep={1}
         >
           <DomainInput
-            domainName={this.state.domainName}
+            domainName={this.state.domain}
             internalDomain
             handleDomainChange={this.handleDomainChange}
             handleSubmitDomain={this.submitDomain}

--- a/frontend/src/registration/components/DomainInputPage/__snapshots__/DomainInputPage.spec.tsx.snap
+++ b/frontend/src/registration/components/DomainInputPage/__snapshots__/DomainInputPage.spec.tsx.snap
@@ -143,7 +143,6 @@ exports[`renders without crashing 1`] = `
                 Check Availability
               </button>
             </div>
-            
           </div>
         </div>
         <div

--- a/frontend/src/registration/components/DomainInputPage/__snapshots__/DomainInputPage.spec.tsx.snap
+++ b/frontend/src/registration/components/DomainInputPage/__snapshots__/DomainInputPage.spec.tsx.snap
@@ -106,52 +106,55 @@ exports[`renders without crashing 1`] = `
       <div
         className="registration-page-content row"
       >
-        <form
-          className=""
+        <div
+          className="domain-input-container"
         >
           <div
-            className="form-group"
+            className="domain-label"
           >
-            <label
-              className="form-label"
-              htmlFor="domainNameInput"
-            >
-              Type your domain name below
-            </label>
-            <div
-              className="input-group"
-            >
-              <input
-                className="form-control"
-                defaultValue=""
-                id="domainNameInput"
-                onChange={[Function]}
-                placeholder="yourdomain"
-              />
-              <div
-                className="input-group-append"
-              >
-                <button
-                  className="btn btn-primary"
-                  disabled={false}
-                  onClick={[Function]}
-                  type="button"
-                >
-                  Check Availability
-                </button>
-              </div>
-            </div>
+            Type your domain name below
           </div>
           <div
-            className="use-own"
+            className="input-group"
           >
-            <a
-              href="/#"
+            <input
+              className="form-control"
+              onChange={[Function]}
+              value=""
+            />
+            <div
+              className="input-group-append"
             >
-              I want to use my own domain
-            </a>
+              <span
+                className="input-group-text"
+              >
+                .opencraft.hosting
+              </span>
+            </div>
+            <div
+              className="input-group-append"
+            >
+              <button
+                className="btn btn-primary"
+                disabled={false}
+                onClick={[Function]}
+                type="button"
+              >
+                Check Availability
+              </button>
+            </div>
+            
           </div>
-        </form>
+        </div>
+        <div
+          className="use-own"
+        >
+          <a
+            href="/#"
+          >
+            I want to use my own domain
+          </a>
+        </div>
       </div>
     </div>
   </div>

--- a/frontend/src/registration/components/DomainInputPage/displayMessages.ts
+++ b/frontend/src/registration/components/DomainInputPage/displayMessages.ts
@@ -1,12 +1,4 @@
 const messages = {
-  typeDomainNameBelow: {
-    defaultMessage: 'Type your domain name below',
-    description: 'Message above domain input text box.'
-  },
-  checkAvailability: {
-    defaultMessage: 'Check Availability',
-    description: 'Label for button that check availability of Domain'
-  },
   useOwnDomain: {
     defaultMessage: 'I want to use my own domain',
     description:

--- a/frontend/src/registration/components/DomainInputPage/styles.scss
+++ b/frontend/src/registration/components/DomainInputPage/styles.scss
@@ -9,5 +9,5 @@
   font-size: 18px;
   letter-spacing: 0.54px;
   color: #1e4c59;
-  margin-top: 64px;
+  margin-top: 40px;
 }

--- a/frontend/src/registration/components/DomainInputPage/styles.scss
+++ b/frontend/src/registration/components/DomainInputPage/styles.scss
@@ -1,3 +1,13 @@
 .div-fill {
   height: 100%;
 }
+
+.use-own {
+  text-align: center;
+  text-decoration: underline;
+  font-family: Chivo;
+  font-size: 18px;
+  letter-spacing: 0.54px;
+  color: #1e4c59;
+  margin-top: 64px;
+}

--- a/frontend/src/registration/components/InstanceSetupPage/InstanceSetupPage.tsx
+++ b/frontend/src/registration/components/InstanceSetupPage/InstanceSetupPage.tsx
@@ -10,7 +10,7 @@ import { performValidation, updateRootState } from '../../actions';
 import { RegistrationPage } from '../RegistrationPage';
 import messages from './displayMessages';
 import './styles.scss';
-import { RegistrationStateModel } from 'registration/models'
+import { RegistrationStateModel } from 'registration/models';
 
 interface ActionProps {
   performValidation: Function;
@@ -42,7 +42,8 @@ export class InstanceSetupPage extends React.PureComponent<Props, StateProps> {
   };
 
   private submitInstanceData = () => {
-    this.props.performValidation({
+    this.props.performValidation(
+      {
         registrationData: {
           instanceName: this.props.registrationData.instanceName,
           publicContactEmail: this.props.registrationData.publicContactEmail

--- a/frontend/src/registration/components/InstanceSetupPage/InstanceSetupPage.tsx
+++ b/frontend/src/registration/components/InstanceSetupPage/InstanceSetupPage.tsx
@@ -61,9 +61,7 @@ export class InstanceSetupPage extends React.PureComponent<Props, State> {
 
     // Clear error message when the user changes field
     if (this.props.registrationFeedback[field]) {
-      this.props.clearErrorMessage({
-        [field]: ''
-      });
+      this.props.clearErrorMessage(field);
     }
   };
 

--- a/frontend/src/registration/components/InstanceSetupPage/InstanceSetupPage.tsx
+++ b/frontend/src/registration/components/InstanceSetupPage/InstanceSetupPage.tsx
@@ -6,14 +6,15 @@ import { WrappedMessage } from 'utils/intl';
 import { DomainSuccessJumbotron } from 'ui/components';
 import { RegistrationNavButtons } from 'registration/components';
 import { ROUTES } from 'global/constants';
-import { submitInstanceInfo } from '../../actions';
+import { validateInstanceInfo, updateInstanceInfoState } from '../../actions';
 import { getRegistrationData } from '../../selectors';
 import { RegistrationPage } from '../RegistrationPage';
 import messages from './displayMessages';
 import './styles.scss';
 
 interface ActionProps {
-  submitInstanceInfo: typeof submitInstanceInfo;
+  validateInstanceInfo: Function;
+  updateInstanceInfoState: Function;
 }
 
 interface StateProps {
@@ -21,6 +22,7 @@ interface StateProps {
   domainIsExternal: boolean;
   instanceName: string;
   publicContactEmail: string;
+  loading: boolean;
 }
 
 interface Props extends StateProps, ActionProps {}
@@ -30,36 +32,33 @@ interface Props extends StateProps, ActionProps {}
     domain: getRegistrationData(state, 'domain'),
     domainIsExternal: getRegistrationData(state, 'domainIsExternal'),
     instanceName: getRegistrationData(state, 'instanceName'),
-    publicContactEmail: getRegistrationData(state, 'publicContactEmail')
+    publicContactEmail: getRegistrationData(state, 'publicContactEmail'),
+    loading: getRegistrationData(state, 'loading')
   }),
   {
-    submitInstanceInfo
+    validateInstanceInfo,
+    updateInstanceInfoState
   }
 )
 export class InstanceSetupPage extends React.PureComponent<Props, StateProps> {
   public constructor(props: Props) {
     super(props);
-
-    this.state = {
-      domain: props.domain,
-      domainIsExternal: props.domainIsExternal,
-      instanceName: props.instanceName,
-      publicContactEmail: props.publicContactEmail
-    };
   }
 
   private onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const field = e.target.name;
     const { value } = e.target;
 
-    this.setState<never>({ [field]: value });
+    this.props.updateInstanceInfoState({
+      [field]: value
+    });
   };
 
   private submitInstanceData = () => {
-    this.props.submitInstanceInfo(
+    this.props.validateInstanceInfo(
       {
-        instanceName: this.state.instanceName,
-        publicContactEmail: this.state.publicContactEmail
+        instanceName: this.props.instanceName,
+        publicContactEmail: this.props.publicContactEmail
       },
       ROUTES.Registration.ACCOUNT
     );
@@ -85,7 +84,7 @@ export class InstanceSetupPage extends React.PureComponent<Props, StateProps> {
             </FormLabel>
             <FormControl
               name="instanceName"
-              value={this.state.instanceName}
+              value={this.props.instanceName}
               onChange={this.onChange}
             />
             <p>
@@ -99,7 +98,7 @@ export class InstanceSetupPage extends React.PureComponent<Props, StateProps> {
             <FormControl
               type="email"
               name="publicContactEmail"
-              value={this.state.publicContactEmail}
+              value={this.props.publicContactEmail}
               onChange={this.onChange}
             />
             <p>
@@ -108,7 +107,7 @@ export class InstanceSetupPage extends React.PureComponent<Props, StateProps> {
           </FormGroup>
         </Form>
         <RegistrationNavButtons
-          loading={false}
+          loading={this.props.loading}
           disableNextButton={false}
           showBackButton
           showNextButton

--- a/frontend/src/registration/components/InstanceSetupPage/InstanceSetupPage.tsx
+++ b/frontend/src/registration/components/InstanceSetupPage/InstanceSetupPage.tsx
@@ -7,14 +7,20 @@ import { DomainSuccessJumbotron, TextInputField } from 'ui/components';
 import { RegistrationNavButtons } from 'registration/components';
 import { ROUTES } from 'global/constants';
 import { RegistrationStateModel } from 'registration/models';
-import { performValidation, updateRootState } from '../../actions';
+import { performValidationAndStore, clearErrorMessage } from '../../actions';
 import { RegistrationPage } from '../RegistrationPage';
 import messages from './displayMessages';
 import './styles.scss';
 
 interface ActionProps {
-  performValidation: Function;
-  updateRootState: Function;
+  performValidationAndStore: Function;
+  clearErrorMessage: Function;
+}
+
+interface State {
+  [key: string]: string;
+  instanceName: string;
+  publicContactEmail: string;
 }
 
 interface StateProps extends RegistrationStateModel {}
@@ -31,32 +37,41 @@ interface Props extends StateProps, ActionProps {}
     }
   }),
   {
-    performValidation,
-    updateRootState
+    performValidationAndStore,
+    clearErrorMessage
   }
 )
-export class InstanceSetupPage extends React.PureComponent<Props, StateProps> {
+export class InstanceSetupPage extends React.PureComponent<Props, State> {
+  constructor(props: Props, state: State){
+    super(props);
+
+    this.state = {
+      instanceName: props.registrationData.instanceName,
+      publicContactEmail: props.registrationData.publicContactEmail,
+    }
+  }
+
   private onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const field = e.target.name;
     const { value } = e.target;
 
-    this.props.updateRootState({
-      registrationData: {
-        [field]: value
-      },
-      registrationFeedback: {
+    this.setState({
+      [field]: value
+    })
+
+    // Clear error message when the user changes field
+    if (this.props.registrationFeedback[field]) {
+      this.props.clearErrorMessage({
         [field]: ''
-      }
-    });
+      });
+    };
   };
 
   private submitInstanceData = () => {
-    this.props.performValidation(
+    this.props.performValidationAndStore(
       {
-        registrationData: {
-          instanceName: this.props.registrationData.instanceName,
-          publicContactEmail: this.props.registrationData.publicContactEmail
-        }
+        instanceName: this.state.instanceName,
+        publicContactEmail: this.state.publicContactEmail
       },
       ROUTES.Registration.ACCOUNT
     );
@@ -79,14 +94,14 @@ export class InstanceSetupPage extends React.PureComponent<Props, StateProps> {
 
           <TextInputField
             fieldName="instanceName"
-            value={this.props.registrationData.instanceName}
+            value={this.state.instanceName}
             onChange={this.onChange}
             messages={messages}
             error={this.props.registrationFeedback.instanceName}
           />
           <TextInputField
             fieldName="publicContactEmail"
-            value={this.props.registrationData.publicContactEmail}
+            value={this.state.publicContactEmail}
             onChange={this.onChange}
             messages={messages}
             type="email"

--- a/frontend/src/registration/components/InstanceSetupPage/InstanceSetupPage.tsx
+++ b/frontend/src/registration/components/InstanceSetupPage/InstanceSetupPage.tsx
@@ -82,6 +82,7 @@ export class InstanceSetupPage extends React.PureComponent<Props, StateProps> {
             value={this.props.registrationData.instanceName}
             onChange={this.onChange}
             messages={messages}
+            error={this.props.registrationFeedback.instanceName}
           />
           <TextInputField
             fieldName="publicContactEmail"
@@ -89,6 +90,7 @@ export class InstanceSetupPage extends React.PureComponent<Props, StateProps> {
             onChange={this.onChange}
             messages={messages}
             type="email"
+            error={this.props.registrationFeedback.publicContactEmail}
           />
         </Form>
         <RegistrationNavButtons

--- a/frontend/src/registration/components/InstanceSetupPage/InstanceSetupPage.tsx
+++ b/frontend/src/registration/components/InstanceSetupPage/InstanceSetupPage.tsx
@@ -6,59 +6,47 @@ import { WrappedMessage } from 'utils/intl';
 import { DomainSuccessJumbotron } from 'ui/components';
 import { RegistrationNavButtons } from 'registration/components';
 import { ROUTES } from 'global/constants';
-import { validateInstanceInfo, updateInstanceInfoState } from '../../actions';
-import { getRegistrationData } from '../../selectors';
+import { performValidation, updateRootState } from '../../actions';
 import { RegistrationPage } from '../RegistrationPage';
 import messages from './displayMessages';
 import './styles.scss';
+import { RegistrationStateModel } from 'registration/models'
 
 interface ActionProps {
-  validateInstanceInfo: Function;
-  updateInstanceInfoState: Function;
+  performValidation: Function;
+  updateRootState: Function;
 }
 
-interface StateProps {
-  domain: string;
-  domainIsExternal: boolean;
-  instanceName: string;
-  publicContactEmail: string;
-  loading: boolean;
-}
-
+interface StateProps extends RegistrationStateModel {}
 interface Props extends StateProps, ActionProps {}
 
 @connect<StateProps, ActionProps, {}, Props, RootState>(
   (state: RootState) => ({
-    domain: getRegistrationData(state, 'domain'),
-    domainIsExternal: getRegistrationData(state, 'domainIsExternal'),
-    instanceName: getRegistrationData(state, 'instanceName'),
-    publicContactEmail: getRegistrationData(state, 'publicContactEmail'),
-    loading: getRegistrationData(state, 'loading')
+    loading: state.registration.loading,
+    registrationData: state.registration.registrationData,
+    registrationFeedback: state.registration.registrationFeedback
   }),
   {
-    validateInstanceInfo,
-    updateInstanceInfoState
+    performValidation,
+    updateRootState
   }
 )
 export class InstanceSetupPage extends React.PureComponent<Props, StateProps> {
-  public constructor(props: Props) {
-    super(props);
-  }
-
   private onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const field = e.target.name;
     const { value } = e.target;
 
-    this.props.updateInstanceInfoState({
+    this.props.updateRootState({
       [field]: value
     });
   };
 
   private submitInstanceData = () => {
-    this.props.validateInstanceInfo(
-      {
-        instanceName: this.props.instanceName,
-        publicContactEmail: this.props.publicContactEmail
+    this.props.performValidation({
+        registrationData: {
+          instanceName: this.props.registrationData.instanceName,
+          publicContactEmail: this.props.registrationData.publicContactEmail
+        }
       },
       ROUTES.Registration.ACCOUNT
     );
@@ -71,8 +59,8 @@ export class InstanceSetupPage extends React.PureComponent<Props, StateProps> {
         currentStep={2}
       >
         <DomainSuccessJumbotron
-          domain={this.props.domain}
-          domainIsExternal={this.props.domainIsExternal}
+          domain={this.props.registrationData.domain}
+          domainIsExternal={this.props.registrationData.domainIsExternal}
         />
         <Form className="secure-domain-form">
           <h2>
@@ -84,7 +72,7 @@ export class InstanceSetupPage extends React.PureComponent<Props, StateProps> {
             </FormLabel>
             <FormControl
               name="instanceName"
-              value={this.props.instanceName}
+              value={this.props.registrationData.instanceName}
               onChange={this.onChange}
             />
             <p>
@@ -98,7 +86,7 @@ export class InstanceSetupPage extends React.PureComponent<Props, StateProps> {
             <FormControl
               type="email"
               name="publicContactEmail"
-              value={this.props.publicContactEmail}
+              value={this.props.registrationData.publicContactEmail}
               onChange={this.onChange}
             />
             <p>

--- a/frontend/src/registration/components/InstanceSetupPage/InstanceSetupPage.tsx
+++ b/frontend/src/registration/components/InstanceSetupPage/InstanceSetupPage.tsx
@@ -25,7 +25,7 @@ interface Props extends StateProps, ActionProps {}
     loading: state.registration.loading,
     registrationData: {
       ...state.registration.registrationData
-      },
+    },
     registrationFeedback: {
       ...state.registration.registrationFeedback
     }

--- a/frontend/src/registration/components/InstanceSetupPage/InstanceSetupPage.tsx
+++ b/frontend/src/registration/components/InstanceSetupPage/InstanceSetupPage.tsx
@@ -4,6 +4,7 @@ import { Form, FormControl, FormGroup, FormLabel } from 'react-bootstrap';
 import { connect } from 'react-redux';
 import { WrappedMessage } from 'utils/intl';
 import { DomainSuccessJumbotron } from 'ui/components';
+import { RegistrationNavButtons } from 'registration/components';
 import { submitRegistration } from '../../actions';
 import { getRegistrationData } from '../../selectors';
 import { RegistrationPage } from '../RegistrationPage';
@@ -64,6 +65,13 @@ export class InstanceSetupPage extends React.PureComponent<Props> {
             </p>
           </FormGroup>
         </Form>
+        <RegistrationNavButtons
+          disableNextButton
+          showBackButton
+          showNextButton
+          handleBackClick={() => {}}
+          handleNextClick={() => {}}
+        />
       </RegistrationPage>
     );
   }

--- a/frontend/src/registration/components/InstanceSetupPage/InstanceSetupPage.tsx
+++ b/frontend/src/registration/components/InstanceSetupPage/InstanceSetupPage.tsx
@@ -42,7 +42,7 @@ export class InstanceSetupPage extends React.PureComponent<Props> {
           domain={this.props.domain}
           domainIsExternal={this.props.domainIsExternal}
         />
-        <Form>
+        <Form className="secure-domain-form">
           <h2>
             <WrappedMessage id="secureYourDomain" messages={messages} />
           </h2>
@@ -66,7 +66,8 @@ export class InstanceSetupPage extends React.PureComponent<Props> {
           </FormGroup>
         </Form>
         <RegistrationNavButtons
-          disableNextButton
+          loading={false}
+          disableNextButton={false}
           showBackButton
           showNextButton
           handleBackClick={() => {}}

--- a/frontend/src/registration/components/InstanceSetupPage/InstanceSetupPage.tsx
+++ b/frontend/src/registration/components/InstanceSetupPage/InstanceSetupPage.tsx
@@ -42,13 +42,13 @@ interface Props extends StateProps, ActionProps {}
   }
 )
 export class InstanceSetupPage extends React.PureComponent<Props, State> {
-  constructor(props: Props, state: State){
+  constructor(props: Props, state: State) {
     super(props);
 
     this.state = {
       instanceName: props.registrationData.instanceName,
-      publicContactEmail: props.registrationData.publicContactEmail,
-    }
+      publicContactEmail: props.registrationData.publicContactEmail
+    };
   }
 
   private onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -57,14 +57,14 @@ export class InstanceSetupPage extends React.PureComponent<Props, State> {
 
     this.setState({
       [field]: value
-    })
+    });
 
     // Clear error message when the user changes field
     if (this.props.registrationFeedback[field]) {
       this.props.clearErrorMessage({
         [field]: ''
       });
-    };
+    }
   };
 
   private submitInstanceData = () => {

--- a/frontend/src/registration/components/InstanceSetupPage/InstanceSetupPage.tsx
+++ b/frontend/src/registration/components/InstanceSetupPage/InstanceSetupPage.tsx
@@ -1,16 +1,16 @@
 import { RootState } from 'global/state';
 import * as React from 'react';
-import { Form, FormControl, FormGroup, FormLabel } from 'react-bootstrap';
+import { Form } from 'react-bootstrap';
 import { connect } from 'react-redux';
 import { WrappedMessage } from 'utils/intl';
-import { DomainSuccessJumbotron } from 'ui/components';
+import { DomainSuccessJumbotron, TextInputField } from 'ui/components';
 import { RegistrationNavButtons } from 'registration/components';
 import { ROUTES } from 'global/constants';
+import { RegistrationStateModel } from 'registration/models';
 import { performValidation, updateRootState } from '../../actions';
 import { RegistrationPage } from '../RegistrationPage';
 import messages from './displayMessages';
 import './styles.scss';
-import { RegistrationStateModel } from 'registration/models';
 
 interface ActionProps {
   performValidation: Function;
@@ -23,8 +23,12 @@ interface Props extends StateProps, ActionProps {}
 @connect<StateProps, ActionProps, {}, Props, RootState>(
   (state: RootState) => ({
     loading: state.registration.loading,
-    registrationData: state.registration.registrationData,
-    registrationFeedback: state.registration.registrationFeedback
+    registrationData: {
+      ...state.registration.registrationData
+      },
+    registrationFeedback: {
+      ...state.registration.registrationFeedback
+    }
   }),
   {
     performValidation,
@@ -37,7 +41,12 @@ export class InstanceSetupPage extends React.PureComponent<Props, StateProps> {
     const { value } = e.target;
 
     this.props.updateRootState({
-      [field]: value
+      registrationData: {
+        [field]: value
+      },
+      registrationFeedback: {
+        [field]: ''
+      }
     });
   };
 
@@ -67,33 +76,20 @@ export class InstanceSetupPage extends React.PureComponent<Props, StateProps> {
           <h2>
             <WrappedMessage id="secureYourDomain" messages={messages} />
           </h2>
-          <FormGroup>
-            <FormLabel>
-              <WrappedMessage id="instanceName" messages={messages} />
-            </FormLabel>
-            <FormControl
-              name="instanceName"
-              value={this.props.registrationData.instanceName}
-              onChange={this.onChange}
-            />
-            <p>
-              <WrappedMessage id="instanceNameHelp" messages={messages} />
-            </p>
-          </FormGroup>
-          <FormGroup>
-            <FormLabel>
-              <WrappedMessage id="publicContactEmail" messages={messages} />
-            </FormLabel>
-            <FormControl
-              type="email"
-              name="publicContactEmail"
-              value={this.props.registrationData.publicContactEmail}
-              onChange={this.onChange}
-            />
-            <p>
-              <WrappedMessage id="publicContactEmailHelp" messages={messages} />
-            </p>
-          </FormGroup>
+
+          <TextInputField
+            fieldName="instanceName"
+            value={this.props.registrationData.instanceName}
+            onChange={this.onChange}
+            messages={messages}
+          />
+          <TextInputField
+            fieldName="publicContactEmail"
+            value={this.props.registrationData.publicContactEmail}
+            onChange={this.onChange}
+            messages={messages}
+            type="email"
+          />
         </Form>
         <RegistrationNavButtons
           loading={this.props.loading}

--- a/frontend/src/registration/components/InstanceSetupPage/InstanceSetupPage.tsx
+++ b/frontend/src/registration/components/InstanceSetupPage/InstanceSetupPage.tsx
@@ -5,19 +5,22 @@ import { connect } from 'react-redux';
 import { WrappedMessage } from 'utils/intl';
 import { DomainSuccessJumbotron } from 'ui/components';
 import { RegistrationNavButtons } from 'registration/components';
-import { submitRegistration } from '../../actions';
+import { ROUTES } from 'global/constants';
+import { submitInstanceInfo } from '../../actions';
 import { getRegistrationData } from '../../selectors';
 import { RegistrationPage } from '../RegistrationPage';
 import messages from './displayMessages';
 import './styles.scss';
 
 interface ActionProps {
-  submitRegistration: typeof submitRegistration;
+  submitInstanceInfo: typeof submitInstanceInfo;
 }
 
 interface StateProps {
   domain: string;
   domainIsExternal: boolean;
+  instanceName: string;
+  publicContactEmail: string;
 }
 
 interface Props extends StateProps, ActionProps {}
@@ -25,13 +28,43 @@ interface Props extends StateProps, ActionProps {}
 @connect<StateProps, ActionProps, {}, Props, RootState>(
   (state: RootState) => ({
     domain: getRegistrationData(state, 'domain'),
-    domainIsExternal: getRegistrationData(state, 'domainIsExternal')
+    domainIsExternal: getRegistrationData(state, 'domainIsExternal'),
+    instanceName: getRegistrationData(state, 'instanceName'),
+    publicContactEmail: getRegistrationData(state, 'publicContactEmail')
   }),
   {
-    submitRegistration
+    submitInstanceInfo
   }
 )
-export class InstanceSetupPage extends React.PureComponent<Props> {
+export class InstanceSetupPage extends React.PureComponent<Props, StateProps> {
+  public constructor(props: Props) {
+    super(props);
+
+    this.state = {
+      domain: props.domain,
+      domainIsExternal: props.domainIsExternal,
+      instanceName: props.instanceName,
+      publicContactEmail: props.publicContactEmail
+    };
+  }
+
+  private onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const field = e.target.name;
+    const { value } = e.target;
+
+    this.setState<never>({ [field]: value });
+  };
+
+  private submitInstanceData = () => {
+    this.props.submitInstanceInfo(
+      {
+        instanceName: this.state.instanceName,
+        publicContactEmail: this.state.publicContactEmail
+      },
+      ROUTES.Registration.ACCOUNT
+    );
+  };
+
   render() {
     return (
       <RegistrationPage
@@ -50,7 +83,11 @@ export class InstanceSetupPage extends React.PureComponent<Props> {
             <FormLabel>
               <WrappedMessage id="instanceName" messages={messages} />
             </FormLabel>
-            <FormControl />
+            <FormControl
+              name="instanceName"
+              value={this.state.instanceName}
+              onChange={this.onChange}
+            />
             <p>
               <WrappedMessage id="instanceNameHelp" messages={messages} />
             </p>
@@ -59,7 +96,12 @@ export class InstanceSetupPage extends React.PureComponent<Props> {
             <FormLabel>
               <WrappedMessage id="publicContactEmail" messages={messages} />
             </FormLabel>
-            <FormControl type="email" />
+            <FormControl
+              type="email"
+              name="publicContactEmail"
+              value={this.state.publicContactEmail}
+              onChange={this.onChange}
+            />
             <p>
               <WrappedMessage id="publicContactEmailHelp" messages={messages} />
             </p>
@@ -71,7 +113,7 @@ export class InstanceSetupPage extends React.PureComponent<Props> {
           showBackButton
           showNextButton
           handleBackClick={() => {}}
-          handleNextClick={() => {}}
+          handleNextClick={this.submitInstanceData}
         />
       </RegistrationPage>
     );

--- a/frontend/src/registration/components/InstanceSetupPage/__snapshots__/InstanceSetupPage.spec.tsx.snap
+++ b/frontend/src/registration/components/InstanceSetupPage/__snapshots__/InstanceSetupPage.spec.tsx.snap
@@ -115,6 +115,9 @@ exports[`renders without crashing 1`] = `
         >
           <p>
             
+            <span>
+              .opencraft.hosting
+            </span>
           </p>
         </div>
         <p>
@@ -122,7 +125,7 @@ exports[`renders without crashing 1`] = `
         </p>
       </div>
       <form
-        className=""
+        className="secure-domain-form"
       >
         <h2>
           Secure your domain
@@ -137,6 +140,9 @@ exports[`renders without crashing 1`] = `
           </label>
           <input
             className="form-control"
+            name="instanceName"
+            onChange={[Function]}
+            value=""
           />
           <p>
             The name of your institution, company or project.
@@ -152,13 +158,36 @@ exports[`renders without crashing 1`] = `
           </label>
           <input
             className="form-control"
+            name="publicContactEmail"
+            onChange={[Function]}
             type="email"
+            value=""
           />
           <p>
             The email your instance of Open edX will be using to send emails, and where your users should send their support requests. This needs to be a valid email.
           </p>
         </div>
       </form>
+      <div
+        className="registration-nav"
+      >
+        <button
+          className="float-left btn btn-outline-primary btn-lg"
+          disabled={false}
+          onClick={[Function]}
+          type="button"
+        >
+          back
+        </button>
+        <button
+          className="float-right loading btn btn-primary btn-lg"
+          disabled={false}
+          onClick={[Function]}
+          type="button"
+        >
+          Next
+        </button>
+      </div>
     </div>
   </div>
 </div>

--- a/frontend/src/registration/components/InstanceSetupPage/__snapshots__/InstanceSetupPage.spec.tsx.snap
+++ b/frontend/src/registration/components/InstanceSetupPage/__snapshots__/InstanceSetupPage.spec.tsx.snap
@@ -177,7 +177,7 @@ exports[`renders without crashing 1`] = `
           onClick={[Function]}
           type="button"
         >
-          back
+          Back
         </button>
         <button
           className="float-right loading btn btn-primary btn-lg"

--- a/frontend/src/registration/components/InstanceSetupPage/styles.scss
+++ b/frontend/src/registration/components/InstanceSetupPage/styles.scss
@@ -1,39 +1,13 @@
 @import '~styles/theme';
 
-.domain-available {
-  width: 80%;
-  padding: 32px 32px;
-  background-color: $primary-2;
-  text-align: center;
-
-  img {
-    padding-bottom: 16px;
-  }
-
+.secure-domain-form {
   h2 {
     font-family: $playfair-font;
-    font-size: 28px;
-    font-weight: 900;
-    letter-spacing: 0.28px;
-    margin-bottom: 9px;
-  }
-
-  .domain-name {
-    background-color: #1e4c59;
-    padding: 10px;
-    height: 45px;
-    margin-bottom: 16px;
-  }
-
-  p {
-    font-family: Chivo;
-    font-size: 18px;
-    letter-spacing: 0.54px;
-    color: #ffffff;
-  }
-
-  @media (min-width: 800px)
-  {
-    max-width: 600px;
+    font-size: 24px;
+    font-weight: bold;
+    letter-spacing: 1.44px;
+    color: $primary-1;
+    text-align: left;
+    margin-bottom: 32px;
   }
 }

--- a/frontend/src/registration/components/RegistrationNavButtons/RegistrationNavButtons.spec.tsx
+++ b/frontend/src/registration/components/RegistrationNavButtons/RegistrationNavButtons.spec.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import { setupComponentForTesting } from "utils/testing";
+import { RegistrationNavButtons } from './RegistrationNavButtons';
+
+it('renders without crashing', () => {
+    const tree = setupComponentForTesting(<RegistrationNavButtons />).toJSON();
+    expect(tree).toMatchSnapshot();
+});

--- a/frontend/src/registration/components/RegistrationNavButtons/RegistrationNavButtons.spec.tsx
+++ b/frontend/src/registration/components/RegistrationNavButtons/RegistrationNavButtons.spec.tsx
@@ -6,3 +6,8 @@ it('renders without crashing', () => {
     const tree = setupComponentForTesting(<RegistrationNavButtons />).toJSON();
     expect(tree).toMatchSnapshot();
 });
+
+it('renders loading button', () => {
+    const tree = setupComponentForTesting(<RegistrationNavButtons loading={true} />).toJSON();
+    expect(tree).toMatchSnapshot();
+});

--- a/frontend/src/registration/components/RegistrationNavButtons/RegistrationNavButtons.tsx
+++ b/frontend/src/registration/components/RegistrationNavButtons/RegistrationNavButtons.tsx
@@ -39,7 +39,7 @@ export const RegistrationNavButtons: React.SFC<Props> = (props: Props) => {
         {props.loading === true && (
           <Spinner animation="border" size="sm" className="spinner" />
         )}
-        <WrappedMessage messages={messages} id="Next" />
+        <WrappedMessage messages={messages} id="next" />
       </Button>
     </div>
   );

--- a/frontend/src/registration/components/RegistrationNavButtons/RegistrationNavButtons.tsx
+++ b/frontend/src/registration/components/RegistrationNavButtons/RegistrationNavButtons.tsx
@@ -1,0 +1,32 @@
+import * as React from 'react';
+import './styles.scss';
+
+import { Button } from 'react-bootstrap';
+import { WrappedMessage } from 'utils/intl';
+import messages from './displayMessages';
+
+interface Props {
+  showBackButton: boolean;
+  showNextButton: boolean;
+  disableNextButton: boolean;
+  handleNextClick?: Function;
+  handleBackClick?: Function;
+}
+
+export const RegistrationNavButtons: React.SFC<Props> = (props: Props) => {
+  return (
+    <div className="registration-nav">
+      <Button className="float-left" variant="outline-primary" size="lg">
+        <WrappedMessage messages={messages} id="back" />
+      </Button>
+      <Button
+        className="float-right"
+        variant="primary"
+        size="lg"
+        disabled={props.disableNextButton}
+      >
+        <WrappedMessage messages={messages} id="Next" />
+      </Button>
+    </div>
+  );
+};

--- a/frontend/src/registration/components/RegistrationNavButtons/RegistrationNavButtons.tsx
+++ b/frontend/src/registration/components/RegistrationNavButtons/RegistrationNavButtons.tsx
@@ -32,7 +32,6 @@ export const RegistrationNavButtons: React.SFC<Props> = (props: Props) => {
         variant="primary"
         size="lg"
         disabled={props.disableNextButton || props.loading}
-        data-loading-text="</i> Processing Order"
         onClick={() => {
           props.handleNextClick();
         }}

--- a/frontend/src/registration/components/RegistrationNavButtons/RegistrationNavButtons.tsx
+++ b/frontend/src/registration/components/RegistrationNavButtons/RegistrationNavButtons.tsx
@@ -10,14 +10,21 @@ interface Props {
   showBackButton: boolean;
   showNextButton: boolean;
   disableNextButton: boolean;
-  handleNextClick?: Function;
-  handleBackClick?: Function;
+  handleNextClick: Function;
+  handleBackClick: Function;
 }
 
 export const RegistrationNavButtons: React.SFC<Props> = (props: Props) => {
   return (
     <div className="registration-nav">
-      <Button className="float-left" variant="outline-primary" size="lg">
+      <Button
+        className="float-left"
+        variant="outline-primary"
+        size="lg"
+        onClick={() => {
+          props.handleBackClick();
+        }}
+      >
         <WrappedMessage messages={messages} id="back" />
       </Button>
       <Button
@@ -26,6 +33,9 @@ export const RegistrationNavButtons: React.SFC<Props> = (props: Props) => {
         size="lg"
         disabled={props.disableNextButton || props.loading}
         data-loading-text="</i> Processing Order"
+        onClick={() => {
+          props.handleNextClick();
+        }}
       >
         {props.loading === true && (
           <Spinner animation="border" size="sm" className="spinner" />

--- a/frontend/src/registration/components/RegistrationNavButtons/RegistrationNavButtons.tsx
+++ b/frontend/src/registration/components/RegistrationNavButtons/RegistrationNavButtons.tsx
@@ -1,11 +1,12 @@
 import * as React from 'react';
 import './styles.scss';
 
-import { Button } from 'react-bootstrap';
+import { Button, Spinner } from 'react-bootstrap';
 import { WrappedMessage } from 'utils/intl';
 import messages from './displayMessages';
 
 interface Props {
+  loading: boolean;
   showBackButton: boolean;
   showNextButton: boolean;
   disableNextButton: boolean;
@@ -20,11 +21,15 @@ export const RegistrationNavButtons: React.SFC<Props> = (props: Props) => {
         <WrappedMessage messages={messages} id="back" />
       </Button>
       <Button
-        className="float-right"
+        className="float-right loading"
         variant="primary"
         size="lg"
-        disabled={props.disableNextButton}
+        disabled={props.disableNextButton || props.loading}
+        data-loading-text="</i> Processing Order"
       >
+        {props.loading === true && (
+          <Spinner animation="border" size="sm" className="spinner" />
+        )}
         <WrappedMessage messages={messages} id="Next" />
       </Button>
     </div>

--- a/frontend/src/registration/components/RegistrationNavButtons/__snapshots__/RegistrationNavButtons.spec.tsx.snap
+++ b/frontend/src/registration/components/RegistrationNavButtons/__snapshots__/RegistrationNavButtons.spec.tsx.snap
@@ -1,5 +1,31 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`renders loading button 1`] = `
+<div
+  className="registration-nav"
+>
+  <button
+    className="float-left btn btn-outline-primary btn-lg"
+    disabled={false}
+    onClick={[Function]}
+    type="button"
+  >
+    Back
+  </button>
+  <button
+    className="float-right loading btn btn-primary btn-lg"
+    disabled={true}
+    onClick={[Function]}
+    type="button"
+  >
+    <div
+      className="spinner spinner-border spinner-border-sm"
+    />
+    Next
+  </button>
+</div>
+`;
+
 exports[`renders without crashing 1`] = `
 <div
   className="registration-nav"
@@ -10,7 +36,7 @@ exports[`renders without crashing 1`] = `
     onClick={[Function]}
     type="button"
   >
-    back
+    Back
   </button>
   <button
     className="float-right loading btn btn-primary btn-lg"

--- a/frontend/src/registration/components/RegistrationNavButtons/__snapshots__/RegistrationNavButtons.spec.tsx.snap
+++ b/frontend/src/registration/components/RegistrationNavButtons/__snapshots__/RegistrationNavButtons.spec.tsx.snap
@@ -1,0 +1,24 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders without crashing 1`] = `
+<div
+  className="registration-nav"
+>
+  <button
+    className="float-left btn btn-outline-primary btn-lg"
+    disabled={false}
+    onClick={[Function]}
+    type="button"
+  >
+    back
+  </button>
+  <button
+    className="float-right loading btn btn-primary btn-lg"
+    disabled={false}
+    onClick={[Function]}
+    type="button"
+  >
+    Next
+  </button>
+</div>
+`;

--- a/frontend/src/registration/components/RegistrationNavButtons/displayMessages.ts
+++ b/frontend/src/registration/components/RegistrationNavButtons/displayMessages.ts
@@ -1,0 +1,8 @@
+const messages = {
+  messageID: {
+    defaultMessage: 'A translatable string.',
+    description: 'A description of the translatable string.'
+  }
+};
+
+export default messages;

--- a/frontend/src/registration/components/RegistrationNavButtons/displayMessages.ts
+++ b/frontend/src/registration/components/RegistrationNavButtons/displayMessages.ts
@@ -1,7 +1,11 @@
 const messages = {
-  messageID: {
-    defaultMessage: 'A translatable string.',
-    description: 'A description of the translatable string.'
+  back: {
+    defaultMessage: 'Back',
+    description: 'Text that goes in the back button in the registration form.'
+  },
+  next: {
+    defaultMessage: 'Next',
+    description: 'Text that goes in the next button in the registration form.'
   }
 };
 

--- a/frontend/src/registration/components/RegistrationNavButtons/index.ts
+++ b/frontend/src/registration/components/RegistrationNavButtons/index.ts
@@ -1,0 +1,1 @@
+export * from './RegistrationNavButtons';

--- a/frontend/src/registration/components/RegistrationNavButtons/styles.scss
+++ b/frontend/src/registration/components/RegistrationNavButtons/styles.scss
@@ -1,5 +1,9 @@
 .registration-nav {
   display: inline-block;
   width: 100%;
-  padding-top: 32px; 
+  padding-top: 32px;
+
+  .spinner {
+    margin-right: 10px;
+  }
 }

--- a/frontend/src/registration/components/RegistrationNavButtons/styles.scss
+++ b/frontend/src/registration/components/RegistrationNavButtons/styles.scss
@@ -1,0 +1,5 @@
+.registration-nav {
+  display: inline-block;
+  width: 100%;
+  padding-top: 32px; 
+}

--- a/frontend/src/registration/components/RegistrationPage/RegistrationPage.tsx
+++ b/frontend/src/registration/components/RegistrationPage/RegistrationPage.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { Row } from 'react-bootstrap';
-// import messages from './displayMessages';
 import './styles.scss';
 import { StepBar } from 'ui/components/StepBar';
 
@@ -11,16 +10,19 @@ interface Props {
   currentStep: number;
 }
 
-export const RegistrationPage: React.FC<Props> = (props: Props) => (
-  <div className="registration-page">
-    <h1>{props.title}</h1>
-    {props.subtitle && <h2>{props.subtitle}</h2>}
-    <div className="d-flex justify-content-center">
-      <StepBar count={4} currentStep={props.currentStep} />
-    </div>
+export const RegistrationPage: React.FC<Props> = (props: Props) => {
+  return (
+    <div className="registration-page">
+      <h1>{props.title}</h1>
+      {props.subtitle && <h2>{props.subtitle}</h2>}
 
-    <div className="registration-page-container">
-      <Row className="registration-page-content">{props.children}</Row>
+      <div className="d-flex justify-content-center">
+        <StepBar count={4} currentStep={props.currentStep} />
+      </div>
+
+      <div className="registration-page-container">
+        <Row className="registration-page-content">{props.children}</Row>
+      </div>
     </div>
-  </div>
-);
+  );
+};

--- a/frontend/src/registration/components/index.ts
+++ b/frontend/src/registration/components/index.ts
@@ -2,3 +2,6 @@ export * from './RegistrationContainer';
 export * from './InstanceSetupPage';
 export * from './DomainInputPage';
 export * from './RegistrationPage';
+export * from './AccountSetupPage';
+export * from './CongratulationsPage';
+export * from './RegistrationNavButtons';

--- a/frontend/src/registration/models.ts
+++ b/frontend/src/registration/models.ts
@@ -8,10 +8,6 @@ export interface DomainInfoModel {
   domainIsExternal: boolean;
 }
 
-export interface DomainInfoValidationModel {
-  domainError: string;
-}
-
 export interface InstanceInfoModel {
   instanceName: string;
   publicContactEmail: string;
@@ -50,11 +46,9 @@ export interface RegistrationStateModel {
 
 export interface RegistrationModel
   extends DomainInfoModel,
-    DomainInfoValidationModel,
     AccountInfoModel,
     InstanceInfoModel,
-    ThemeInfoModel,
-    RegistrationStateModel {}
+    ThemeInfoModel {}
 
 export type RegistrationFields = keyof RegistrationModel;
 
@@ -64,7 +58,6 @@ export const blankRegistration: Readonly<RegistrationModel> = {
   acceptTipsEmail: false,
   cover: null,
   domain: '',
-  domainError: '',
   domainIsExternal: false,
   emailAddress: '',
   fullName: '',
@@ -74,6 +67,28 @@ export const blankRegistration: Readonly<RegistrationModel> = {
   passwordConfirm: '',
   publicContactEmail: '',
   username: '',
-  loading: false,
   ...DefaultTheme
+};
+
+export interface DomainInfoValidationModel {
+  domain: string;
+}
+
+export interface RegistrationFeedbackModel
+  extends DomainInfoValidationModel {}
+
+export const blankRegistrationFeedbackModel: Readonly<RegistrationFeedbackModel> = {
+  domain: ''
+};
+
+export interface RegistrationStateModel {
+  loading: boolean,
+  registrationData: RegistrationModel,
+  registrationFeedback: RegistrationFeedbackModel
+}
+
+export const blankRegistrationState: Readonly<RegistrationStateModel> = {
+  loading: false,
+  registrationData: blankRegistration,
+  registrationFeedback: blankRegistrationFeedbackModel
 };

--- a/frontend/src/registration/models.ts
+++ b/frontend/src/registration/models.ts
@@ -8,6 +8,10 @@ export interface DomainInfoModel {
   domainIsExternal: boolean;
 }
 
+export interface DomainInfoValidationModel {
+  domainError: string;
+}
+
 export interface InstanceInfoModel {
   instanceName: string;
   publicContactEmail: string;
@@ -40,11 +44,17 @@ export const DefaultTheme: Readonly<ThemeInfoModel> = {
   cover: null
 };
 
+export interface RegistrationStateModel {
+  loading: boolean;
+}
+
 export interface RegistrationModel
   extends DomainInfoModel,
+    DomainInfoValidationModel,
     AccountInfoModel,
     InstanceInfoModel,
-    ThemeInfoModel {}
+    ThemeInfoModel,
+    RegistrationStateModel {}
 
 export type RegistrationFields = keyof RegistrationModel;
 
@@ -54,6 +64,7 @@ export const blankRegistration: Readonly<RegistrationModel> = {
   acceptTipsEmail: false,
   cover: null,
   domain: '',
+  domainError: '',
   domainIsExternal: false,
   emailAddress: '',
   fullName: '',
@@ -63,5 +74,6 @@ export const blankRegistration: Readonly<RegistrationModel> = {
   passwordConfirm: '',
   publicContactEmail: '',
   username: '',
+  loading: false,
   ...DefaultTheme
 };

--- a/frontend/src/registration/models.ts
+++ b/frontend/src/registration/models.ts
@@ -67,14 +67,12 @@ export const blankRegistration: Readonly<RegistrationModel> = {
 };
 
 export interface DomainInfoValidationModel {
-  domain: string;
+  [key: string]: string;
 }
 
 export interface RegistrationFeedbackModel extends DomainInfoValidationModel {}
 
-export const blankRegistrationFeedbackModel: Readonly<RegistrationFeedbackModel> = {
-  domain: ''
-};
+export const blankRegistrationFeedbackModel: Readonly<RegistrationFeedbackModel> = {};
 
 export interface RegistrationStateModel {
   loading: boolean;

--- a/frontend/src/registration/models.ts
+++ b/frontend/src/registration/models.ts
@@ -9,19 +9,19 @@ export interface DomainInfoModel {
 }
 
 export interface InstanceInfoModel {
-  instanceName: null | string;
-  publicEmail: null | string;
+  instanceName: string;
+  publicContactEmail: string;
 }
 
 export interface AccountInfoModel {
-  fullName: null | string;
-  username: null | string;
-  emailAddress: null | string;
-  password: null | string;
-  passwordConfirm: null | string;
-  acceptTOS: null | boolean;
-  acceptSupport: null | boolean;
-  acceptTipsEmail: null | boolean;
+  fullName: string;
+  username: string;
+  emailAddress: string;
+  password: string;
+  passwordConfirm: string;
+  acceptTOS: boolean;
+  acceptSupport: boolean;
+  acceptTipsEmail: boolean;
 }
 
 export interface ThemeInfoModel {
@@ -49,19 +49,19 @@ export interface RegistrationModel
 export type RegistrationFields = keyof RegistrationModel;
 
 export const blankRegistration: Readonly<RegistrationModel> = {
-  acceptSupport: null,
-  acceptTOS: null,
-  acceptTipsEmail: null,
+  acceptSupport: false,
+  acceptTOS: false,
+  acceptTipsEmail: false,
   cover: null,
   domain: '',
   domainIsExternal: false,
-  emailAddress: null,
-  fullName: null,
-  instanceName: null,
+  emailAddress: '',
+  fullName: '',
+  instanceName: '',
   logo: null,
-  password: null,
-  passwordConfirm: null,
-  publicEmail: null,
-  username: null,
+  password: '',
+  passwordConfirm: '',
+  publicContactEmail: '',
+  username: '',
   ...DefaultTheme
 };

--- a/frontend/src/registration/models.ts
+++ b/frontend/src/registration/models.ts
@@ -74,17 +74,16 @@ export interface DomainInfoValidationModel {
   domain: string;
 }
 
-export interface RegistrationFeedbackModel
-  extends DomainInfoValidationModel {}
+export interface RegistrationFeedbackModel extends DomainInfoValidationModel {}
 
 export const blankRegistrationFeedbackModel: Readonly<RegistrationFeedbackModel> = {
   domain: ''
 };
 
 export interface RegistrationStateModel {
-  loading: boolean,
-  registrationData: RegistrationModel,
-  registrationFeedback: RegistrationFeedbackModel
+  loading: boolean;
+  registrationData: RegistrationModel;
+  registrationFeedback: RegistrationFeedbackModel;
 }
 
 export const blankRegistrationState: Readonly<RegistrationStateModel> = {

--- a/frontend/src/registration/models.ts
+++ b/frontend/src/registration/models.ts
@@ -40,10 +40,6 @@ export const DefaultTheme: Readonly<ThemeInfoModel> = {
   cover: null
 };
 
-export interface RegistrationStateModel {
-  loading: boolean;
-}
-
 export interface RegistrationModel
   extends DomainInfoModel,
     AccountInfoModel,

--- a/frontend/src/registration/reducers.ts
+++ b/frontend/src/registration/reducers.ts
@@ -8,17 +8,13 @@ export function registrationReducer(
   action: RegistrationActions.ActionTypes
 ): RegistrationStateModel {
   switch (action.type) {
-    case RegistrationActions.Types.ROOT_STATE_UPDATE:
+    case RegistrationActions.Types.CLEAR_ERROR_MESSAGE:
       // Merge state without erasing previous values
       return {
-        loading: state.loading,
-        registrationData: {
-          ...state.registrationData,
-          ...action.data.registrationData
-        },
+        ...state,
         registrationFeedback: {
           ...state.registrationFeedback,
-          ...action.data.registrationFeedback
+          ...action.data
         }
       };
     case RegistrationActions.Types.REGISTRATION_VALIDATION:
@@ -33,7 +29,7 @@ export function registrationReducer(
         loading: false,
         registrationData: {
           ...state.registrationData,
-          ...action.data.registrationData
+          ...action.data
         }
       };
     case RegistrationActions.Types.REGISTRATION_VALIDATION_FAILURE:
@@ -54,9 +50,14 @@ export function registrationReducer(
         registrationFeedback: { ...action.error }
       };
     case RegistrationActions.Types.REGISTRATION_SUCCESS:
+      // Merge state without erasing previous values
       return {
         ...state,
-        loading: false
+        loading: false,
+        registrationData: {
+          ...state.registrationData,
+          ...action.data
+        }
       };
     default:
       return state;

--- a/frontend/src/registration/reducers.ts
+++ b/frontend/src/registration/reducers.ts
@@ -1,5 +1,5 @@
-import * as RegistrationActions from './actions';
 import update from 'immutability-helper';
+import * as RegistrationActions from './actions';
 import { blankRegistrationState, RegistrationStateModel } from './models';
 
 export const initialState: Readonly<RegistrationStateModel> = blankRegistrationState;
@@ -12,7 +12,7 @@ export function registrationReducer(
     case RegistrationActions.Types.CLEAR_ERROR_MESSAGE:
       // Merge state without erasing previous values
       return update(state, {
-        registrationFeedback: {[action.field]: {$set: ''}},
+        registrationFeedback: { [action.field]: { $set: '' } }
       });
     case RegistrationActions.Types.REGISTRATION_VALIDATION:
       return update(state, { loading: { $set: true } });

--- a/frontend/src/registration/reducers.ts
+++ b/frontend/src/registration/reducers.ts
@@ -7,26 +7,37 @@ export function registrationReducer(
   state = initialState,
   action: RegistrationActions.ActionTypes
 ): RegistrationStateModel {
+  console.log(state)
   switch (action.type) {
     case RegistrationActions.Types.ROOT_STATE_UPDATE:
+      // Merge state without erasing previous values
       return {
-        ...state,
-        ...action.data
+        loading: state.loading,
+        registrationData: {
+          ...state.registrationData,
+          ...action.data.registrationData
+        },
+        registrationFeedback: {
+          ...state.registrationFeedback,
+          ...action.data.registrationFeedback
+        }
       };
     case RegistrationActions.Types.REGISTRATION_VALIDATION:
       return {
         ...state,
-        ...action.data,
         loading: true
       };
     case RegistrationActions.Types.REGISTRATION_VALIDATION_SUCCESS:
+      // Merge state without erasing previous values
       return {
         ...state,
-        ...action.data,
-        loading: false
+        loading: false,
+        registrationData: {
+          ...state.registrationData,
+          ...action.data.registrationData
+        }
       };
     case RegistrationActions.Types.REGISTRATION_VALIDATION_FAILURE:
-      console.log(action);
       return {
         ...state,
         registrationFeedback: { ...action.error },
@@ -41,15 +52,11 @@ export function registrationReducer(
       return {
         ...state,
         loading: false,
-        registrationFeedback: {
-          domain: 'This domain already exists!'
-        }
+        registrationFeedback: { ...action.error }
       };
     case RegistrationActions.Types.REGISTRATION_SUCCESS:
-      console.log('registration ok');
       return {
         ...state,
-        ...action.data,
         loading: false
       };
     default:

--- a/frontend/src/registration/reducers.ts
+++ b/frontend/src/registration/reducers.ts
@@ -22,11 +22,11 @@ export function registrationReducer(
         domainError: 'This domain already exists!'
       };
     case RegistrationActions.Types.REGISTRATION_SUCCESS:
-    console.log(action.data)
+      console.log(action.data);
       return {
         ...state,
         ...action.data,
-        loading: false,
+        loading: false
       };
     default:
       return state;

--- a/frontend/src/registration/reducers.ts
+++ b/frontend/src/registration/reducers.ts
@@ -7,7 +7,7 @@ export function registrationReducer(
   state = initialState,
   action: RegistrationActions.ActionTypes
 ): RegistrationStateModel {
-  console.log(state)
+  console.log(state);
   switch (action.type) {
     case RegistrationActions.Types.ROOT_STATE_UPDATE:
       // Merge state without erasing previous values

--- a/frontend/src/registration/reducers.ts
+++ b/frontend/src/registration/reducers.ts
@@ -35,7 +35,7 @@ export function registrationReducer(
     case RegistrationActions.Types.REGISTRATION_SUBMIT:
       return {
         ...state,
-        loading: true,
+        loading: true
       };
     case RegistrationActions.Types.REGISTRATION_FAILURE:
       return {
@@ -46,7 +46,7 @@ export function registrationReducer(
         }
       };
     case RegistrationActions.Types.REGISTRATION_SUCCESS:
-    console.log('registration ok')
+      console.log('registration ok');
       return {
         ...state,
         ...action.data,

--- a/frontend/src/registration/reducers.ts
+++ b/frontend/src/registration/reducers.ts
@@ -9,11 +9,25 @@ export function registrationReducer(
 ): RegistrationModel {
   switch (action.type) {
     case RegistrationActions.Types.REGISTRATION_SUBMIT:
-      return state;
+      return {
+        ...state,
+        loading: true,
+        domainError: ''
+      };
     case RegistrationActions.Types.REGISTRATION_FAILURE:
-      return state;
+      return {
+        ...state,
+        loading: false,
+        // TODO: Internationalize this
+        domainError: 'This domain already exists!'
+      };
     case RegistrationActions.Types.REGISTRATION_SUCCESS:
-      return { ...state, ...action.data };
+    console.log(action.data)
+      return {
+        ...state,
+        ...action.data,
+        loading: false,
+      };
     default:
       return state;
   }

--- a/frontend/src/registration/reducers.ts
+++ b/frontend/src/registration/reducers.ts
@@ -1,4 +1,5 @@
 import * as RegistrationActions from './actions';
+import update from 'immutability-helper';
 import { blankRegistrationState, RegistrationStateModel } from './models';
 
 export const initialState: Readonly<RegistrationStateModel> = blankRegistrationState;
@@ -10,18 +11,11 @@ export function registrationReducer(
   switch (action.type) {
     case RegistrationActions.Types.CLEAR_ERROR_MESSAGE:
       // Merge state without erasing previous values
-      return {
-        ...state,
-        registrationFeedback: {
-          ...state.registrationFeedback,
-          ...action.data
-        }
-      };
+      return update(state, {
+        registrationFeedback: {[action.field]: {$set: ''}},
+      });
     case RegistrationActions.Types.REGISTRATION_VALIDATION:
-      return {
-        ...state,
-        loading: true
-      };
+      return update(state, { loading: { $set: true } });
     case RegistrationActions.Types.REGISTRATION_VALIDATION_SUCCESS:
       // Merge state without erasing previous values
       return {

--- a/frontend/src/registration/reducers.ts
+++ b/frontend/src/registration/reducers.ts
@@ -7,7 +7,6 @@ export function registrationReducer(
   state = initialState,
   action: RegistrationActions.ActionTypes
 ): RegistrationStateModel {
-  console.log(state);
   switch (action.type) {
     case RegistrationActions.Types.ROOT_STATE_UPDATE:
       // Merge state without erasing previous values

--- a/frontend/src/registration/reducers.ts
+++ b/frontend/src/registration/reducers.ts
@@ -1,28 +1,52 @@
 import * as RegistrationActions from './actions';
-import { blankRegistration, RegistrationModel } from './models';
+import { blankRegistrationState, RegistrationStateModel } from './models';
 
-export const initialState: Readonly<RegistrationModel> = blankRegistration;
+export const initialState: Readonly<RegistrationStateModel> = blankRegistrationState;
 
 export function registrationReducer(
   state = initialState,
   action: RegistrationActions.ActionTypes
-): RegistrationModel {
+): RegistrationStateModel {
   switch (action.type) {
+    case RegistrationActions.Types.ROOT_STATE_UPDATE:
+      return {
+        ...state,
+        ...action.data
+      };
+    case RegistrationActions.Types.REGISTRATION_VALIDATION:
+      return {
+        ...state,
+        ...action.data,
+        loading: true
+      };
+    case RegistrationActions.Types.REGISTRATION_VALIDATION_SUCCESS:
+      return {
+        ...state,
+        ...action.data,
+        loading: false
+      };
+    case RegistrationActions.Types.REGISTRATION_VALIDATION_FAILURE:
+      console.log(action);
+      return {
+        ...state,
+        registrationFeedback: { ...action.error },
+        loading: false
+      };
     case RegistrationActions.Types.REGISTRATION_SUBMIT:
       return {
         ...state,
         loading: true,
-        domainError: ''
       };
     case RegistrationActions.Types.REGISTRATION_FAILURE:
       return {
         ...state,
         loading: false,
-        // TODO: Internationalize this
-        domainError: 'This domain already exists!'
+        registrationFeedback: {
+          domain: 'This domain already exists!'
+        }
       };
     case RegistrationActions.Types.REGISTRATION_SUCCESS:
-      console.log(action.data);
+    console.log('registration ok')
       return {
         ...state,
         ...action.data,

--- a/frontend/src/registration/selectors.ts
+++ b/frontend/src/registration/selectors.ts
@@ -7,4 +7,4 @@ export const getCurrentRegistrationStep = (state: RootState) =>
 export const getRegistrationData = <K extends keyof RegistrationModel>(
   state: RootState,
   field: K
-): RegistrationModel[K] => state.registration[field];
+): RegistrationModel[K] => state.registration.registrationData[field];

--- a/frontend/src/routes/registration.tsx
+++ b/frontend/src/routes/registration.tsx
@@ -2,7 +2,12 @@ import { ROUTES } from 'global/constants';
 import * as React from 'react';
 
 import { Redirect, Route, Switch } from 'react-router';
-import { DomainInputPage, InstanceSetupPage } from 'registration/components';
+import {
+  AccountSetupPage,
+  CongratulationsPage,
+  DomainInputPage,
+  InstanceSetupPage
+} from 'registration/components';
 
 export const RegistrationRoutes = () => (
   <Switch>
@@ -11,5 +16,10 @@ export const RegistrationRoutes = () => (
     </Route>
     <Route path={ROUTES.Registration.DOMAIN} component={DomainInputPage} />
     <Route path={ROUTES.Registration.INSTANCE} component={InstanceSetupPage} />
+    <Route path={ROUTES.Registration.ACCOUNT} component={AccountSetupPage} />
+    <Route
+      path={ROUTES.Registration.CONGRATS}
+      component={CongratulationsPage}
+    />
   </Switch>
 );

--- a/frontend/src/styles/_theme.scss
+++ b/frontend/src/styles/_theme.scss
@@ -2,7 +2,7 @@ $primary-1: #1e4c59;
 $primary-2: #6d9cae;
 $secondary-1: #0f1f24;
 $secondary-2: #7a7a7a;
-$secondary-3: #000000;
+$secondary-4: #666666;
 
 $theme-colors: (
   "primary": $primary-1,
@@ -15,3 +15,33 @@ $roboto-font: 'Roboto', sans-serif;
 
 // Disable rounded button corners
 $enable-rounded: false;
+
+// Form group styling
+.form-group {
+  .form-label {
+    font-family: $chivo-font;
+    font-size: 14px;
+    letter-spacing: 0.14px;
+    color: $secondary-1;
+    margin-bottom: 4px;
+  }
+  .form-control {
+    border: solid 1px $secondary-4;
+  }
+  p {
+    padding-top: 4px;
+    font-family: $chivo-font;
+    font-size: 12px;
+    letter-spacing: 0.72px;
+    color: $secondary-1;
+  }
+}
+
+.custom-checkbox {
+  margin: 20px 0;
+  label {
+    font-family: $chivo-font;
+    font-size: 16px;
+    color: $secondary-1;
+  }
+}

--- a/frontend/src/styles/_theme.scss
+++ b/frontend/src/styles/_theme.scss
@@ -30,10 +30,17 @@ $enable-rounded: false;
   }
   p {
     padding-top: 4px;
+    margin-bottom: 4px;
     font-family: $chivo-font;
     font-size: 12px;
     letter-spacing: 0.72px;
     color: $secondary-1;
+  }
+  .invalid-feedback {
+    font-family: $chivo-font;
+    font-size: 12px;
+    letter-spacing: 0.72px;
+    color: red;
   }
 }
 

--- a/frontend/src/ui/components/App/__snapshots__/App.spec.tsx.snap
+++ b/frontend/src/ui/components/App/__snapshots__/App.spec.tsx.snap
@@ -173,7 +173,6 @@ exports[`renders without crashing 1`] = `
                       Check Availability
                     </button>
                   </div>
-                  
                 </div>
               </div>
               <div

--- a/frontend/src/ui/components/App/__snapshots__/App.spec.tsx.snap
+++ b/frontend/src/ui/components/App/__snapshots__/App.spec.tsx.snap
@@ -136,52 +136,55 @@ exports[`renders without crashing 1`] = `
             <div
               className="registration-page-content row"
             >
-              <form
-                className=""
+              <div
+                className="domain-input-container"
               >
                 <div
-                  className="form-group"
+                  className="domain-label"
                 >
-                  <label
-                    className="form-label"
-                    htmlFor="domainNameInput"
-                  >
-                    Type your domain name below
-                  </label>
-                  <div
-                    className="input-group"
-                  >
-                    <input
-                      className="form-control"
-                      defaultValue=""
-                      id="domainNameInput"
-                      onChange={[Function]}
-                      placeholder="yourdomain"
-                    />
-                    <div
-                      className="input-group-append"
-                    >
-                      <button
-                        className="btn btn-primary"
-                        disabled={false}
-                        onClick={[Function]}
-                        type="button"
-                      >
-                        Check Availability
-                      </button>
-                    </div>
-                  </div>
+                  Type your domain name below
                 </div>
                 <div
-                  className="use-own"
+                  className="input-group"
                 >
-                  <a
-                    href="/#"
+                  <input
+                    className="form-control"
+                    onChange={[Function]}
+                    value=""
+                  />
+                  <div
+                    className="input-group-append"
                   >
-                    I want to use my own domain
-                  </a>
+                    <span
+                      className="input-group-text"
+                    >
+                      .opencraft.hosting
+                    </span>
+                  </div>
+                  <div
+                    className="input-group-append"
+                  >
+                    <button
+                      className="btn btn-primary"
+                      disabled={false}
+                      onClick={[Function]}
+                      type="button"
+                    >
+                      Check Availability
+                    </button>
+                  </div>
+                  
                 </div>
-              </form>
+              </div>
+              <div
+                className="use-own"
+              >
+                <a
+                  href="/#"
+                >
+                  I want to use my own domain
+                </a>
+              </div>
             </div>
           </div>
         </div>

--- a/frontend/src/ui/components/DomainInput/DomainInput.spec.tsx
+++ b/frontend/src/ui/components/DomainInput/DomainInput.spec.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import { setupComponentForTesting } from "utils/testing";
+import { DomainInput } from './DomainInput';
+
+it('renders without crashing', () => {
+    const tree = setupComponentForTesting(<DomainInput />).toJSON();
+    expect(tree).toMatchSnapshot();
+});

--- a/frontend/src/ui/components/DomainInput/DomainInput.tsx
+++ b/frontend/src/ui/components/DomainInput/DomainInput.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { Button, FormControl, InputGroup, Spinner } from 'react-bootstrap';
 import { WrappedMessage } from 'utils/intl';
+import { INTERNAL_DOMAIN_NAME } from 'global/constants';
 import messages from './displayMessages';
 import './styles.scss';
 
@@ -28,9 +29,9 @@ export const DomainInput: React.SFC<Props> = (props: Props) => {
           }}
           isInvalid={isInvalid}
         />
-        {props.internalDomain === true && (
+        {props.internalDomain && (
           <InputGroup.Append>
-            <InputGroup.Text>.opencraft.hosting</InputGroup.Text>
+            <InputGroup.Text>{INTERNAL_DOMAIN_NAME}</InputGroup.Text>
           </InputGroup.Append>
         )}
         <InputGroup.Append>
@@ -41,7 +42,7 @@ export const DomainInput: React.SFC<Props> = (props: Props) => {
               props.handleSubmitDomain();
             }}
           >
-            {props.loading === true && (
+            {props.loading && (
               <Spinner animation="border" size="sm" className="spinner" />
             )}
             <WrappedMessage messages={messages} id="checkAvailability" />

--- a/frontend/src/ui/components/DomainInput/DomainInput.tsx
+++ b/frontend/src/ui/components/DomainInput/DomainInput.tsx
@@ -26,7 +26,7 @@ export const DomainInput: React.SFC<Props> = (props: Props) => {
           onChange={(event: any) => {
             props.handleDomainChange(event.target.value);
           }}
-          isInvalid={!!(props.error)}
+          isInvalid={!!props.error}
         />
         {props.internalDomain && (
           <InputGroup.Append>

--- a/frontend/src/ui/components/DomainInput/DomainInput.tsx
+++ b/frontend/src/ui/components/DomainInput/DomainInput.tsx
@@ -15,7 +15,6 @@ interface Props {
 }
 
 export const DomainInput: React.SFC<Props> = (props: Props) => {
-  const isInvalid = !!props.error;
   return (
     <div className="domain-input-container">
       <div className="domain-label">
@@ -27,7 +26,7 @@ export const DomainInput: React.SFC<Props> = (props: Props) => {
           onChange={(event: any) => {
             props.handleDomainChange(event.target.value);
           }}
-          isInvalid={isInvalid}
+          isInvalid={!!(props.error)}
         />
         {props.internalDomain && (
           <InputGroup.Append>
@@ -48,7 +47,7 @@ export const DomainInput: React.SFC<Props> = (props: Props) => {
             <WrappedMessage messages={messages} id="checkAvailability" />
           </Button>
         </InputGroup.Append>
-        {isInvalid && (
+        {props.error && (
           <FormControl.Feedback type="invalid">
             {props.error}
           </FormControl.Feedback>

--- a/frontend/src/ui/components/DomainInput/DomainInput.tsx
+++ b/frontend/src/ui/components/DomainInput/DomainInput.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Button, FormControl, InputGroup } from 'react-bootstrap';
+import { Button, FormControl, InputGroup, Spinner } from 'react-bootstrap';
 import { WrappedMessage } from 'utils/intl';
 import messages from './displayMessages';
 import './styles.scss';
@@ -7,13 +7,16 @@ import './styles.scss';
 interface Props {
   domainName: string;
   internalDomain: boolean;
+  loading: boolean;
+  error: string;
   handleDomainChange: Function;
   handleSubmitDomain: Function;
 }
 
 export const DomainInput: React.SFC<Props> = (props: Props) => {
+  const isInvalid = !!props.error;
   return (
-    <div>
+    <div className="domain-input-container">
       <div className="domain-label">
         <WrappedMessage messages={messages} id="typeDomainNameBelow" />
       </div>
@@ -23,22 +26,32 @@ export const DomainInput: React.SFC<Props> = (props: Props) => {
           onChange={(event: any) => {
             props.handleDomainChange(event.target.value);
           }}
+          isInvalid={isInvalid}
         />
         {props.internalDomain === true && (
           <InputGroup.Append>
-            <InputGroup.Text className="">.opencraft.hosting</InputGroup.Text>
+            <InputGroup.Text>.opencraft.hosting</InputGroup.Text>
           </InputGroup.Append>
         )}
         <InputGroup.Append>
           <Button
-            variant="secondary"
+            variant="primary"
+            disabled={false || props.loading}
             onClick={(event: any) => {
               props.handleSubmitDomain();
             }}
           >
+            {props.loading === true && (
+              <Spinner animation="border" size="sm" className="spinner" />
+            )}
             <WrappedMessage messages={messages} id="checkAvailability" />
           </Button>
         </InputGroup.Append>
+        {isInvalid && (
+          <FormControl.Feedback type="invalid">
+            {props.error}
+          </FormControl.Feedback>
+        )}
       </InputGroup>
     </div>
   );

--- a/frontend/src/ui/components/DomainInput/DomainInput.tsx
+++ b/frontend/src/ui/components/DomainInput/DomainInput.tsx
@@ -1,0 +1,45 @@
+import * as React from 'react';
+import { Button, FormControl, InputGroup } from 'react-bootstrap';
+import { WrappedMessage } from 'utils/intl';
+import messages from './displayMessages';
+import './styles.scss';
+
+interface Props {
+  domainName: string;
+  internalDomain: boolean;
+  handleDomainChange: Function;
+  handleSubmitDomain: Function;
+}
+
+export const DomainInput: React.FC<Props> = (props: Props) => {
+  return (
+    <div>
+      <div className="domain-label">
+        <WrappedMessage messages={messages} id="typeDomainNameBelow" />
+      </div>
+      <InputGroup>
+        <FormControl
+          value={props.domainName}
+          onChange={(event: any) => {
+            props.handleDomainChange(event.target.value);
+          }}
+        />
+        {props.internalDomain === true && (
+          <InputGroup.Append>
+            <InputGroup.Text className="">.opencraft.hosting</InputGroup.Text>
+          </InputGroup.Append>
+        )}
+        <InputGroup.Append>
+          <Button
+            variant="secondary"
+            onClick={(event: any) => {
+              props.handleSubmitDomain();
+            }}
+          >
+            <WrappedMessage messages={messages} id="checkAvailability" />
+          </Button>
+        </InputGroup.Append>
+      </InputGroup>
+    </div>
+  );
+};

--- a/frontend/src/ui/components/DomainInput/DomainInput.tsx
+++ b/frontend/src/ui/components/DomainInput/DomainInput.tsx
@@ -11,7 +11,7 @@ interface Props {
   handleSubmitDomain: Function;
 }
 
-export const DomainInput: React.FC<Props> = (props: Props) => {
+export const DomainInput: React.SFC<Props> = (props: Props) => {
   return (
     <div>
       <div className="domain-label">

--- a/frontend/src/ui/components/DomainInput/__snapshots__/DomainInput.spec.tsx.snap
+++ b/frontend/src/ui/components/DomainInput/__snapshots__/DomainInput.spec.tsx.snap
@@ -1,0 +1,33 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders without crashing 1`] = `
+<div
+  className="domain-input-container"
+>
+  <div
+    className="domain-label"
+  >
+    Type your domain name below
+  </div>
+  <div
+    className="input-group"
+  >
+    <input
+      className="form-control"
+      onChange={[Function]}
+    />
+    <div
+      className="input-group-append"
+    >
+      <button
+        className="btn btn-primary"
+        disabled={false}
+        onClick={[Function]}
+        type="button"
+      >
+        Check Availability
+      </button>
+    </div>
+  </div>
+</div>
+`;

--- a/frontend/src/ui/components/DomainInput/displayMessages.ts
+++ b/frontend/src/ui/components/DomainInput/displayMessages.ts
@@ -1,0 +1,12 @@
+const messages = {
+  typeDomainNameBelow: {
+    defaultMessage: 'Type your domain name below',
+    description: 'Message above domain input text box.'
+  },
+  checkAvailability: {
+    defaultMessage: 'Check Availability',
+    description: 'Label for button that check availability of Domain'
+  }
+};
+
+export default messages;

--- a/frontend/src/ui/components/DomainInput/index.ts
+++ b/frontend/src/ui/components/DomainInput/index.ts
@@ -1,0 +1,1 @@
+export * from './DomainInput';

--- a/frontend/src/ui/components/DomainInput/styles.scss
+++ b/frontend/src/ui/components/DomainInput/styles.scss
@@ -1,9 +1,39 @@
-.domain-label {
-  width: 460px;
-  height: 21px;
-  font-family: Chivo;
-  font-size: 18px;
-  letter-spacing: 0.54px;
-  color: #0f1f24;
-  margin-bottom: 32px;
+@import "~styles/theme";
+
+.domain-input-container {
+  width: 100%;
+
+  .domain-label {
+    font-family: Chivo;
+    font-size: 18px;
+    letter-spacing: 0.54px;
+    color: #0f1f24;
+    margin-bottom: 20px;
+  }
+
+  .input-group {
+    font-family: $chivo-font;
+    font-size: 16px;
+    letter-spacing: 0.96px;
+    color: #000000;
+
+    .form-control {
+      border: 1px solid $primary-1;
+      border-right-width: 0px;
+    }
+    .input-group-text {
+      height: 38px;
+      border: 1px solid $primary-1;
+      background-color: white;
+      color: black;
+    }
+
+    button {
+      height: 38px;
+      width: 200px;
+      .spinner {
+        margin-right: 10px;
+      }
+    }
+  }
 }

--- a/frontend/src/ui/components/DomainInput/styles.scss
+++ b/frontend/src/ui/components/DomainInput/styles.scss
@@ -1,0 +1,9 @@
+.domain-label {
+  width: 460px;
+  height: 21px;
+  font-family: Chivo;
+  font-size: 18px;
+  letter-spacing: 0.54px;
+  color: #0f1f24;
+  margin-bottom: 32px;
+}

--- a/frontend/src/ui/components/DomainSuccessJumbotron/DomainSuccessJumbotron.tsx
+++ b/frontend/src/ui/components/DomainSuccessJumbotron/DomainSuccessJumbotron.tsx
@@ -28,7 +28,10 @@ export const DomainSuccessJumbotron: React.FC<DomainProps> = (
         <WrappedMessage id={domainStatusText} messages={messages} />
       </h2>
       <div className="domain-name">
-        <p>{props.domain}</p>
+        <p>
+          {props.domain}
+          {props.domainIsExternal === false && <span>.opencraft.hosting</span>}
+        </p>
       </div>
       <p>
         <WrappedMessage id="secureDomainNow" messages={messages} />

--- a/frontend/src/ui/components/DomainSuccessJumbotron/DomainSuccessJumbotron.tsx
+++ b/frontend/src/ui/components/DomainSuccessJumbotron/DomainSuccessJumbotron.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { Jumbotron } from 'react-bootstrap';
 import { WrappedMessage } from 'utils/intl';
+import { INTERNAL_DOMAIN_NAME } from 'global/constants';
 import iconCheck from 'assets/circle-check.png';
 import messages from './displayMessages';
 import './styles.scss';
@@ -15,7 +16,7 @@ export const DomainSuccessJumbotron: React.FC<DomainProps> = (
 ) => {
   let domainStatusText: string;
 
-  if (props.domainIsExternal === true) {
+  if (props.domainIsExternal) {
     domainStatusText = 'domainIsConnected';
   } else {
     domainStatusText = 'domainIsAvailable';
@@ -30,7 +31,7 @@ export const DomainSuccessJumbotron: React.FC<DomainProps> = (
       <div className="domain-name">
         <p>
           {props.domain}
-          {props.domainIsExternal === false && <span>.opencraft.hosting</span>}
+          {!props.domainIsExternal && <span>{INTERNAL_DOMAIN_NAME}</span>}
         </p>
       </div>
       <p>

--- a/frontend/src/ui/components/DomainSuccessJumbotron/__snapshots__/DomainSuccessJumbotron.spec.tsx.snap
+++ b/frontend/src/ui/components/DomainSuccessJumbotron/__snapshots__/DomainSuccessJumbotron.spec.tsx.snap
@@ -14,7 +14,11 @@ exports[`renders without crashing 1`] = `
   <div
     className="domain-name"
   >
-    <p />
+    <p>
+      <span>
+        .opencraft.hosting
+      </span>
+    </p>
   </div>
   <p>
     To secure your domain now, please fill in the details below.

--- a/frontend/src/ui/components/DomainSuccessJumbotron/styles.scss
+++ b/frontend/src/ui/components/DomainSuccessJumbotron/styles.scss
@@ -1,0 +1,41 @@
+@import '~styles/theme';
+
+.domain-available {
+  margin-top: -20px;
+  font-family: $chivo-font;
+  width: 100%;
+  padding: 32px 32px;
+  background-color: $primary-2;
+  text-align: center;
+
+  img {
+    padding-bottom: 16px;
+  }
+
+  h2 {
+    font-family: $playfair-font;
+    font-size: 28px;
+    font-weight: 900;
+    letter-spacing: 0.28px;
+    margin-bottom: 9px;
+  }
+
+  .domain-name {
+    background-color: #1e4c59;
+    padding: 10px;
+    height: 45px;
+    margin-bottom: 16px;
+  }
+
+  p {
+    font-family: Chivo;
+    font-size: 18px;
+    letter-spacing: 0.54px;
+    color: #ffffff;
+  }
+
+  @media (min-width: 800px)
+  {
+    max-width: 700px;
+  }
+}

--- a/frontend/src/ui/components/Main/__snapshots__/Main.spec.tsx.snap
+++ b/frontend/src/ui/components/Main/__snapshots__/Main.spec.tsx.snap
@@ -112,52 +112,55 @@ exports[`renders without crashing 1`] = `
           <div
             className="registration-page-content row"
           >
-            <form
-              className=""
+            <div
+              className="domain-input-container"
             >
               <div
-                className="form-group"
+                className="domain-label"
               >
-                <label
-                  className="form-label"
-                  htmlFor="domainNameInput"
-                >
-                  Type your domain name below
-                </label>
-                <div
-                  className="input-group"
-                >
-                  <input
-                    className="form-control"
-                    defaultValue=""
-                    id="domainNameInput"
-                    onChange={[Function]}
-                    placeholder="yourdomain"
-                  />
-                  <div
-                    className="input-group-append"
-                  >
-                    <button
-                      className="btn btn-primary"
-                      disabled={false}
-                      onClick={[Function]}
-                      type="button"
-                    >
-                      Check Availability
-                    </button>
-                  </div>
-                </div>
+                Type your domain name below
               </div>
               <div
-                className="use-own"
+                className="input-group"
               >
-                <a
-                  href="/#"
+                <input
+                  className="form-control"
+                  onChange={[Function]}
+                  value=""
+                />
+                <div
+                  className="input-group-append"
                 >
-                  I want to use my own domain
-                </a>
+                  <span
+                    className="input-group-text"
+                  >
+                    .opencraft.hosting
+                  </span>
+                </div>
+                <div
+                  className="input-group-append"
+                >
+                  <button
+                    className="btn btn-primary"
+                    disabled={false}
+                    onClick={[Function]}
+                    type="button"
+                  >
+                    Check Availability
+                  </button>
+                </div>
+                
               </div>
-            </form>
+            </div>
+            <div
+              className="use-own"
+            >
+              <a
+                href="/#"
+              >
+                I want to use my own domain
+              </a>
+            </div>
           </div>
         </div>
       </div>

--- a/frontend/src/ui/components/Main/__snapshots__/Main.spec.tsx.snap
+++ b/frontend/src/ui/components/Main/__snapshots__/Main.spec.tsx.snap
@@ -149,7 +149,6 @@ exports[`renders without crashing 1`] = `
                     Check Availability
                   </button>
                 </div>
-                
               </div>
             </div>
             <div

--- a/frontend/src/ui/components/TextInputField/TextInputField.spec.tsx
+++ b/frontend/src/ui/components/TextInputField/TextInputField.spec.tsx
@@ -2,7 +2,24 @@ import React from 'react';
 import { setupComponentForTesting } from "utils/testing";
 import { TextInputField } from './TextInputField';
 
+const messages = {
+  test: {
+    defaultMessage: 'A translatable string.',
+    description: 'A description of the translatable string.'
+  }
+};
+
+
 it('renders without crashing', () => {
-    const tree = setupComponentForTesting(<TextInputField />).toJSON();
+    const tree = setupComponentForTesting(
+      <TextInputField
+        fieldName="test"
+        value="test"
+        type="password"
+        error="test"
+        onChange={() => {}}
+        messages={messages}
+      />
+    ).toJSON();
     expect(tree).toMatchSnapshot();
 });

--- a/frontend/src/ui/components/TextInputField/TextInputField.spec.tsx
+++ b/frontend/src/ui/components/TextInputField/TextInputField.spec.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import { setupComponentForTesting } from "utils/testing";
+import { TextInputField } from './TextInputField';
+
+it('renders without crashing', () => {
+    const tree = setupComponentForTesting(<TextInputField />).toJSON();
+    expect(tree).toMatchSnapshot();
+});

--- a/frontend/src/ui/components/TextInputField/TextInputField.spec.tsx
+++ b/frontend/src/ui/components/TextInputField/TextInputField.spec.tsx
@@ -6,6 +6,10 @@ const messages = {
   test: {
     defaultMessage: 'A translatable string.',
     description: 'A description of the translatable string.'
+  },
+  testHelp: {
+    defaultMessage: 'A translatable string.',
+    description: 'A description of the translatable string.'
   }
 };
 

--- a/frontend/src/ui/components/TextInputField/TextInputField.tsx
+++ b/frontend/src/ui/components/TextInputField/TextInputField.tsx
@@ -7,6 +7,7 @@ interface InputFieldProps {
   fieldName: string;
   value: string;
   onChange: any;
+  error?: string;
   messages: any;
   type?: string;
 }
@@ -24,7 +25,13 @@ export const TextInputField: React.SFC<InputFieldProps> = (
         value={props.value}
         onChange={props.onChange}
         type={props.type}
+        isInvalid={!!props.error}
       />
+      {props.error && (
+        <FormControl.Feedback type="invalid">
+          {props.error}
+        </FormControl.Feedback>
+      )}
       <p>
         <WrappedMessage
           id={`${props.fieldName}Help`}

--- a/frontend/src/ui/components/TextInputField/TextInputField.tsx
+++ b/frontend/src/ui/components/TextInputField/TextInputField.tsx
@@ -11,7 +11,9 @@ interface InputFieldProps {
   type?: string;
 }
 
-export const TextInputField: React.SFC<InputFieldProps> = (props: InputFieldProps) => {
+export const TextInputField: React.SFC<InputFieldProps> = (
+  props: InputFieldProps
+) => {
   return (
     <FormGroup>
       <FormLabel>
@@ -24,7 +26,10 @@ export const TextInputField: React.SFC<InputFieldProps> = (props: InputFieldProp
         type={props.type}
       />
       <p>
-        <WrappedMessage id={`${props.fieldName}Help`} messages={props.messages} />
+        <WrappedMessage
+          id={`${props.fieldName}Help`}
+          messages={props.messages}
+        />
       </p>
     </FormGroup>
   );

--- a/frontend/src/ui/components/TextInputField/TextInputField.tsx
+++ b/frontend/src/ui/components/TextInputField/TextInputField.tsx
@@ -1,0 +1,31 @@
+import * as React from 'react';
+import { FormControl, FormGroup, FormLabel } from 'react-bootstrap';
+import { WrappedMessage } from 'utils/intl';
+import './styles.scss';
+
+interface InputFieldProps {
+  fieldName: string;
+  value: string;
+  onChange: any;
+  messages: any;
+  type?: string;
+}
+
+export const TextInputField: React.SFC<InputFieldProps> = (props: InputFieldProps) => {
+  return (
+    <FormGroup>
+      <FormLabel>
+        <WrappedMessage id={props.fieldName} messages={props.messages} />
+      </FormLabel>
+      <FormControl
+        name={props.fieldName}
+        value={props.value}
+        onChange={props.onChange}
+        type={props.type}
+      />
+      <p>
+        <WrappedMessage id={`${props.fieldName}Help`} messages={props.messages} />
+      </p>
+    </FormGroup>
+  );
+};

--- a/frontend/src/ui/components/TextInputField/__snapshots__/TextInputField.spec.tsx.snap
+++ b/frontend/src/ui/components/TextInputField/__snapshots__/TextInputField.spec.tsx.snap
@@ -1,0 +1,28 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders without crashing 1`] = `
+<div
+  className="form-group"
+>
+  <label
+    className="form-label"
+  >
+    A translatable string.
+  </label>
+  <input
+    className="form-control is-invalid"
+    name="test"
+    onChange={[Function]}
+    type="password"
+    value="test"
+  />
+  <div
+    className="invalid-feedback"
+  >
+    test
+  </div>
+  <p>
+    testHelp
+  </p>
+</div>
+`;

--- a/frontend/src/ui/components/TextInputField/__snapshots__/TextInputField.spec.tsx.snap
+++ b/frontend/src/ui/components/TextInputField/__snapshots__/TextInputField.spec.tsx.snap
@@ -22,7 +22,7 @@ exports[`renders without crashing 1`] = `
     test
   </div>
   <p>
-    testHelp
+    A translatable string.
   </p>
 </div>
 `;

--- a/frontend/src/ui/components/TextInputField/displayMessages.ts
+++ b/frontend/src/ui/components/TextInputField/displayMessages.ts
@@ -1,8 +1,8 @@
 const messages = {
-    messageID: {
-        defaultMessage: 'A translatable string.',
-        description: 'A description of the translatable string.',
-    },
+  messageID: {
+    defaultMessage: 'A translatable string.',
+    description: 'A description of the translatable string.'
+  }
 };
 
 export default messages;

--- a/frontend/src/ui/components/TextInputField/displayMessages.ts
+++ b/frontend/src/ui/components/TextInputField/displayMessages.ts
@@ -1,8 +1,0 @@
-const messages = {
-  messageID: {
-    defaultMessage: 'A translatable string.',
-    description: 'A description of the translatable string.'
-  }
-};
-
-export default messages;

--- a/frontend/src/ui/components/TextInputField/displayMessages.ts
+++ b/frontend/src/ui/components/TextInputField/displayMessages.ts
@@ -1,0 +1,8 @@
+const messages = {
+    messageID: {
+        defaultMessage: 'A translatable string.',
+        description: 'A description of the translatable string.',
+    },
+};
+
+export default messages;

--- a/frontend/src/ui/components/TextInputField/index.ts
+++ b/frontend/src/ui/components/TextInputField/index.ts
@@ -1,0 +1,1 @@
+export * from "./TextInputField";

--- a/frontend/src/ui/components/TextInputField/index.ts
+++ b/frontend/src/ui/components/TextInputField/index.ts
@@ -1,1 +1,1 @@
-export * from "./TextInputField";
+export * from './TextInputField';

--- a/frontend/src/ui/components/index.ts
+++ b/frontend/src/ui/components/index.ts
@@ -6,3 +6,4 @@ export * from './StepBar';
 export * from './DomainSuccessJumbotron';
 export * from './InstitutionalAccountHero';
 export * from './DomainInput';
+export * from "./TextInputField";

--- a/frontend/src/ui/components/index.ts
+++ b/frontend/src/ui/components/index.ts
@@ -6,4 +6,4 @@ export * from './StepBar';
 export * from './DomainSuccessJumbotron';
 export * from './InstitutionalAccountHero';
 export * from './DomainInput';
-export * from "./TextInputField";
+export * from './TextInputField';

--- a/frontend/src/ui/components/index.ts
+++ b/frontend/src/ui/components/index.ts
@@ -5,3 +5,4 @@ export * from './Main';
 export * from './StepBar';
 export * from './DomainSuccessJumbotron';
 export * from './InstitutionalAccountHero';
+export * from './DomainInput';


### PR DESCRIPTION
This PR introduces the new Ocim registration pages with the basic registration flow.

**Testing instructions:**
1. `npm i && npm start`
2. Go to http://localhost:3000/registration/domain.
3. Insert `existing` and click "Check availability".
4. Check that an error message is displayed.
5. Write something and check that the error message immediately vanishes after editing the field.
6. Test that that registration form is working (next/back buttons work, data is store on the state).
7. Check that the styles are similar to the ones in the mockups.

Since the validators aren't implemented yet, change a few values in the `registrationReducer` to show when fields have feedback error messages. Example: show error on password field:
```
    case RegistrationActions.Types.ROOT_STATE_UPDATE:
      // Merge state without erasing previous values
      return {
        loading: state.loading,
        registrationData: {
          ...state.registrationData,
          ...action.data.registrationData
        },
        registrationFeedback: {
          ...state.registrationFeedback,
          ...action.data.registrationFeedback,
          // ADD THIS LINE
          password: "This password already exists!"
        }
      };
```

**Reviewer:**
- [ ] @Agrendalath 