### PR TITLE
BB-1970: Fix registration emails

### DIFF
--- a/registration/utils.py
+++ b/registration/utils.py
@@ -67,10 +67,6 @@ def send_account_info_email(application: BetaTestApplication) -> None:
     confirmed their email addresses and their instance is set up.
     """
     user = application.user
-    logo_url = application.draft_theme_config.get('images', {}).get('logo', 'logo')
-    logo_file = logo_url.split('/')[-1]
-    header_url = application.draft_theme_config.get('images', {}).get('cover', 'header')
-    header_file = header_url.split('/')[-1]
     context = dict(
         user_name=user.profile.full_name,
         instance_url=application.instance.get_domain('lms'),
@@ -78,13 +74,6 @@ def send_account_info_email(application: BetaTestApplication) -> None:
         full_name=user.profile.full_name,
         email=user.email,
         public_contact_email=application.public_contact_email,
-        theme=application.draft_theme_config.get('theme'),
-        primary_color=application.draft_theme_config.get('colors').get('main'),
-        secondary_color=application.draft_theme_config.get('colors').get('accent'),
-        logo_url=logo_url,
-        logo_file=logo_file,
-        header_url=header_url,
-        header_file=header_file,
     )
     html_email_helper(
         template_base_name='emails/account_info_email',

--- a/templates/emails/account_info_email.html
+++ b/templates/emails/account_info_email.html
@@ -54,34 +54,5 @@
             <td>{{ public_contact_email }}</td>
         </tr>
     </table>
-    <h2>Customisation details</h2>
-    <table class="details">
-        <tr>
-            <td>Theme</td>
-            <td>{{ theme }}</td>
-        </tr>
-        <tr>
-            <td>Primary color</td>
-            <td>
-                <span class="swatch" style="background-color: {{ primary_color }}"/>
-                {{ primary_color }}
-            </td>
-        </tr>
-        <tr>
-            <td>Secondary colour</td>
-            <td>
-                <span class="swatch" style="background-color: {{ secondary_color }}"/>
-                {{ secondary_color }}
-            </td>
-        </tr>
-        <tr>
-            <td>Logo</td>
-            <td><a href="{{ logo_url }}">{{ logo_file }}</a></td>
-        </tr>
-        <tr>
-            <td>Header image</td>
-            <td><a href="{{ header_url }}">{{ header_file }}</a></td>
-        </tr>
-    </table>
     {% include "emails/_email_signature.html" %}
 {% endblock %}

--- a/templates/emails/account_info_email.txt
+++ b/templates/emails/account_info_email.txt
@@ -17,10 +17,3 @@ Instance name: {{ instance_name }}
 Full name: {{ full_name }}
 Email address: {{ email }}
 Public contact email address: {{ public_contact_email }}
-
-Customisation details:
-Theme: {{ theme }}
-Primary color: {{ primary_color }}
-Secondary colour: {{ secondary_color }}
-Logo: {{ logo_url }}
-Header image: {{ header_url }}


### PR DESCRIPTION
This PR fixes an issue where the email templates expected theme configuration, but this isn't set up during the registration form.

**Testing instructions:**
1. Create a new account through the registration form.
2. Activate the account using the email link.

**Reviewer:**
- [ ] @xitij2000 