### PR TITLE
[BB-2003] Remove the 'clean' target dependency for the 'test.integration_cleanup' target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -128,7 +128,7 @@ test.migrations_missing: clean ## Check if migrations are missing.
 test.browser: clean static_external ## Run browser-specific tests.
 	@echo -e "\nRunning browser tests..."
 	xvfb-run --auto-servernum $(HONCHO_COVERAGE_TEST) --pattern=browser_*.py
-	
+
 test.integration: clean ## Run integration tests.
 ifneq ($(wildcard .env.integration),)
 	echo -e "\nRunning integration tests with credentials from .env.integration file..."
@@ -140,7 +140,7 @@ else
 	echo -e "\nIntegration tests skipped (create a '.env.integration' file to run them)"
 endif
 
-test.integration_cleanup: clean ## Run the integration cleanup script.
+test.integration_cleanup: ## Run the integration cleanup script.
 ifneq ($(wildcard .env.integration),)
 	echo -e "\nRunning integration test cleanup script with credentials from .env.integration file..."
 	PYTHONPATH=$(PYTHONPATH):$(pwd) honcho -e .env.integration run python3 cleanup_utils/integration_cleanup.py


### PR DESCRIPTION
It runs a lot of stuff (including `coverage`) which are not needed in the cleanup job.

**Testing instructions**:
* After the PR is merged (the job runs only on the master branch), verify that the cleanup job doesn't run the commands in the `clean` target and that the error about the missing `coverage` command is not thrown. Since the cleanup job runs as a scheduled task, we will have to wait till the next scheduled run.
* Alternatively, use the [CircleCI local CLI tool](https://circleci.com/docs/2.0/local-cli/) to run the cleanup job locally after [converting the configuration file](https://circleci.com/docs/2.0/local-cli/#running-a-job) and verifying that the execution proceeds past the step that is currently failing.