### PR TITLE
[BB-1913] Delete SSH key upon terminating the AppServer

### DIFF
--- a/instance/models/server.py
+++ b/instance/models/server.py
@@ -493,4 +493,3 @@ class OpenStackServer(Server):
         self.logger.info('Deleting SSH key of "%s" host.', ip)
         command = f'ssh-keygen -R {ip}'
         subprocess.Popen(command, shell=True)
-

--- a/instance/models/server.py
+++ b/instance/models/server.py
@@ -492,4 +492,7 @@ class OpenStackServer(Server):
         """
         self.logger.info('Deleting SSH key of "%s" host.', self.public_ip)
         command = f'ssh-keygen -R {self.public_ip}'
-        subprocess.Popen(command, shell=True)
+        try:
+            subprocess.Popen(command, shell=True)
+        except subprocess.SubprocessError as e:
+            self.logger.error('Failed to delete SSH key of "%s" host: %s', self.public_ip, e)

--- a/instance/models/server.py
+++ b/instance/models/server.py
@@ -493,6 +493,6 @@ class OpenStackServer(Server):
         self.logger.info('Deleting SSH key of "%s" host.', self.public_ip)
         command = f'ssh-keygen -R {self.public_ip}'
         try:
-            subprocess.Popen(command, shell=True)
+            subprocess.Popen(command, shell=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
         except subprocess.SubprocessError as e:
             self.logger.error('Failed to delete SSH key of "%s" host: %s', self.public_ip, e)

--- a/instance/tests/models/factories/server.py
+++ b/instance/tests/models/factories/server.py
@@ -108,6 +108,9 @@ class OpenStackServerFactory(DjangoModelFactory):
         # This isn't a model field, so it needs to be set separately, not passed to the model `__init__`
         server.nova = Mock()
 
+        # Mock method for deleting SSH key to assert it's called.
+        server._delete_ssh_key = Mock()
+
         # Allow to set OpenStack API data for the current `self.os_server`, using fixtures
         if os_server_fixture is not None:
             add_fixture_to_object(server.nova.servers.get.return_value, os_server_fixture)

--- a/instance/tests/models/test_server.py
+++ b/instance/tests/models/test_server.py
@@ -342,9 +342,11 @@ class OpenStackServerTestCase(TestCase):
         Terminate a server with a VM
         """
         server = OpenStackServerFactory(openstack_id=openstack_id, status=server_status)
+        ip = str(server.public_ip)
         server.terminate()
         self.assertEqual(server.status, ServerStatus.Terminated)
         server.os_server.delete.assert_called_once_with()
+        server._delete_ssh_key.assert_called_once_with(ip)
 
     @override_settings(SHUTDOWN_TIMEOUT=0)
     @data(
@@ -383,9 +385,11 @@ class OpenStackServerTestCase(TestCase):
         server.logger = Mock()
         mock_logger = server.logger
 
+        ip = str(server.public_ip)
         server.terminate()
         self.assertEqual(server.status, ServerStatus.Terminated)
         server.os_server.delete.assert_called_once_with()
+        server._delete_ssh_key.assert_called_once_with(ip)
         mock_logger.error.assert_called_once_with(AnyStringMatching('Error while attempting to terminate server'))
 
     @override_settings(SHUTDOWN_TIMEOUT=0)


### PR DESCRIPTION
This PR is a follow-up to #495. It removes SSH key from `~/.ssh/known_hosts` before we terminate the sever. This way we won't encounter SSH key conflict when we get the server with the same IP we've used before.

## Testing instructions.
1. Log into stage.
1. Create new AppServer for any existing instance.
1. Log to stage via SSH and switch to the proper user.
1. Run `ssh-keygen -F $IP` to check that the key has been added to `~/.ssh/known_hosts`. If the response is empty, try again in a minute.
1. Use `Terminate` button in Ocim.
1. Run `ssh-keygen -F $IP` to confirm that the key has been deleted.

Note: integration tests are failing, but they're not related to this change.