### PR TITLE
WIP [SE-1968] Send deployment failure e-mail after all N attempts failed instead of after each attempt

### DIFF
--- a/instance/models/mixins/utilities.py
+++ b/instance/models/mixins/utilities.py
@@ -34,20 +34,19 @@ from django.views.debug import ExceptionReporter
 
 class EmailMixin:
     """
-    Mixin that enables AppServer to send emails
+    Mixin that enables OpenEdXInstance to send emails
     """
     class EmailSubject:
         """
         Class holding email subject constants
         """
-        PROVISION_FAILED = "AppServer {name} ({instance_name}) failed to provision"
+        PROVISION_FAILED = "AppServer {name} ({instance_name}) failed to provision. FIXME:update1"
 
     class EmailBody:
         """
         Class holding email body constants
         """
-        PROVISION_FAILED = "AppServer {name} for Instance {instance_name} failed to provision.\n" \
-                           "Reason: {reason}\n"
+        PROVISION_FAILED = "AppServer {name} for Instance {instance_name} failed to provision.\nFIXME:update2"
 
     @staticmethod
     def _get_exc_info(default=None):
@@ -61,23 +60,26 @@ class EmailMixin:
         else:
             return exc_info
 
-    def provision_failed_email(self, reason, log=None):
+    def provision_failed_email(self):
         """
-        Send email notifications when instance provisioning is failed. Will
+        Send email notifications when instance provisioning has failed. Will
         send notifications to settings.ADMINs and the instance's
         provisioning_failure_notification_emails.
         """
         attachments = []
+        # FIXME remove support for attachments, since we can't get them. Or maybe take last deployed server's log?
+        log = None
         if log is not None:
             log_str = "\n".join(log)
             attachments.append(("provision.log", log_str, "text/plain"))
-
+        # FIXME remove support for appserver's name
+        appserver_name = "Appserver without a name"
         self._send_email(
-            self.EmailSubject.PROVISION_FAILED.format(name=self.name, instance_name=self.instance.name),
-            self.EmailBody.PROVISION_FAILED.format(name=self.name, instance_name=self.instance.name, reason=reason),
+            self.EmailSubject.PROVISION_FAILED.format(name=appserver_name, instance_name=self.name),
+            self.EmailBody.PROVISION_FAILED.format(name=appserver_name, instance_name=self.name),
             self._get_exc_info(default=None),
             attachments=attachments,
-            extra_recipients=self.instance.provisioning_failure_notification_emails,
+            extra_recipients=self.provisioning_failure_notification_emails,
         )
 
     def _send_email(self, subject, message, exc_info=None, attachments=None,

--- a/instance/models/mixins/utilities.py
+++ b/instance/models/mixins/utilities.py
@@ -40,13 +40,17 @@ class EmailMixin:
         """
         Class holding email subject constants
         """
-        PROVISION_FAILED = "AppServer {name} ({instance_name}) failed to provision. FIXME:update1"
+        # FIXME improve messages for subject and body. Maybe include the server number? A link?
+        PROVISION_FAILED = "AppServer failed to provision ({instance_name})"
 
     class EmailBody:
         """
         Class holding email body constants
         """
-        PROVISION_FAILED = "AppServer {name} for Instance {instance_name} failed to provision.\nFIXME:update2"
+        PROVISION_FAILED = (
+            "An AppServer for Instance {instance_name} failed to provision.\n"
+            "You can find the details in Ocim's web interface.\n"
+        )
 
     @staticmethod
     def _get_exc_info(default=None):
@@ -72,11 +76,9 @@ class EmailMixin:
         if log is not None:
             log_str = "\n".join(log)
             attachments.append(("provision.log", log_str, "text/plain"))
-        # FIXME remove support for appserver's name
-        appserver_name = "Appserver without a name"
         self._send_email(
-            self.EmailSubject.PROVISION_FAILED.format(name=appserver_name, instance_name=self.name),
-            self.EmailBody.PROVISION_FAILED.format(name=appserver_name, instance_name=self.name),
+            self.EmailSubject.PROVISION_FAILED.format(instance_name=self.name),
+            self.EmailBody.PROVISION_FAILED.format(instance_name=self.name),
             self._get_exc_info(default=None),
             attachments=attachments,
             extra_recipients=self.provisioning_failure_notification_emails,

--- a/instance/models/openedx_appserver.py
+++ b/instance/models/openedx_appserver.py
@@ -205,7 +205,8 @@ class OpenEdXAppConfiguration(models.Model):
         return [field.name for field in cls._meta.fields if field.name not in ('id', )]
 
 
-class OpenEdXAppServer(AppServer, OpenEdXAppConfiguration, AnsibleAppServerMixin, OpenEdXConfigMixin):  # FIXME remove rests of EmailMixin
+# FIXME remove rests of EmailMixin, if any
+class OpenEdXAppServer(AppServer, OpenEdXAppConfiguration, AnsibleAppServerMixin, OpenEdXConfigMixin):
     """
     OpenEdXAppServer: One or more of the Open edX apps, running on a single VM
 

--- a/instance/models/openedx_instance.py
+++ b/instance/models/openedx_instance.py
@@ -257,32 +257,31 @@ class OpenEdXInstance(
             Returns the ID of the new AppServer on success or None on failure.
         """
         # FIXME: restore. This is just disabled because it's not needed to make the deployments fail
-        if 0:  # pylint: disable=using-constant-test
-            if not self.load_balancing_server:
-                self.load_balancing_server = LoadBalancingServer.objects.select_random()
-                self.save()
-                self.reconfigure_load_balancer()
-
-            # We unconditionally set the DNS records here, though this would only be strictly needed
-            # when the first AppServer is spawned.  However, there is no easy way to tell whether the
-            # DNS records have already been successfully set, and it doesn't hurt to always do it.
-            self.set_dns_records()
-
-            # Provision external databases:
-            # TODO: Use db row-level locking to ensure we don't get any race conditions when creating these DBs.
-            # Use select_for_update(nowait=True) to lock this object's row, then do these steps, then refresh_from_db
-            self.logger.info('Provisioning MySQL database...')
-            self.provision_mysql()
-            self.logger.info('Provisioning MongoDB databases...')
-            self.provision_mongo()
-            if self.storage_type == self.SWIFT_STORAGE:
-                self.logger.info('Provisioning Swift container...')
-                self.provision_swift()
-            elif self.storage_type == self.S3_STORAGE:
-                self.logger.info('Provisioning S3 bucket...')
-                self.provision_s3()
-            self.logger.info('Provisioning RabbitMQ vhost...')
-            self.provision_rabbitmq()
+        # if not self.load_balancing_server:
+        #     self.load_balancing_server = LoadBalancingServer.objects.select_random()
+        #     self.save()
+        #     self.reconfigure_load_balancer()
+        #
+        # # We unconditionally set the DNS records here, though this would only be strictly needed
+        # # when the first AppServer is spawned.  However, there is no easy way to tell whether the
+        # # DNS records have already been successfully set, and it doesn't hurt to always do it.
+        # self.set_dns_records()
+        #
+        # # Provision external databases:
+        # # TODO: Use db row-level locking to ensure we don't get any race conditions when creating these DBs.
+        # # Use select_for_update(nowait=True) to lock this object's row, then do these steps, then refresh_from_db
+        # self.logger.info('Provisioning MySQL database...')
+        # self.provision_mysql()
+        # self.logger.info('Provisioning MongoDB databases...')
+        # self.provision_mongo()
+        # if self.storage_type == self.SWIFT_STORAGE:
+        #     self.logger.info('Provisioning Swift container...')
+        #     self.provision_swift()
+        # elif self.storage_type == self.S3_STORAGE:
+        #     self.logger.info('Provisioning S3 bucket...')
+        #     self.provision_s3()
+        # self.logger.info('Provisioning RabbitMQ vhost...')
+        # self.provision_rabbitmq()
 
         return self._create_owned_appserver()
 

--- a/instance/models/openedx_instance.py
+++ b/instance/models/openedx_instance.py
@@ -257,17 +257,17 @@ class OpenEdXInstance(
             Returns the ID of the new AppServer on success or None on failure.
         """
         # FIXME: restore. This is just disabled because it's not needed to make the deployments fail
-        if 0:
+        if 0:  # pylint: disable=using-constant-test
             if not self.load_balancing_server:
                 self.load_balancing_server = LoadBalancingServer.objects.select_random()
                 self.save()
                 self.reconfigure_load_balancer()
-    
+
             # We unconditionally set the DNS records here, though this would only be strictly needed
             # when the first AppServer is spawned.  However, there is no easy way to tell whether the
             # DNS records have already been successfully set, and it doesn't hurt to always do it.
             self.set_dns_records()
-    
+
             # Provision external databases:
             # TODO: Use db row-level locking to ensure we don't get any race conditions when creating these DBs.
             # Use select_for_update(nowait=True) to lock this object's row, then do these steps, then refresh_from_db
@@ -315,7 +315,8 @@ class OpenEdXInstance(
 
         else:
             self.logger.error('Failed to provision new app server after {} attempts'.format(num_attempts))
-            # FIXME send e-mail here. Maybe pass the number of attempts. And maybe attach the e-mail-sending code into the signal instead
+            # FIXME send e-mail here. Maybe pass the number of attempts.
+            # FIXME (cont): And maybe attach the e-mail-sending code into the signal instead
             self.provision_failed_email()
             if failure_tag:
                 self.tags.add(failure_tag)

--- a/instance/models/openedx_instance.py
+++ b/instance/models/openedx_instance.py
@@ -43,6 +43,7 @@ from instance.models.mixins.openedx_storage import OpenEdXStorageMixin
 from instance.models.mixins.openedx_theme import OpenEdXThemeMixin
 from instance.models.mixins.openedx_periodic_builds import OpenEdXPeriodicBuildsMixin
 from instance.models.mixins.secret_keys import SecretKeyInstanceMixin
+from instance.models.mixins.utilities import EmailMixin
 from instance.models.openedx_appserver import OpenEdXAppConfiguration
 from instance.models.utils import WrongStateException, ConsulAgent, get_base_playbook_name
 from instance.utils import sufficient_time_passed
@@ -61,7 +62,8 @@ class OpenEdXInstance(
         OpenEdXThemeMixin,
         OpenEdXPeriodicBuildsMixin,
         SecretKeyInstanceMixin,
-        Instance
+        Instance,
+        EmailMixin
 ):
     """
     OpenEdXInstance: represents a website or set of affiliated websites powered by the same
@@ -254,31 +256,33 @@ class OpenEdXInstance(
 
             Returns the ID of the new AppServer on success or None on failure.
         """
-        if not self.load_balancing_server:
-            self.load_balancing_server = LoadBalancingServer.objects.select_random()
-            self.save()
-            self.reconfigure_load_balancer()
-
-        # We unconditionally set the DNS records here, though this would only be strictly needed
-        # when the first AppServer is spawned.  However, there is no easy way to tell whether the
-        # DNS records have already been successfully set, and it doesn't hurt to always do it.
-        self.set_dns_records()
-
-        # Provision external databases:
-        # TODO: Use db row-level locking to ensure we don't get any race conditions when creating these DBs.
-        # Use select_for_update(nowait=True) to lock this object's row, then do these steps, then refresh_from_db
-        self.logger.info('Provisioning MySQL database...')
-        self.provision_mysql()
-        self.logger.info('Provisioning MongoDB databases...')
-        self.provision_mongo()
-        if self.storage_type == self.SWIFT_STORAGE:
-            self.logger.info('Provisioning Swift container...')
-            self.provision_swift()
-        elif self.storage_type == self.S3_STORAGE:
-            self.logger.info('Provisioning S3 bucket...')
-            self.provision_s3()
-        self.logger.info('Provisioning RabbitMQ vhost...')
-        self.provision_rabbitmq()
+        # FIXME: restore. This is just disabled because it's not needed to make the deployments fail
+        if 0:
+            if not self.load_balancing_server:
+                self.load_balancing_server = LoadBalancingServer.objects.select_random()
+                self.save()
+                self.reconfigure_load_balancer()
+    
+            # We unconditionally set the DNS records here, though this would only be strictly needed
+            # when the first AppServer is spawned.  However, there is no easy way to tell whether the
+            # DNS records have already been successfully set, and it doesn't hurt to always do it.
+            self.set_dns_records()
+    
+            # Provision external databases:
+            # TODO: Use db row-level locking to ensure we don't get any race conditions when creating these DBs.
+            # Use select_for_update(nowait=True) to lock this object's row, then do these steps, then refresh_from_db
+            self.logger.info('Provisioning MySQL database...')
+            self.provision_mysql()
+            self.logger.info('Provisioning MongoDB databases...')
+            self.provision_mongo()
+            if self.storage_type == self.SWIFT_STORAGE:
+                self.logger.info('Provisioning Swift container...')
+                self.provision_swift()
+            elif self.storage_type == self.S3_STORAGE:
+                self.logger.info('Provisioning S3 bucket...')
+                self.provision_s3()
+            self.logger.info('Provisioning RabbitMQ vhost...')
+            self.provision_rabbitmq()
 
         return self._create_owned_appserver()
 
@@ -311,6 +315,8 @@ class OpenEdXInstance(
 
         else:
             self.logger.error('Failed to provision new app server after {} attempts'.format(num_attempts))
+            # FIXME send e-mail here. Maybe pass the number of attempts. And maybe attach the e-mail-sending code into the signal instead
+            self.provision_failed_email()
             if failure_tag:
                 self.tags.add(failure_tag)
             if success_tag:

--- a/registration/approval.py
+++ b/registration/approval.py
@@ -89,7 +89,9 @@ def on_appserver_spawned(sender, **kwargs):
         return
 
     elif appserver is None:
-        # FIXME send instance failure e-mail here? This looks like a good place, since it happens after N attempts (not after each attempt). Clarify this (the function name isn't very clear now) and move the code here
+        # FIXME send instance failure e-mail here?
+        # FIXME (cont): This looks like a good place, since it happens after N attempts (not after each attempt).
+        # FIXME (cont): Clarify this (the function name isn't very clear now) and move the code here
 
         raise ApplicationNotReady('Provisioning of AppServer failed.')
 

--- a/registration/approval.py
+++ b/registration/approval.py
@@ -89,6 +89,8 @@ def on_appserver_spawned(sender, **kwargs):
         return
 
     elif appserver is None:
+        # FIXME send instance failure e-mail here? This looks like a good place, since it happens after N attempts (not after each attempt). Clarify this (the function name isn't very clear now) and move the code here
+
         raise ApplicationNotReady('Provisioning of AppServer failed.')
 
     else:


### PR DESCRIPTION
This code replaces the deployment failure e-mails, so that instead of being 1 per deployment attempt, they become 1 after all deployment attempts have been used.

Closed in favour of https://github.com/open-craft/opencraft/pull/515, which adds a new e-mail type instead of replacing the existing one.