### PR TITLE
BB-2026: Add new authentication endpoints

### DIFF
--- a/api/auth.py
+++ b/api/auth.py
@@ -43,8 +43,8 @@ class TokenSerializer(serializers.Serializer):
         "refresh": "<TOKEN>",
     }
     """
-    refresh = serializers.CharField(required=False)
-    access = serializers.CharField(required=False)
+    refresh = serializers.CharField()
+    access = serializers.CharField()
 
 
 class TokenErrorSerializer(serializers.Serializer):

--- a/api/auth.py
+++ b/api/auth.py
@@ -24,7 +24,11 @@ JWT Auth overrides to generate swagger models
 from drf_yasg.utils import swagger_auto_schema
 from rest_framework import serializers
 
-from rest_framework_simplejwt.views import TokenObtainPairView
+from rest_framework_simplejwt.views import (
+    TokenObtainPairView,
+    TokenRefreshView,
+    TokenVerifyView,
+)
 
 
 class TokenSerializer(serializers.Serializer):
@@ -39,8 +43,8 @@ class TokenSerializer(serializers.Serializer):
         "refresh": "<TOKEN>",
     }
     """
-    refresh = serializers.CharField()
-    access = serializers.CharField()
+    refresh = serializers.CharField(required=False)
+    access = serializers.CharField(required=False)
 
 
 class TokenErrorSerializer(serializers.Serializer):
@@ -49,20 +53,43 @@ class TokenErrorSerializer(serializers.Serializer):
 
     This overrides the serializer returned by the JSON library and
     fixes the generated swagger schema.
-    Desired return format:
     {
-        "details": "error"
+        "detail": "error",
+        "code": "error"
     }
     """
-    details = serializers.CharField()
+    detail = serializers.CharField(required=False)
+    code = serializers.CharField(required=False)
 
 
 class JWTAuthToken(TokenObtainPairView):
     """
-    JWTAuthToken - for swagger
+    Generate a JWT auth token from user credentials.
 
     This overrides the method just to add the Swagger schema overrides
     """
-    @swagger_auto_schema(responses={201: TokenSerializer, 491: TokenErrorSerializer})
+    @swagger_auto_schema(responses={201: TokenSerializer, 401: TokenErrorSerializer})
     def post(self, *args, **kwargs):
         return super(JWTAuthToken, self).post(*args, **kwargs)
+
+
+class JwtTokenRefresh(TokenRefreshView):
+    """
+    Refresh a JWT auth token from refresh token.
+
+    This overrides the method just to add the Swagger schema overrides
+    """
+    @swagger_auto_schema(responses={201: TokenSerializer, 401: TokenErrorSerializer})
+    def post(self, *args, **kwargs):
+        return super(JwtTokenRefresh, self).post(*args, **kwargs)
+
+
+class JwtTokenVerify(TokenVerifyView):
+    """
+    Check if a JWT auth token is valid.
+
+    This overrides the method just to add the Swagger schema overrides
+    """
+    @swagger_auto_schema(responses={201: None, 401: TokenErrorSerializer})
+    def post(self, *args, **kwargs):
+        return super(JwtTokenVerify, self).post(*args, **kwargs)

--- a/api/urls.py
+++ b/api/urls.py
@@ -27,7 +27,7 @@ from django.views.generic.base import RedirectView
 from drf_yasg.views import get_schema_view
 from rest_framework.permissions import AllowAny
 
-from api.auth import JWTAuthToken
+from api.auth import JWTAuthToken, JwtTokenRefresh, JwtTokenVerify
 from api.router import v1_router, v2_router
 from opencraft.swagger import api_info
 
@@ -51,11 +51,10 @@ urlpatterns = [
     # v2 urls
     url(r'^v2/', include((v2_router.urls, 'api_v2'), namespace='v2')),
     url(r'^v2/auth/token/', JWTAuthToken.as_view(), name='token_obtain_pair'),
-    # These two endpoints need to be re-added when building the console
     # They are required to check if the token is valid and to refresh the access
     # token and allow a session that lasts more than a few minutes
-    # url(r'^v2/auth/refresh/', TokenRefreshView.as_view(), name='token_refresh'),
-    # url(r'^v2/auth/verify/', TokenVerifyView.as_view(), name='token_verify'),
+    url(r'^v2/auth/refresh/', JwtTokenRefresh.as_view(), name='token_refresh'),
+    url(r'^v2/auth/verify/', JwtTokenVerify.as_view(), name='token_verify'),
     # Documentation
     url(r'^swagger(?P<format>\.json|\.yaml)$', schema_view.without_ui(cache_timeout=10), name='schema-json'),
     url(r'^swagger/$', schema_view.with_ui('swagger', cache_timeout=10), name='schema-swagger-ui'),

--- a/frontend/packages/api_client/src/apis/V2Api.ts
+++ b/frontend/packages/api_client/src/apis/V2Api.ts
@@ -33,6 +33,12 @@ import {
     TokenObtainPair,
     TokenObtainPairFromJSON,
     TokenObtainPairToJSON,
+    TokenRefresh,
+    TokenRefreshFromJSON,
+    TokenRefreshToJSON,
+    TokenVerify,
+    TokenVerifyFromJSON,
+    TokenVerifyToJSON,
     ValidationError,
     ValidationErrorFromJSON,
     ValidationErrorToJSON,
@@ -52,8 +58,16 @@ export interface AccountsUpdateRequest {
     data: Account;
 }
 
+export interface AuthRefreshCreateRequest {
+    data: TokenRefresh;
+}
+
 export interface AuthTokenCreateRequest {
     data: TokenObtainPair;
+}
+
+export interface AuthVerifyCreateRequest {
+    data: TokenVerify;
 }
 
 export interface InstancesOpenedxConfigCommitChangesRequest {
@@ -259,6 +273,50 @@ export class V2Api extends runtime.BaseAPI {
     }
 
     /**
+     * This overrides the method just to add the Swagger schema overrides
+     * Refresh a JWT auth token from refresh token.
+     */
+    async authRefreshCreateRaw(requestParameters: AuthRefreshCreateRequest): Promise<runtime.ApiResponse<Token>> {
+        if (requestParameters.data === null || requestParameters.data === undefined) {
+            throw new runtime.RequiredError('data','Required parameter requestParameters.data was null or undefined when calling authRefreshCreate.');
+        }
+
+        const queryParameters: runtime.HTTPQuery = {};
+
+        const headerParameters: runtime.HTTPHeaders = {};
+
+        headerParameters['Content-Type'] = 'application/json';
+
+        if (this.configuration && this.configuration.apiKey) {
+            headerParameters["Authorization"] = this.configuration.apiKey("Authorization"); // api_key authentication
+        }
+
+        if (this.configuration && (this.configuration.username !== undefined || this.configuration.password !== undefined)) {
+            headerParameters["Authorization"] = "Basic " + btoa(this.configuration.username + ":" + this.configuration.password);
+        }
+        const response = await this.request({
+            path: `/v2/auth/refresh/`,
+            method: 'POST',
+            headers: headerParameters,
+            query: queryParameters,
+            body: TokenRefreshToJSON(requestParameters.data),
+        });
+
+        return new runtime.JSONApiResponse(response, (jsonValue) => TokenFromJSON(jsonValue));
+    }
+
+    /**
+     * This overrides the method just to add the Swagger schema overrides
+     * Refresh a JWT auth token from refresh token.
+     */
+    async authRefreshCreate(requestParameters: AuthRefreshCreateRequest): Promise<Token> {
+        const response = await this.authRefreshCreateRaw(requestParameters);
+        return await response.value();
+    }
+
+    /**
+     * This overrides the method just to add the Swagger schema overrides
+     * Generate a JWT auth token from user credentials.
      */
     async authTokenCreateRaw(requestParameters: AuthTokenCreateRequest): Promise<runtime.ApiResponse<Token>> {
         if (requestParameters.data === null || requestParameters.data === undefined) {
@@ -290,10 +348,53 @@ export class V2Api extends runtime.BaseAPI {
     }
 
     /**
+     * This overrides the method just to add the Swagger schema overrides
+     * Generate a JWT auth token from user credentials.
      */
     async authTokenCreate(requestParameters: AuthTokenCreateRequest): Promise<Token> {
         const response = await this.authTokenCreateRaw(requestParameters);
         return await response.value();
+    }
+
+    /**
+     * This overrides the method just to add the Swagger schema overrides
+     * Check if a JWT auth token is valid.
+     */
+    async authVerifyCreateRaw(requestParameters: AuthVerifyCreateRequest): Promise<runtime.ApiResponse<void>> {
+        if (requestParameters.data === null || requestParameters.data === undefined) {
+            throw new runtime.RequiredError('data','Required parameter requestParameters.data was null or undefined when calling authVerifyCreate.');
+        }
+
+        const queryParameters: runtime.HTTPQuery = {};
+
+        const headerParameters: runtime.HTTPHeaders = {};
+
+        headerParameters['Content-Type'] = 'application/json';
+
+        if (this.configuration && this.configuration.apiKey) {
+            headerParameters["Authorization"] = this.configuration.apiKey("Authorization"); // api_key authentication
+        }
+
+        if (this.configuration && (this.configuration.username !== undefined || this.configuration.password !== undefined)) {
+            headerParameters["Authorization"] = "Basic " + btoa(this.configuration.username + ":" + this.configuration.password);
+        }
+        const response = await this.request({
+            path: `/v2/auth/verify/`,
+            method: 'POST',
+            headers: headerParameters,
+            query: queryParameters,
+            body: TokenVerifyToJSON(requestParameters.data),
+        });
+
+        return new runtime.VoidApiResponse(response);
+    }
+
+    /**
+     * This overrides the method just to add the Swagger schema overrides
+     * Check if a JWT auth token is valid.
+     */
+    async authVerifyCreate(requestParameters: AuthVerifyCreateRequest): Promise<void> {
+        await this.authVerifyCreateRaw(requestParameters);
     }
 
     /**

--- a/frontend/packages/api_client/src/models/Token.ts
+++ b/frontend/packages/api_client/src/models/Token.ts
@@ -24,13 +24,13 @@ export interface Token {
      * @type {string}
      * @memberof Token
      */
-    refresh: string;
+    refresh?: string;
     /**
      * 
      * @type {string}
      * @memberof Token
      */
-    access: string;
+    access?: string;
 }
 
 export function TokenFromJSON(json: any): Token {
@@ -43,8 +43,8 @@ export function TokenFromJSONTyped(json: any, ignoreDiscriminator: boolean): Tok
     }
     return {
         
-        'refresh': json['refresh'],
-        'access': json['access'],
+        'refresh': !exists(json, 'refresh') ? undefined : json['refresh'],
+        'access': !exists(json, 'access') ? undefined : json['access'],
     };
 }
 

--- a/frontend/packages/api_client/src/models/Token.ts
+++ b/frontend/packages/api_client/src/models/Token.ts
@@ -24,13 +24,13 @@ export interface Token {
      * @type {string}
      * @memberof Token
      */
-    refresh?: string;
+    refresh: string;
     /**
      * 
      * @type {string}
      * @memberof Token
      */
-    access?: string;
+    access: string;
 }
 
 export function TokenFromJSON(json: any): Token {
@@ -43,8 +43,8 @@ export function TokenFromJSONTyped(json: any, ignoreDiscriminator: boolean): Tok
     }
     return {
         
-        'refresh': !exists(json, 'refresh') ? undefined : json['refresh'],
-        'access': !exists(json, 'access') ? undefined : json['access'],
+        'refresh': json['refresh'],
+        'access': json['access'],
     };
 }
 

--- a/frontend/packages/api_client/src/models/TokenError.ts
+++ b/frontend/packages/api_client/src/models/TokenError.ts
@@ -24,7 +24,13 @@ export interface TokenError {
      * @type {string}
      * @memberof TokenError
      */
-    details: string;
+    detail?: string;
+    /**
+     * 
+     * @type {string}
+     * @memberof TokenError
+     */
+    code?: string;
 }
 
 export function TokenErrorFromJSON(json: any): TokenError {
@@ -37,7 +43,8 @@ export function TokenErrorFromJSONTyped(json: any, ignoreDiscriminator: boolean)
     }
     return {
         
-        'details': json['details'],
+        'detail': !exists(json, 'detail') ? undefined : json['detail'],
+        'code': !exists(json, 'code') ? undefined : json['code'],
     };
 }
 
@@ -50,7 +57,8 @@ export function TokenErrorToJSON(value?: TokenError | null): any {
     }
     return {
         
-        'details': value.details,
+        'detail': value.detail,
+        'code': value.code,
     };
 }
 

--- a/frontend/packages/api_client/src/models/index.ts
+++ b/frontend/packages/api_client/src/models/index.ts
@@ -10,5 +10,7 @@ export * from './SpawnAppServer';
 export * from './Token';
 export * from './TokenError';
 export * from './TokenObtainPair';
+export * from './TokenRefresh';
+export * from './TokenVerify';
 export * from './ValidationError';
 export * from './WatchedPullRequest';


### PR DESCRIPTION
This PR adds refresh and verify endpoints and update frontend API client.

**Testing instructions:**
1. Checkout this branch.
2. Run Ocim using `make run.dev`.
3. Go to the Swagger API docs (http://localhost:5000/api/swagger/) and check that the following endpoints exist and are correctly specified:
- /v2/auth/verify/
- /v2/auth/refresh/
4. Test the endpoints using the browser client.
5. Go into the frontend folder and update the API client using the following command:
```
./scripts/build-api-client.sh
```
6. Run the frontend: `npm run start`
7. Access the page and open the browser console. Test the API client from there.
![2020-01-14_16-59](https://user-images.githubusercontent.com/27893385/72377970-399e9800-36ef-11ea-810e-83045e9c103c.png)


**Reviewer:**
- [ ] @xitij2000 