### PR TITLE
[BB-2006] Use a separate variable for the default fallback domain in Gandi account

### DIFF
--- a/documentation/configuration.md
+++ b/documentation/configuration.md
@@ -215,6 +215,8 @@ Required settings:
 * `DEFAULT_DISCOVERY_DOMAIN_PREFIX`: String to prepend to internal LMS domain when
   generating the Course Discovery domain (default: `"discovery-"`)
 * `GANDI_API_KEY`: Your Gandi API key (required)
+* `GANDI_DEFAULT_BASE_DOMAIN`: The base domain owned in the Gandi account if the `DEFAULT_INSTANCE_BASE_DOMAIN`
+  its sub-domain. (optional, default: `DEFAULT_INSTANCE_BASE_DOMAIN`).
 
 ### GitHub settings
 

--- a/instance/gandi.py
+++ b/instance/gandi.py
@@ -221,9 +221,9 @@ class GandiV5API:
             logger.warning(
                 'Using the default instance base domain %s as the fallback. '
                 'This will not work if the API key has no permission to manage the DNS records for this domain',
-                settings.DEFAULT_INSTANCE_BASE_DOMAIN
+                settings.GANDI_DEFAULT_BASE_DOMAIN
             )
-            self._domain_cache = [settings.DEFAULT_INSTANCE_BASE_DOMAIN]
+            self._domain_cache = [settings.GANDI_DEFAULT_BASE_DOMAIN]
 
     def _split_domain_name(self, domain):
         """

--- a/instance/tests/test_gandi.py
+++ b/instance/tests/test_gandi.py
@@ -25,6 +25,8 @@ Gandi - Tests
 from unittest.mock import call, MagicMock, patch
 import xmlrpc.client
 
+from django.conf import settings
+
 from instance import gandi
 from instance.gandi import GandiV5API
 from instance.tests.base import TestCase
@@ -196,6 +198,18 @@ class GandiV5TestCase(TestCase):
         mocked_get.return_value = mock_response
         self.api._populate_domain_cache()
         assert self.api._domain_cache == ['test.com', 'example.com']
+
+    @patch('instance.gandi.requests.get')
+    def test_populate_domain_cache_empty_result_from_api_call(self, mocked_get):
+        """
+        Test that settings.GANDI_DEFAULT_BASE_DOMAIN is added to the domain cache when the API
+        returns an empty list of domains.
+        """
+        mock_response = MagicMock()
+        mock_response.json.return_value = []
+        mocked_get.return_value = mock_response
+        self.api._populate_domain_cache()
+        assert self.api._domain_cache == [settings.GANDI_DEFAULT_BASE_DOMAIN]
 
     def test_split_domain_name(self):
         """

--- a/opencraft/settings.py
+++ b/opencraft/settings.py
@@ -320,12 +320,6 @@ DEFAULT_RABBITMQ_API_URL = env('DEFAULT_RABBITMQ_API_URL', default=None)
 # This rate is per user per day in euros
 BILLING_RATE = env('BILLING_RATE', default=3)
 
-# DNS (Gandi) #################################################################
-
-# See https://www.gandi.net/admin/api_key
-GANDI_API_KEY = env('GANDI_API_KEY')
-
-
 # GitHub - Forks & organizations ##############################################
 
 # The worker queue will watch for PRs from members of a given organization
@@ -496,6 +490,17 @@ SIMPLE_THEME_SKELETON_THEME_REPO = env(
     default='https://github.com/open-craft/edx-simple-theme/'
 )
 SIMPLE_THEME_SKELETON_THEME_VERSION = env('SIMPLE_THEME_SKELETON_THEME_VERSION', default='master')
+
+# DNS (Gandi) #################################################################
+
+# See https://doc.livedns.gandi.net/
+GANDI_API_KEY = env('GANDI_API_KEY')
+
+# The base domain to use as a fallback when the list of domains in the account returned by the Gandi
+# API is empty. This should be explicitly set only when  the 'DEFAULT_INSTANCE_BASE_DOMAIN' is not a
+# domain listed in the Gandi account and is instead a sub-domain. For example, 'stage.ocim.domain' where
+# 'ocim.domain' is the domain registered in the Gandi account.
+GANDI_DEFAULT_BASE_DOMAIN = env('GANDI_DEFAULT_BASE_DOMAIN', default=DEFAULT_INSTANCE_BASE_DOMAIN)
 
 # Ansible #####################################################################
 


### PR DESCRIPTION
This will be needed when the 'DEFAULT_INSTANCE_BASE_DOMAIN' is not
set to the base domain present in the Gandi account.

**Testing instructions**:
* In the stage environment, set the `GANDI_DEFAULT_BASE_DOMAIN` environment variable and verify that the DNS records for an instance are created properly as subdomains of the stage subdomain and not directly as the subdomains of the production domain. 