### PR TITLE
SE-2121 Don't filter custom domains for load balancer

### DIFF
--- a/instance/models/mixins/domain_names.py
+++ b/instance/models/mixins/domain_names.py
@@ -168,7 +168,7 @@ class DomainNameInstance(models.Model):
 
     def get_custom_domains(self):
         """
-        Returns a list of custom sub-domains configured for the instance.
+        Returns a list of custom (internal) sub-domains configured for the instance.
         """
         return [
             domain for domain in self.extra_custom_domains.split("\r\n") if domain.endswith(self.internal_lms_domain)

--- a/instance/models/mixins/domain_names.py
+++ b/instance/models/mixins/domain_names.py
@@ -191,7 +191,7 @@ class DomainNameInstance(models.Model):
             self.internal_ecommerce_domain,
         ]
         custom_domains = self.extra_custom_domains.split("\r\n")
-        domain_names += [domain for domain in custom_domains if domain.endswith(self.internal_lms_domain)]
+        domain_names.extend(custom_domains)
         return [name for name in domain_names if name]
 
     def get_managed_domains(self):


### PR DESCRIPTION
This will allow adding extra external domains to be handled by the load
balancer. We don't remove filtering for other areas, because we don't
want to manage dns, etc. for external domains.

**Test instructions**:

- deploy to stage
- choose an openedx instance to test against
- set up dns (cname or A record) for an external domain to point to that instance 
- add the external domain to the extra custom domains list for the instance
- verify that this extra custom domain is added to the load balancer and points to the instance

**Reviewer**:

- [x] @symbolist 