### PR TITLE
[SE-2216] Deprovision RabbitMQ when archiving instance.

### DIFF
--- a/instance/management/commands/archive_instances.py
+++ b/instance/management/commands/archive_instances.py
@@ -102,7 +102,6 @@ class Command(BaseCommand):
         """
         try:
             instance.archive()
-            instance.deprovision_rabbitmq()
             return True
         except Exception:  # noqa
             tb = traceback.format_exc()

--- a/instance/models/openedx_instance.py
+++ b/instance/models/openedx_instance.py
@@ -448,6 +448,7 @@ class OpenEdXInstance(
             self.reconfigure_load_balancer(load_balancer)
         for appserver in self.appserver_set.iterator():
             appserver.terminate_vm()
+        self.deprovision_rabbitmq()
         self.purge_consul_metadata()
         super().archive()
         self.logger.info('Archiving instance finished.')
@@ -549,7 +550,7 @@ class OpenEdXInstance(
         :return: A pair (version, changed) with the current version number and
                  a bool to indicate whether the information was updated.
         """
-        if not settings.CONSUL_ENABLED:
+        if not settings.CONSUL_ENABLED or self.ref.is_archived:
             return 0, False
 
         new_configurations = self._generate_consul_metadata()


### PR DESCRIPTION
This PR implements the following changes to fix a problem when metadata for archived instances would remain present in consul:

- Deprovision RabbitMQ when `instance.archive()`.
- Remove explicit call to deprovision RabbitMQ from the `archive_instances` management command.
- Make sure that consul metadata does not get written if instance is archived.

**Test instructions**:

For these to work the Ocim installation where you are testing needs to have Consul enabled. I suggest testing on Ocim stage where I have deployed the changes from this PR.

1. Create a new instance and spawn at least one appserver.
2. In the django shell, verify that consul contains metadata for this instance: `from instance.models.utils import ConsulAgent`, then `ConsulAgent(prefix=instance.consul_prefix).get('')`.
3. Verify that RabbitMQ vhost for the instance exists: `instance._rabbitmq_request('get', 'vhosts', instance.rabbitmq_vhost).json()` should return metadata about the vhost.
4. Issue `instance.archive()`.
5. Verify that the metadata from consul has been purged: `ConsulAgent(prefix=instance.consul_prefix).get('')` should return `None`.
6. Verify that the RabbitMQ vhost has been deleted: `instance._rabbitmq_request('get', 'vhosts', instance.rabbitmq_vhost).json()` should raise a 404 error.

Repeat the above procedure with a new test instance, but this time instead of explicitly invoking `instance.archive()`, use the management command to archive the instance:

```
make manage 'archive_instances domains=mytestinstance.stage.opencraft.hosting'
```