### PR TITLE
BB-2179: Registration form and welcome email fixes.

### DIFF
--- a/opencraft/settings.py
+++ b/opencraft/settings.py
@@ -830,7 +830,10 @@ SELF_SERVICE_SPAWN_RETRY_ATTEMPTS = env('SELF_SERVICE_SPAWN_RETRY_ATTEMPTS', def
 
 # User Console - React SPA
 # This is used to handle redirects from validation links back to the SPA
-USER_CONSOLE_FRONTEND_URL = env('USER_CONSOLE_FRONTEND_URL', default='https://app.console.opencraft.com')
+USER_CONSOLE_FRONTEND_URL = env(
+    'USER_CONSOLE_FRONTEND_URL',
+    default='http://localhost:3000/console'
+)
 
 # CORS Settings - https://github.com/adamchainz/django-cors-headers
 CORS_ORIGIN_REGEX_WHITELIST = [

--- a/opencraft/settings.py
+++ b/opencraft/settings.py
@@ -80,6 +80,15 @@ AUTH_PASSWORD_VALIDATORS = [
     {
         'NAME': 'django.contrib.auth.password_validation.NumericPasswordValidator',
     },
+    {
+        'NAME': 'registration.validators.UppercaseValidator',
+    },
+    {
+        'NAME': 'registration.validators.LowercaseValidator',
+    },
+    {
+        'NAME': 'registration.validators.SymbolValidator',
+    },
 ]
 
 # Database ####################################################################

--- a/registration/tests/test_api.py
+++ b/registration/tests/test_api.py
@@ -48,7 +48,7 @@ class AccountAPITestCase(APITestCase):
         self.user.profile.save()
         self.user_data = {
             "username": "another.user",
-            "password": "thisisapassword",
+            "password": "Thisisapassword123()",
             "email": "another.user@some.domain",
         }
         self.profile_data = {
@@ -82,6 +82,7 @@ class AccountAPITestCase(APITestCase):
             data=data,
             format="json",
         )
+        import pdb; pdb.set_trace()
         self.assertEqual(response.status_code, 201)
         new_user_query = User.objects.filter(username=self.user_data.get('username'))
         self.assertTrue(new_user_query.exists())
@@ -103,6 +104,8 @@ class AccountAPITestCase(APITestCase):
         ({"password": None}),
         ({"password": "invalid"}),
         ({"password": "password123"}),
+        ({"password": "INVALID"}),
+        ({"password": "MissingSp3ci4lChars"}),
         ({"accepted_privacy_policy": None}),
         ({"accepted_privacy_policy": timezone.now() + timezone.timedelta(days=2)}),
         ({"accept_paid_support": False}),
@@ -215,11 +218,11 @@ class AccountAPITestCase(APITestCase):
         """
         self.client.force_login(self.user)
         url = reverse("api:v2:accounts-detail", kwargs={'username': self.user.username})
-        response = self.client.patch(url, data={"password": "newvalidpassword"}, format="json")
+        response = self.client.patch(url, data={"password": "NewV4l1dPw()"}, format="json")
         self.assertEqual(response.status_code, 200)
         self.user.refresh_from_db()
         # Should be able to log in with the new credentials
-        self.assertTrue(self.client.login(username='test.user', password='newvalidpassword'))
+        self.assertTrue(self.client.login(username='test.user', password='NewV4l1dPw()'))
 
 
 @ddt.ddt

--- a/registration/tests/test_api.py
+++ b/registration/tests/test_api.py
@@ -82,7 +82,6 @@ class AccountAPITestCase(APITestCase):
             data=data,
             format="json",
         )
-        import pdb; pdb.set_trace()
         self.assertEqual(response.status_code, 201)
         new_user_query = User.objects.filter(username=self.user_data.get('username'))
         self.assertTrue(new_user_query.exists())

--- a/registration/utils.py
+++ b/registration/utils.py
@@ -50,8 +50,7 @@ def send_welcome_email(application: BetaTestApplication) -> None:
         user_name=user.profile.full_name,
         lms_link=application.instance.get_domain('lms'),
         studio_link=application.instance.get_domain('studio'),
-        # TODO: add in once implemented
-        customise_link='',
+        customise_link=settings.USER_CONSOLE_FRONTEND_URL,
     )
     html_email_helper(
         template_base_name='emails/welcome_email',

--- a/registration/validators.py
+++ b/registration/validators.py
@@ -27,7 +27,7 @@ class UppercaseValidator:
     Uppercase password validator
     """
     def validate(self, password, user=None):  # pylint: disable=missing-docstring
-        if not re.findall('[A-Z]', password):
+        if not re.findall('r[A-Z]', password):
             raise ValidationError(
                 "The password must contain at least 1 uppercase letter, A-Z.",
                 code='password_no_upper',
@@ -42,7 +42,7 @@ class LowercaseValidator:
     Lowercase password validator
     """
     def validate(self, password, user=None):  # pylint: disable=missing-docstring
-        if not re.findall('[a-z]', password):
+        if not re.findall('r[a-z]', password):
             raise ValidationError(
                 "The password must contain at least 1 lowercase letter, a-z.",
                 code='password_no_lower',
@@ -57,7 +57,7 @@ class SymbolValidator:
     Symbol password validator
     """
     def validate(self, password, user=None):  # pylint: disable=missing-docstring
-        if not re.findall('[,.\\!~`<>\/!?:;"+=\-%\'$&@#{}()_]', password):
+        if not re.findall(r'[,.\\!~`<>\/!?:;"+=\-%\'$&@#{}()_]', password):
             raise ValidationError(
                 "The password must contain at least 1 special character.",
                 code='password_no_special_chars',

--- a/registration/validators.py
+++ b/registration/validators.py
@@ -27,7 +27,7 @@ class UppercaseValidator:
     Uppercase password validator
     """
     def validate(self, password, user=None):  # pylint: disable=missing-docstring
-        if not re.findall('r[A-Z]', password):
+        if not re.findall('[A-Z]', password):
             raise ValidationError(
                 "The password must contain at least 1 uppercase letter, A-Z.",
                 code='password_no_upper',
@@ -42,7 +42,7 @@ class LowercaseValidator:
     Lowercase password validator
     """
     def validate(self, password, user=None):  # pylint: disable=missing-docstring
-        if not re.findall('r[a-z]', password):
+        if not re.findall('[a-z]', password):
             raise ValidationError(
                 "The password must contain at least 1 lowercase letter, a-z.",
                 code='password_no_lower',

--- a/registration/validators.py
+++ b/registration/validators.py
@@ -23,7 +23,10 @@ from django.core.exceptions import ValidationError
 
 
 class UppercaseValidator:
-    def validate(self, password, user=None):
+    """
+    Uppercase password validator
+    """
+    def validate(self, password, user=None):  # pylint: disable=missing-docstring
         if not re.findall('[A-Z]', password):
             raise ValidationError(
                 "The password must contain at least 1 uppercase letter, A-Z.",
@@ -35,7 +38,10 @@ class UppercaseValidator:
 
 
 class LowercaseValidator:
-    def validate(self, password, user=None):
+    """
+    Lowercase password validator
+    """
+    def validate(self, password, user=None):  # pylint: disable=missing-docstring
         if not re.findall('[a-z]', password):
             raise ValidationError(
                 "The password must contain at least 1 lowercase letter, a-z.",
@@ -47,7 +53,10 @@ class LowercaseValidator:
 
 
 class SymbolValidator:
-    def validate(self, password, user=None):
+    """
+    Symbol password validator
+    """
+    def validate(self, password, user=None):  # pylint: disable=missing-docstring
         if not re.findall('[,.<>/?:;"-+=%$&@#]', password):
             raise ValidationError(
                 "The password must contain at least 1 special character.",

--- a/registration/validators.py
+++ b/registration/validators.py
@@ -57,10 +57,10 @@ class SymbolValidator:
     Symbol password validator
     """
     def validate(self, password, user=None):  # pylint: disable=missing-docstring
-        if not re.findall('[,.<>/?:;"-+=%$&@#]', password):
+        if not re.findall('[,.<>/?:;"-+=%$&@#{}()]', password):
             raise ValidationError(
                 "The password must contain at least 1 special character.",
-                code='password_no_lower',
+                code='password_no_special_chars',
             )
 
     def get_help_text(self):  # pylint: disable=missing-docstring

--- a/registration/validators.py
+++ b/registration/validators.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+#
+# OpenCraft -- tools to aid developing and hosting free software projects
+# Copyright (C) 2015-2019 OpenCraft <xavier@opencraft.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+"""Custom password validators for users."""
+
+import re
+from django.core.exceptions import ValidationError
+
+
+class UppercaseValidator:
+    def validate(self, password, user=None):
+        if not re.findall('[A-Z]', password):
+            raise ValidationError(
+                "The password must contain at least 1 uppercase letter, A-Z.",
+                code='password_no_upper',
+            )
+
+    def get_help_text(self):
+        return "Your password must contain at least 1 uppercase letter, A-Z."
+
+
+class LowercaseValidator:
+    def validate(self, password, user=None):
+        if not re.findall('[a-z]', password):
+            raise ValidationError(
+                "The password must contain at least 1 lowercase letter, a-z.",
+                code='password_no_lower',
+            )
+
+    def get_help_text(self):
+        return "Your password must contain at least 1 lowercase letter, a-z."
+
+
+class SymbolValidator:
+    def validate(self, password, user=None):
+        if not re.findall('[,.<>/?:;"-+=%$&@#]', password):
+            raise ValidationError(
+                "The password must contain at least 1 special character.",
+                code='password_no_lower',
+            )
+
+    def get_help_text(self):
+        return "Your password must contain at least 1 special character."

--- a/registration/validators.py
+++ b/registration/validators.py
@@ -57,7 +57,7 @@ class SymbolValidator:
     Symbol password validator
     """
     def validate(self, password, user=None):  # pylint: disable=missing-docstring
-        if not re.findall('[,.<>/?:;"-+=%$&@#{}()]', password):
+        if not re.findall('[,.\\!~`<>\/!?:;"+=\-%\'$&@#{}()_]', password):
             raise ValidationError(
                 "The password must contain at least 1 special character.",
                 code='password_no_special_chars',

--- a/registration/validators.py
+++ b/registration/validators.py
@@ -33,7 +33,7 @@ class UppercaseValidator:
                 code='password_no_upper',
             )
 
-    def get_help_text(self):
+    def get_help_text(self):  # pylint: disable=missing-docstring
         return "Your password must contain at least 1 uppercase letter, A-Z."
 
 
@@ -48,7 +48,7 @@ class LowercaseValidator:
                 code='password_no_lower',
             )
 
-    def get_help_text(self):
+    def get_help_text(self):  # pylint: disable=missing-docstring
         return "Your password must contain at least 1 lowercase letter, a-z."
 
 
@@ -63,5 +63,5 @@ class SymbolValidator:
                 code='password_no_lower',
             )
 
-    def get_help_text(self):
+    def get_help_text(self):  # pylint: disable=missing-docstring
         return "Your password must contain at least 1 special character."

--- a/templates/emails/welcome_email.html
+++ b/templates/emails/welcome_email.html
@@ -25,10 +25,10 @@
         </tr>
         <tr class="text">
             <td>
-                Login as a student to see what your instance would look like.
+                Log into the learning management system.
             </td>
             <td>
-                Login as an educator and start creating courses.
+                Log into the Studio course authoring platform.
             </td>
             <td>
                 Customize your instance to align with your institutions's look and feel.
@@ -46,9 +46,15 @@
                 </a>
             </td>
             <td>
-                <a href="{{ customise_link }}">
-                    Customize
-                </a>
+                {% if customise_link %}
+                    <a href="{{ customise_link }}">
+                        Customize
+                    </a>
+                {% else %}
+                    <a>
+                        Coming soon
+                    </a>
+                {% endif %}
             </td>
         </tr>
     </table>


### PR DESCRIPTION
This PR introduces 2 changes:
1. Fixes broken link on welcome email and add support for empty link.
2. Add custom password validators.

**Testing instructions:**
1. Checkout this branch.
2. Set up some email configuration in `.env`.
```
EMAIL_BACKEND='django.core.mail.backends.smtp.EmailBackend'
EMAIL_HOST=smtp.gmail.com
EMAIL_USE_TLS=True
EMAIL_PORT=587
EMAIL_HOST_USER=your_email@opencraft.com
EMAIL_HOST_PASSWORD=
```
3. Run Ocim and create a betatest instance (no need to activate emails).
4. Run `make shell` and then the following commands:
```
from registration.utils import send_welcome_email
from registration.models import BetaTestApplication

# Pick the betatest instance that you created here (the user email must be valid)
x = BetaTestApplication.objects.all()[0] 
send_welcome_email(x)                                                                            
```
5. Open the email and check that the `Customize` link has a link to localhost.
6. Exit shell, change `USER_CONSOLE_FRONTEND_URL` to an empty string (in `.env` file).
7. Run step 4 and check if the email has a "Coming soon" button instead of "Customize".
8. Check if password validators are working properly using:
- Swagger API
- Old registration form
- New registration form
- Django Admin

**Reviewer:** 
- [ ] @lgp171188 
