### PR TITLE
SE-2413 Fixes formatting on the rendered documentation How To page

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -171,6 +171,12 @@ test: clean test.quality test.unit test.migrations_missing test.js test.browser 
 test.one: clean
 	$(HONCHO_MANAGE_TESTS) test $(RUN_ARGS)
 
+docs:
+	mkdocs build -f mkdocs.yml
+
+docs-serve:
+	mkdocs serve -f mkdocs.yml -a localhost:5001
+
 # Files #######################################################################
 
 static_external:

--- a/documentation/howtos.md
+++ b/documentation/howtos.md
@@ -1,17 +1,14 @@
-### Configuring ecommerce and Course Discovery
+## Configuring Ecommerce and Course Discovery
 
-By default, instances are not provisioned with either ecommerce or the Course Discovery
-service. However, support is available to manually enable those services. To do so:
+By default, instances are not provisioned with either ecommerce or the Course Discovery service. However, support is available to manually enable those services.
 
-* Ensure that the [`refresh_course_metadata` cron task](https://github.com/open-craft/configuration/blob/c1e576eabefea82d21d7785810126e39752cd14e/playbooks/roles/discovery/tasks/main.yml)
-  is added to the ansible discovery tasks. If using a configuration revision
-  that doesn't include this, the following extra cronjob can be added to extra
-  configuration:
+### Ocim instance extra configuration
 
-```
-# must add as root cronjob, even though we want to run the task as the
-# discovery user, because these cronjobs are added before the discovery user is
-# created.
+*  Ensure that the [`refresh_course_metadata` cron task](https://github.com/open-craft/configuration/blob/c1e576eabefea82d21d7785810126e39752cd14e/playbooks/roles/discovery/tasks/main.yml)
+   is added to the ansible discovery tasks. If using a configuration revision that doesn't include this, the following extra cronjob can be added to extra configuration:
+
+```yaml
+# must add as root cronjob, even though we want to run the task as the discovery user, because these cronjobs are added before the discovery user is created.
 EDXAPP_ADDITIONAL_CRON_JOBS:
 - name: "discovery: hourly course metadata refresh"
   user: "root"
@@ -19,10 +16,8 @@ EDXAPP_ADDITIONAL_CRON_JOBS:
   hour: "*"
   minute: "43"
   day: "*"
-# update_index is required but isn't currently part of the provisioning
-# process. So in the interests of saving time, this is run every 10 minutes
-# through cron (it's not an expensive operation). TODO: remove this once
-# update_index is part of provisioning.
+# update_index is required but isn't currently part of the provisioning process. So in the interests of saving time, this is run every 10 minutes through cron (it's not an expensive operation).
+# TODO: remove this once update_index is part of provisioning.
 - name: "discovery: update_index"
   user: "root"
   job: "sudo -u discovery bash -c 'source {{ discovery_home }}/discovery_env; {{ COMMON_BIN_DIR }}/manage.discovery update_index --disable-change-limit'"
@@ -33,7 +28,7 @@ EDXAPP_ADDITIONAL_CRON_JOBS:
 
 * Set these extra variables on the instance:
 
-```
+```yaml
 # prevent creating example partners; this isn't required, and will cause provision errors later
 ecommerce_create_demo_data: false
 
@@ -53,139 +48,132 @@ ECOMMERCE_BROKER_URL: '{{ EDXAPP_CELERY_BROKER_TRANSPORT }}://{{ EDXAPP_CELERY_U
 ECOMMERCE_WORKER_BROKER_URL: '{{ EDXAPP_CELERY_BROKER_TRANSPORT }}://{{ EDXAPP_CELERY_USER }}:{{ EDXAPP_CELERY_PASSWORD }}@{{ EDXAPP_CELERY_BROKER_HOSTNAME }}{{ EDXAPP_CELERY_BROKER_VHOST }}'
 ECOMMERCE_WORKER_ECOMMERCE_API_ROOT: '{{ ECOMMERCE_ECOMMERCE_URL_ROOT }}/api/v2/'
 ```
+* To change the default currency used in the ecommerce system from USD ($) to, for example, British pounds (£), add this extra configuration:
+
+```yaml
+# Use a configuration branch which contains this fix:
+# https://github.com/open-craft/configuration/pull/119/files
+EDXAPP_PAID_COURSE_REGISTRATION_CURRENCY: ['gbp', '£']
+ECOMMERCE_OSCAR_DEFAULT_CURRENCY: 'GBP'
+ECOMMERCE_REPOS:
+  - PROTOCOL: '{{ COMMON_GIT_PROTOCOL }}'
+    DOMAIN: '{{ COMMON_GIT_MIRROR }}'
+    PATH: 'open-craft'
+    REPO: 'ecommerce.git'
+    # Use a branch which contains this fix:
+    # https://github.com/open-craft/ecommerce/pull/13/files
+    VERSION: opencraft-release/ironwood.2
+    DESTINATION: "{{ ecommerce_code_dir }}"
+    SSH_KEY: '{{ ECOMMERCE_GIT_IDENTITY }}'
+
+# Append to any existing EDXAPP_LMS_ENV_EXTRA:
+EDXAPP_LMS_ENV_EXTRA:
+  COURSE_MODE_DEFAULTS:
+    bulk_sku: !!null
+    currency: gbp
+    description: !!null
+    expiration_datetime: !!null
+    min_price: 0
+    name: Honor
+    sku: !!null
+    slug: honor
+    suggested_prices: ''
+```
 
 **Notes**:
 
-* We need to set the `COMMON_HOSTNAME` to something other than the external
-  lms domain name (eg. `openlearning.example.com`), so
-  that API requests made on the server can be properly routed through the load
-  balancer-terminated SSL connection.  This is required because, by default, an
-  /etc/hosts entry for the `COMMON_HOSTNAME` is set pointing to localhost,
-  which will break SSL connections to the LMS from within the instance.
-* The [`ECOMMERCE_PAYMENT_PROCESSOR_CONFIG`](https://github.com/edx/configuration/blob/d68bf51d7b8403bdad09dc764af5ebafe16d7309/playbooks/roles/ecommerce/defaults/main.yml#L103)
-  should contain the payment processors and their keys.
+* We need to set the `COMMON_HOSTNAME` to something other than the external lms domain name (eg. `openlearning.example.com`), so that API requests made on the server can be properly routed through the
+  load balancer-terminated SSL connection.  This is required because, by default, an /etc/hosts entry for the `COMMON_HOSTNAME` is set pointing to localhost, which will break SSL connections to the
+  LMS from within the instance.
+* The [`ECOMMERCE_PAYMENT_PROCESSOR_CONFIG`](https://github.com/edx/configuration/blob/open-release/ironwood.2/playbooks/roles/ecommerce/defaults/main.yml#L103) should contain the payment processors
+  and their keys.
+* A larger appserver vm type may need to be used, since it will be running ecommerce and course discovery as well.
 
+### Manual steps
 
-* A larger appserver vm type may need to be used, since it will be running
-  ecommerce and course discovery as well.
+Spawn a new appserver to use the updated settings to deploy the ecommerce and discovery services.
 
-Once the spawn is complete, you'll need to take the following steps to finish setup
-(these are one-time actions that are stored in the database):
+Once the appserver is running, you'll need to take the following steps to finish setup (these are one-time actions that are stored in the database):
 
+* In Django Admin > Authentication > Users (`/admin/auth/user/`), there should already be service users created, i.e. `ecommerce_worker` and `discovery_worker`.
 
-1.  In Django Admin > Authentication > Users (`/admin/auth/user/`), there should already be service users created, i.e. `ecommerce_worker` and `discovery_worker`.
-
-    If not, create them with staff privileges, no password, and set the Full
-    Name so that a user profile is associated with the users.
+    If not, create them with staff privileges, no password, and set the Full Name so that a user profile is associated with the users.
 
     Add these extra permissions to the `ecommerce_worker`:
 
-    ```
-    api_admin | catalog | *
-    bulk_email | course mode target | *
-    commerce | commerce configuration | *
-    course_modes | * | *
-    ```
-1. In Django Admin > OAuth2 > Clients (`/admin/oauth2/client/`), there should already be clients created for ecommerce and discovery.
+        api_admin | catalog | *
+        bulk_email | course mode target | *
+        commerce | commerce configuration | *
+        course_modes | * | *
 
-   If not, [create and register new
-   clients](http://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/latest/ecommerce/install_ecommerce.html#configure-edx-openid-connect-oidc)
-   for each service.  Attach each client to the worker user discussed in the
-   previous step.
+* In Django Admin > OAuth2 > Clients (`/admin/oauth2/client/`), there should already be clients created for ecommerce and discovery.
 
-   You'll need the client IDs and client secrets for the next steps.
-1. In the ecommerce env, add a Site, Partner, and Site Configuration as per the
-   instructions in the [edX ecommerce docs](http://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/latest/ecommerce/install_ecommerce.html#add-another-site-partner-and-site-configuration).
-   Use the partner code from `ECOMMERCE_PAYMENT_PROCESSOR_CONFIG`.
-   Eg.
+    If not, [create and register new clients](http://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/latest/ecommerce/install_ecommerce.html#configure-edx-openid-connect-oidc)
+    for each service.  Attach each client to the worker user discussed in the previous step.
 
-   ```
-   sudo -u ecommerce -Hs
-   cd
-   source ecommerce_env
-   source venvs/ecommerce/bin/activate
-   cd ecommerce
-   python manage.py create_or_update_site \
-     --site-name 'My Site E-Commerce' \
-     --site-domain 'ecommerce.lms.external.domain' \
-     --partner-code 'partn_id' \ # this is limited to only 8 characters
-     --partner-name 'Partner Name' \
-     --lms-url-root 'https://lms.external.domain' \
-     --client-id '{ecommerce_worker oauth client id}' \
-     --client-secret '{ecommerce_worker oauth client secret}' \
-     --from-email 'user@example.com' \ # set to same as EDXAPP_DEFAULT_FROM_EMAIL on instance
-     --discovery_api_url 'https://discovery.external.lms.domain/api/v1' \
-     --client-side-payment-processor stripe \ # if using Stripe
-   ```
+    You'll need the client IDs and client secrets for the next steps.
 
-   See [payment processor docs](https://edx-ecommerce.readthedocs.io/en/latest/additional_features/payment_processors.html)
-   for specific payment processors.
+* In the ecommerce env, add a Site, Partner, and Site Configuration as per the instructions in the [edX ecommerce
+  docs](http://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/latest/ecommerce/install_ecommerce.html#add-another-site-partner-and-site-configuration).
 
-   Also note that any of the values from the `create_or_update_site` command
-   can be edited later in Django admin at `/admin/core/siteconfiguration/`; no
-   need to continue rerunning this command once the initial auth related setup
-   is working for the site configuration.
-1. In the discovery env, configure a partner using
-   [`create_or_update_partner`](https://github.com/edx/course-discovery/blob/master/course_discovery/apps/core/management/commands/create_or_update_partner.py).
-   Use the same partner code as what you used for ecommerce.
+   * `--partner-code` should match the partner code from `ECOMMERCE_PAYMENT_PROCESSOR_CONFIG`, limited to 8 characters.
+   * Add `--client-side-payment-processor stripe` if `ECOMMERCE_PAYMENT_PROCESSOR_CONFIG` uses the Stripe payment processor.
 
-   ```
-   sudo -u discovery -Hs
-   cd
-   source discovery_env
-   source venvs/discovery/bin/activate
-   cd discovery
-   python manage.py create_or_update_partner \
-     --site-id 1 \
-     --site-domain 'discovery.external.lms.domain' \
-     --code 'partn_id' \
-     --name 'Client Name' \
-     --courses-api-url 'https://external.lms.domain/api/courses/v1/' \
-     --ecommerce-api-url 'https://ecommerce.external.lms.domain/api/v2/' \
-     --organizations-api-url 'https://external.lms.domain/api/organizations/v0/' \
-     --oidc-url-root 'https://external.lms.domain/oauth2' \
-     --oidc-key '{discovery oauth client id}' \
-     --oidc-secret '{discovery oauth client secret}'
-   ```
-1. [Configure LMS to use ecommerce](http://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/latest/ecommerce/install_ecommerce.html#switch-from-shoppingcart-to-e-commerce)
-1. To change the default currency used in the ecommerce system from USD ($) to, for example, British pounds (£), add this extra configuration:
+     See [payment processor docs](https://edx-ecommerce.readthedocs.io/en/latest/additional_features/payment_processors.html) for other arguments for specific payment processors.
+   * `--from-email` should match `EDXAPP_DEFAULT_FROM_EMAIL`
+   * Any of the values from the `create_or_update_site` command can be edited later in the ecommerce Django admin at `/admin/core/siteconfiguration/`; no need to continue rerunning this command once
+     the initial auth related setup is working for the site configuration.
 
-   ```
-   # Use a configuration branch which contains this fix:
-   # https://github.com/open-craft/configuration/pull/119/files
-   EDXAPP_PAID_COURSE_REGISTRATION_CURRENCY: ['gbp', '£']
-   ECOMMERCE_OSCAR_DEFAULT_CURRENCY: 'GBP'
-   ECOMMERCE_REPOS:
-     - PROTOCOL: '{{ COMMON_GIT_PROTOCOL }}'
-       DOMAIN: '{{ COMMON_GIT_MIRROR }}'
-       PATH: 'open-craft'
-       REPO: 'ecommerce.git'
-       # Use a branch which contains this fix:
-       # https://github.com/open-craft/ecommerce/pull/13/files
-       VERSION: 'jill/set-default-currency'  # FIXME: change to opencraft-release/ironwood.2
-       DESTINATION: "{{ ecommerce_code_dir }}"
-       SSH_KEY: '{{ ECOMMERCE_GIT_IDENTITY }}'
+```bash
+sudo -u ecommerce -Hs
+cd
+source ecommerce_env
+source venvs/ecommerce/bin/activate
+cd ecommerce
+python manage.py create_or_update_site \
+ --site-name 'My Site E-Commerce' \
+ --site-domain 'ecommerce.lms.external.domain' \
+ --partner-code 'partn_id' \
+ --partner-name 'Partner Name' \
+ --lms-url-root 'https://lms.external.domain' \
+ --client-id '{ecommerce_worker oauth client id}' \
+ --client-secret '{ecommerce_worker oauth client secret}' \
+ --from-email 'user@example.com' \
+ --discovery_api_url 'https://discovery.external.lms.domain/api/v1'
+```
 
-   # Append to any existing EDXAPP_LMS_ENV_EXTRA:
-   EDXAPP_LMS_ENV_EXTRA:
-     COURSE_MODE_DEFAULTS:
-       bulk_sku: !!null
-       currency: gbp
-       description: !!null
-       expiration_datetime: !!null
-       min_price: 0
-       name: Honor
-       sku: !!null
-       slug: honor
-       suggested_prices: ''
-   ```
+* In the discovery env, configure a partner using
+  [`create_or_update_partner`](https://github.com/edx/course-discovery/blob/master/course_discovery/apps/core/management/commands/create_or_update_partner.py).
 
-Test your configuration:
+    * Use the same partner `--code` as what you used for ecommerce.
+
+```bash
+sudo -u discovery -Hs
+cd
+source discovery_env
+source venvs/discovery/bin/activate
+cd discovery
+python manage.py create_or_update_partner \
+  --site-id 1 \
+  --site-domain 'discovery.external.lms.domain' \
+  --code 'partn_id' \
+  --name 'Client Name' \
+  --courses-api-url 'https://external.lms.domain/api/courses/v1/' \
+  --ecommerce-api-url 'https://ecommerce.external.lms.domain/api/v2/' \
+  --organizations-api-url 'https://external.lms.domain/api/organizations/v0/' \
+  --oidc-url-root 'https://external.lms.domain/oauth2' \
+  --oidc-key '{discovery oauth client id}' \
+  --oidc-secret '{discovery oauth client secret}'
+```
+
+* [Configure LMS to use ecommerce](http://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/latest/ecommerce/install_ecommerce.html#switch-from-shoppingcart-to-e-commerce)
+
+### Test your configuration
 
 1. Verify the OIDC login for both services:
 
-        https://ecommerce.<your-instance>.opencraft.hosting/login
-        https://discovery.<your-instance>.opencraft.hosting/login
+        https://ecommerce.external.lms.domain/login
+        https://discovery.external.lms.domain/login
 
 1. Verify that the discovery cronjob runs without errors:
 
@@ -200,7 +188,9 @@ Test your configuration:
    Ideally, the payment processor will be initially configured as a sandbox service for testing, and so you can use test credit card numbers as provided by the payment processor.
 1. Delete the course once all is verified.
 
-Useful references:
+## References
+
+Useful references when configuring or troubleshooting issues with ecommerce and course discovery.
 
 * [E-Commerce usage docs](https://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/latest/ecommerce/create_products/index.html)
 * [Adding E-Commerce to the Open edX Platform](http://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/latest/ecommerce/install_ecommerce.html)

--- a/documentation/howtos.md
+++ b/documentation/howtos.md
@@ -87,7 +87,8 @@ EDXAPP_LMS_ENV_EXTRA:
 
 Spawn a new appserver to use the updated settings to deploy the ecommerce and discovery services.
 
-Once the appserver is running, you'll need to take the following steps to finish setup (these are one-time actions that are stored in the database):
+Once the appserver is running, you'll need to run the following commands on the new appserver to finish setup. These are
+one-time actions that are stored in the database.
 
 * In Django Admin > Authentication > Users (`/admin/auth/user/`), there should already be service users created, i.e. `ecommerce_worker` and `discovery_worker`.
 
@@ -162,7 +163,7 @@ python manage.py create_or_update_partner \
   --oidc-secret '{discovery oauth client secret}'
 ```
 
-* To initialize a new Elasticsearch instance, run:
+* To initialize a new Elasticsearch index, run these commands on the appserver:
 
 ```bash
 sudo -u discovery -Hs


### PR DESCRIPTION
Fixes some formatting issues with the `mkdocs` rendered markdown for the "How To" documentation page, cf https://ocim.opencraft.com/en/latest/howtos/

Changes made:

* established standard line length of 200 characters.
* added yaml/bash code rendering hints to code blocks
* code blocks cannot be indented in mkdocs markdown
* code blocks mess with ordered list numbering, so converted to unordered lists.
* comments in pasted shell commands mess with the backslash line continuation character, so have moved them into the main content.
* changed heading levels, added more headings.
* moved all extra configuration changes to the top instance configuration section.

**Testing instructions**

1. Run `make docs` to build the documentation.
1. Run `make docs-serve` to check the rendered documentation on `http://localhost:5001`.
1. Read through the rendered documentation and check for formatting issues.

**Reviewer**

- [x] @swalladge 