### PR TITLE
SE-2318 Enables Studio login SSO from the LMS

### DIFF
--- a/instance/models/mixins/openedx_config.py
+++ b/instance/models/mixins/openedx_config.py
@@ -87,6 +87,7 @@ class OpenEdXConfigMixin(ConfigMixinBase):
             "CMS_HOSTNAME": '~{}'.format(self.instance.studio_domain_nginx_regex),
 
             "EDXAPP_LOGIN_REDIRECT_WHITELIST": [self.instance.studio_domain, ],
+            "EDXAPP_SESSION_COOKIE_DOMAIN": '.{}'.format(self.instance.domain),
 
             # Run a command to delete expired sessions once a day. The time is random and different in each server
             # to avoid the case when all servers connect to the database at exactly the same time.
@@ -221,10 +222,9 @@ class OpenEdXConfigMixin(ConfigMixinBase):
                 "USE_MICROSITES": False,
                 "PREVENT_CONCURRENT_LOGINS": False,
                 "ENABLE_ACCOUNT_DELETION": True,
-                # Disable the unified login from Studio
-                # Since Ironwood, the Studio login changed from a separate login
-                # to using LMS as a SSO provider. This flag disables that behaviour.
-                "DISABLE_STUDIO_SSO_OVER_LMS": True,
+                # Enable the unified login from Studio
+                # Supported in Ironwood, option to disable removed in Juniper.
+                "DISABLE_STUDIO_SSO_OVER_LMS": False,
                 # Enable prerequisite subsections feature
                 "ENABLE_PREREQUISITE_COURSES": True,
                 "MILESTONES_APP": True,


### PR DESCRIPTION
The feature flag which disables Studio login via SSO from the LMS is removed in Juniper.

This PR disables that feature flag to enable Studio SSO, and to make the behaviour standard across all our deployments.  We also set the default session cookie name to `.<lms domain>` to allow sharing of cookies between Studio, LMS, and other service subdomains.

This reverts the changes made by https://github.com/open-craft/opencraft/pull/422, but is deemed safe because we are now using `studio.<lms domain>` subdomains for all our hosts.

**Testing instructions**

Suggest that this is tested on stage.console.opencraft.com

Create instances of the following types, and ensure that logging into Studio works, via the LMS.

* production instance
* PR sandbox instance
* juniper.alpha1 instance

**Reviewer**

- [x] @tartansandal