### PR TITLE
BB-2328: Add new frontend redirects

### DIFF
--- a/opencraft/settings.py
+++ b/opencraft/settings.py
@@ -864,6 +864,8 @@ USER_CONSOLE_FRONTEND_URL = env(
     'USER_CONSOLE_FRONTEND_URL',
     default='http://localhost:3000'
 )
+# Redirect from old registration form to new one
+REDIRECT_TO_NEW_CONSOLE = env.bool('REDIRECT_TO_NEW_CONSOLE', default=False)
 
 # CORS Settings - https://github.com/adamchainz/django-cors-headers
 CORS_ORIGIN_REGEX_WHITELIST = [

--- a/opencraft/settings.py
+++ b/opencraft/settings.py
@@ -865,7 +865,7 @@ USER_CONSOLE_FRONTEND_URL = env(
     default='http://localhost:3000'
 )
 # Redirect from old registration form to new one
-REDIRECT_TO_NEW_CONSOLE = env.bool('REDIRECT_TO_NEW_CONSOLE', default=False)
+NEW_USER_CONSOLE_REGISTRATION_ENABLED = env.bool('NEW_USER_CONSOLE_REGISTRATION_ENABLED', default=False)
 
 # CORS Settings - https://github.com/adamchainz/django-cors-headers
 CORS_ORIGIN_REGEX_WHITELIST = [

--- a/registration/views.py
+++ b/registration/views.py
@@ -22,8 +22,10 @@ Registration views
 
 # Imports #####################################################################
 
+from django.conf import settings
 from django.contrib.auth import authenticate, login
 from django.db import transaction
+from django.shortcuts import redirect
 from django.urls import reverse_lazy
 from django.utils.decorators import method_decorator
 from django.views.decorators.debug import sensitive_post_parameters
@@ -80,6 +82,21 @@ class BetaTestApplicationView(BetaTestApplicationMixin, UpdateView):
             login(self.request, user)
         verify_user_emails(user, user.email, self.object.public_contact_email)
         return response
+
+    def get(self, *args, **kwargs):
+        """
+        Get registration form.
+
+        Retirects to new frontend if flag is set, otherwise
+        returns old registration form.
+
+        Note: `USER_CONSOLE_FRONTEND_URL` must be set to a
+        full valid URL.
+        """
+        if settings.REDIRECT_TO_NEW_CONSOLE and settings.USER_CONSOLE_FRONTEND_URL:
+            return redirect(settings.USER_CONSOLE_FRONTEND_URL)
+
+        return super(BetaTestApplicationView, self).get(*args, **kwargs)
 
     def get_form_kwargs(self):
         kwargs = super(BetaTestApplicationView, self).get_form_kwargs()

--- a/registration/views.py
+++ b/registration/views.py
@@ -88,13 +88,14 @@ class BetaTestApplicationView(BetaTestApplicationMixin, UpdateView):
         """
         Get registration form.
 
-        Retirects to new frontend if flag is set, otherwise
-        returns old registration form.
+        Redirects to new frontend if `settings.NEW_USER_CONSOLE_REGISTRATION_ENABLED`
+        is set, otherwise returns old registration form.
 
         Note: `USER_CONSOLE_FRONTEND_URL` must be set to a
         full valid URL.
         """
-        if settings.REDIRECT_TO_NEW_CONSOLE and settings.USER_CONSOLE_FRONTEND_URL:
+        # TODO: Remove this when cleaning up old registration console on BB-2422.
+        if settings.NEW_USER_CONSOLE_REGISTRATION_ENABLED and settings.USER_CONSOLE_FRONTEND_URL:
             return redirect(settings.USER_CONSOLE_FRONTEND_URL)
 
         return super(BetaTestApplicationView, self).get(*args, **kwargs)

--- a/registration/views.py
+++ b/registration/views.py
@@ -83,6 +83,7 @@ class BetaTestApplicationView(BetaTestApplicationMixin, UpdateView):
         verify_user_emails(user, user.email, self.object.public_contact_email)
         return response
 
+    # pylint: disable=arguments-differ
     def get(self, *args, **kwargs):
         """
         Get registration form.


### PR DESCRIPTION
This PR adds a simple redirection mechanism to direct users to the new frontend until we do the domain migration.

**Testing instructions:**
1. Checkout this branch.
2. Run Ocim.
3. Go to http://localhost:5000/registration and check that the form is displaying as usual.
4. Add these to your `.env` file:
```
USER_CONSOLE_FRONTEND_URL="https://app.console.opencraft.com"
NEW_USER_CONSOLE_REGISTRATION_ENABLED=True
```
5. Open your browser inspetion tool.
6. Restart Ocim, check that http://localhost:5000/registration redirects to the new frontend.
7. Check that the redirect was a `302 Found` and not a permanent redirect. 

**Reviewer:**
- [x] @Agrendalath 

**Notes:**
This is just a temporary change, until Ocim gets migrated to the new domain (manage.opencraft.com). It will be removed soon, so that's why I didn't add any tests.