### PR TITLE
[BB-2444] Remove public contact email from registration

### DIFF
--- a/frontend/packages/api_client/src/models/OpenEdXInstanceConfig.ts
+++ b/frontend/packages/api_client/src/models/OpenEdXInstanceConfig.ts
@@ -71,9 +71,7 @@ export interface OpenEdXInstanceConfig {
      */
     instanceName: string;
     /**
-     * The email your instance of Open edX will be using to send emails, and where your users should send their support requests.
      * 
-     * This needs to be a valid email.
      * @type {string}
      * @memberof OpenEdXInstanceConfig
      */
@@ -138,7 +136,7 @@ export function OpenEdXInstanceConfigFromJSONTyped(json: any, ignoreDiscriminato
         'subdomain': json['subdomain'],
         'externalDomain': !exists(json, 'external_domain') ? undefined : json['external_domain'],
         'instanceName': json['instance_name'],
-        'publicContactEmail': json['public_contact_email'],
+        'publicContactEmail': !exists(json, 'public_contact_email') ? undefined : json['public_contact_email'],
         'privacyPolicyUrl': !exists(json, 'privacy_policy_url') ? undefined : json['privacy_policy_url'],
         'useAdvancedTheme': !exists(json, 'use_advanced_theme') ? undefined : json['use_advanced_theme'],
         'draftThemeConfig': !exists(json, 'draft_theme_config') ? undefined : ThemeSchemaFromJSON(json['draft_theme_config']),

--- a/frontend/packages/api_client/src/models/OpenEdXInstanceConfig.ts
+++ b/frontend/packages/api_client/src/models/OpenEdXInstanceConfig.ts
@@ -71,6 +71,14 @@ export interface OpenEdXInstanceConfig {
      */
     instanceName: string;
     /**
+     * The email your instance of Open edX will be using to send emails, and where your users should send their support requests.
+     * 
+     * This needs to be a valid email.
+     * @type {string}
+     * @memberof OpenEdXInstanceConfig
+     */
+    publicContactEmail?: string;
+    /**
      * URL to the privacy policy.
      * @type {string}
      * @memberof OpenEdXInstanceConfig
@@ -130,6 +138,7 @@ export function OpenEdXInstanceConfigFromJSONTyped(json: any, ignoreDiscriminato
         'subdomain': json['subdomain'],
         'externalDomain': !exists(json, 'external_domain') ? undefined : json['external_domain'],
         'instanceName': json['instance_name'],
+        'publicContactEmail': json['public_contact_email'],
         'privacyPolicyUrl': !exists(json, 'privacy_policy_url') ? undefined : json['privacy_policy_url'],
         'useAdvancedTheme': !exists(json, 'use_advanced_theme') ? undefined : json['use_advanced_theme'],
         'draftThemeConfig': !exists(json, 'draft_theme_config') ? undefined : ThemeSchemaFromJSON(json['draft_theme_config']),
@@ -152,6 +161,7 @@ export function OpenEdXInstanceConfigToJSON(value?: OpenEdXInstanceConfig | null
         'subdomain': value.subdomain,
         'external_domain': value.externalDomain,
         'instance_name': value.instanceName,
+        'public_contact_email': value.publicContactEmail,
         'privacy_policy_url': value.privacyPolicyUrl,
         'use_advanced_theme': value.useAdvancedTheme,
         'draft_theme_config': ThemeSchemaToJSON(value.draftThemeConfig),

--- a/frontend/packages/api_client/src/models/OpenEdXInstanceConfig.ts
+++ b/frontend/packages/api_client/src/models/OpenEdXInstanceConfig.ts
@@ -71,14 +71,6 @@ export interface OpenEdXInstanceConfig {
      */
     instanceName: string;
     /**
-     * The email your instance of Open edX will be using to send emails, and where your users should send their support requests.
-     * 
-     * This needs to be a valid email.
-     * @type {string}
-     * @memberof OpenEdXInstanceConfig
-     */
-    publicContactEmail: string;
-    /**
      * URL to the privacy policy.
      * @type {string}
      * @memberof OpenEdXInstanceConfig
@@ -138,7 +130,6 @@ export function OpenEdXInstanceConfigFromJSONTyped(json: any, ignoreDiscriminato
         'subdomain': json['subdomain'],
         'externalDomain': !exists(json, 'external_domain') ? undefined : json['external_domain'],
         'instanceName': json['instance_name'],
-        'publicContactEmail': json['public_contact_email'],
         'privacyPolicyUrl': !exists(json, 'privacy_policy_url') ? undefined : json['privacy_policy_url'],
         'useAdvancedTheme': !exists(json, 'use_advanced_theme') ? undefined : json['use_advanced_theme'],
         'draftThemeConfig': !exists(json, 'draft_theme_config') ? undefined : ThemeSchemaFromJSON(json['draft_theme_config']),
@@ -161,7 +152,6 @@ export function OpenEdXInstanceConfigToJSON(value?: OpenEdXInstanceConfig | null
         'subdomain': value.subdomain,
         'external_domain': value.externalDomain,
         'instance_name': value.instanceName,
-        'public_contact_email': value.publicContactEmail,
         'privacy_policy_url': value.privacyPolicyUrl,
         'use_advanced_theme': value.useAdvancedTheme,
         'draft_theme_config': ThemeSchemaToJSON(value.draftThemeConfig),

--- a/frontend/packages/api_client/src/models/OpenEdXInstanceConfigUpdate.ts
+++ b/frontend/packages/api_client/src/models/OpenEdXInstanceConfigUpdate.ts
@@ -65,9 +65,7 @@ export interface OpenEdXInstanceConfigUpdate {
      */
     instanceName?: string;
     /**
-     * The email your instance of Open edX will be using to send emails, and where your users should send their support requests.
      * 
-     * This needs to be a valid email.
      * @type {string}
      * @memberof OpenEdXInstanceConfigUpdate
      */

--- a/frontend/src/registration/components/AccountSetupPage/AccountSetupPage.tsx
+++ b/frontend/src/registration/components/AccountSetupPage/AccountSetupPage.tsx
@@ -103,8 +103,7 @@ export class AccountSetupPage extends React.PureComponent<Props, State> {
       {
         externalDomain: this.props.registrationData.externalDomain,
         subdomain: this.props.registrationData.subdomain,
-        instanceName: this.props.registrationData.instanceName,
-        publicContactEmail: this.props.registrationData.publicContactEmail
+        instanceName: this.props.registrationData.instanceName
       },
       RegistrationSteps.CONGRATS
     );

--- a/frontend/src/registration/components/CongratulationsPage/__snapshots__/CongratulationsPage.spec.tsx.snap
+++ b/frontend/src/registration/components/CongratulationsPage/__snapshots__/CongratulationsPage.spec.tsx.snap
@@ -114,11 +114,7 @@ exports[`renders without crashing 1`] = `
           You have successfully created your OpenCraft account.
         </p>
         <p>
-          We have sent you an email to verify your OpenCraft account email and your public contact email. If these are different email addresses, you will need to verify 
-          <strong>
-            both
-          </strong>
-           of them for your instance to be activated. Please follow the link(s) that we emailed you to your email account(s) complete your application process.
+          We have sent you an email to verify your OpenCraft account. Please follow the link in your email account to verify and complete your application process.
         </p>
         <div
           className="text-center"

--- a/frontend/src/registration/components/CongratulationsPage/displayMessages.ts
+++ b/frontend/src/registration/components/CongratulationsPage/displayMessages.ts
@@ -9,9 +9,9 @@ const messages = {
   },
   congratsMessage2: {
     defaultMessage:
-      'We have sent you an email to verify your OpenCraft account email. ' +
-      'Please follow the link that we emailed you in your email ' +
-      'account to verify and complete your application process.',
+      'We have sent you an email to verify your OpenCraft account. ' +
+      'Please follow the link in your email account to ' +
+      'verify and complete your application process.',
     description: ''
   },
   consoleButton: {

--- a/frontend/src/registration/components/CongratulationsPage/displayMessages.ts
+++ b/frontend/src/registration/components/CongratulationsPage/displayMessages.ts
@@ -9,11 +9,9 @@ const messages = {
   },
   congratsMessage2: {
     defaultMessage:
-      'We have sent you an email to verify your OpenCraft account email and ' +
-      'your public contact email. If these are different email addresses, you ' +
-      'will need to verify <strong>both</strong> of them for your instance to ' +
-      'be activated. Please follow the link(s) that we emailed you to your email ' +
-      'account(s) complete your application process.',
+      'We have sent you an email to verify your OpenCraft account email. ' +
+      'Please follow the link that we emailed you in your email ' +
+      'account to verify and complete your application process.',
     description: ''
   },
   consoleButton: {

--- a/frontend/src/registration/components/InstanceSetupPage/InstanceSetupPage.tsx
+++ b/frontend/src/registration/components/InstanceSetupPage/InstanceSetupPage.tsx
@@ -46,7 +46,7 @@ export class InstanceSetupPage extends React.PureComponent<Props, State> {
     super(props);
 
     this.state = {
-      instanceName: props.registrationData.instanceName,
+      instanceName: props.registrationData.instanceName
     };
   }
 

--- a/frontend/src/registration/components/InstanceSetupPage/InstanceSetupPage.tsx
+++ b/frontend/src/registration/components/InstanceSetupPage/InstanceSetupPage.tsx
@@ -67,7 +67,7 @@ export class InstanceSetupPage extends React.PureComponent<Props, State> {
   private submitInstanceData = () => {
     this.props.performValidationAndStore(
       {
-        instanceName: this.state.instanceName,
+        instanceName: this.state.instanceName
       },
       RegistrationSteps.ACCOUNT
     );

--- a/frontend/src/registration/components/InstanceSetupPage/InstanceSetupPage.tsx
+++ b/frontend/src/registration/components/InstanceSetupPage/InstanceSetupPage.tsx
@@ -23,7 +23,6 @@ interface ActionProps {
 interface State {
   [key: string]: string;
   instanceName: string;
-  publicContactEmail: string;
 }
 
 interface StateProps extends RegistrationStateModel {}
@@ -48,7 +47,6 @@ export class InstanceSetupPage extends React.PureComponent<Props, State> {
 
     this.state = {
       instanceName: props.registrationData.instanceName,
-      publicContactEmail: props.registrationData.publicContactEmail
     };
   }
 
@@ -70,7 +68,6 @@ export class InstanceSetupPage extends React.PureComponent<Props, State> {
     this.props.performValidationAndStore(
       {
         instanceName: this.state.instanceName,
-        publicContactEmail: this.state.publicContactEmail
       },
       RegistrationSteps.ACCOUNT
     );
@@ -108,14 +105,6 @@ export class InstanceSetupPage extends React.PureComponent<Props, State> {
             onChange={this.onChange}
             messages={messages}
             error={this.props.registrationFeedback.instanceName}
-          />
-          <TextInputField
-            fieldName="publicContactEmail"
-            value={this.state.publicContactEmail}
-            onChange={this.onChange}
-            messages={messages}
-            type="email"
-            error={this.props.registrationFeedback.publicContactEmail}
           />
         </Form>
         <RegistrationNavButtons

--- a/frontend/src/registration/components/InstanceSetupPage/__snapshots__/InstanceSetupPage.spec.tsx.snap
+++ b/frontend/src/registration/components/InstanceSetupPage/__snapshots__/InstanceSetupPage.spec.tsx.snap
@@ -156,29 +156,6 @@ exports[`renders without crashing 1`] = `
             </p>
           </div>
         </div>
-        <div
-          className="text-input-container"
-        >
-          <div
-            className="form-group"
-          >
-            <label
-              className="form-label"
-            >
-              Public contact email
-            </label>
-            <input
-              className="form-control"
-              name="publicContactEmail"
-              onChange={[Function]}
-              type="email"
-              value=""
-            />
-            <p>
-              The email your instance of Open edX will be using to send emails, and where your users should send their support requests. This needs to be a valid email.
-            </p>
-          </div>
-        </div>
       </form>
       <div
         className="registration-nav"

--- a/frontend/src/registration/components/InstanceSetupPage/displayMessages.ts
+++ b/frontend/src/registration/components/InstanceSetupPage/displayMessages.ts
@@ -10,17 +10,6 @@ const messages = {
   instanceNameHelp: {
     defaultMessage: 'The name of your institution, company or project.',
     description: 'Help text for instance name input.'
-  },
-  publicContactEmail: {
-    defaultMessage: 'Public contact email',
-    description: 'Form label for email input'
-  },
-  publicContactEmailHelp: {
-    defaultMessage:
-      'The email your instance of Open edX will be using to send ' +
-      'emails, and where your users should send their support ' +
-      'requests. This needs to be a valid email.',
-    description: 'Help text for email input'
   }
 };
 

--- a/frontend/src/registration/components/InstanceSetupPage/styles.scss
+++ b/frontend/src/registration/components/InstanceSetupPage/styles.scss
@@ -10,4 +10,5 @@
     text-align: left;
     margin-bottom: 32px;
   }
+  width: 100%;
 }

--- a/frontend/src/registration/models.ts
+++ b/frontend/src/registration/models.ts
@@ -12,7 +12,6 @@ export interface DomainInfoModel {
 
 export interface InstanceInfoModel {
   instanceName: string;
-  publicContactEmail: string;
 }
 
 export interface AccountInfoModel {
@@ -55,7 +54,6 @@ export const blankRegistration: Readonly<RegistrationModel> = {
   instanceName: '',
   password: '',
   passwordConfirm: '',
-  publicContactEmail: '',
   username: '',
   ...DefaultTheme
 };

--- a/frontend/src/ui/components/ErrorPage/__snapshots__/ErrorPage.spec.tsx.snap
+++ b/frontend/src/ui/components/ErrorPage/__snapshots__/ErrorPage.spec.tsx.snap
@@ -13,7 +13,7 @@ exports[`renders without crashing 1`] = `
       <p>
         Something went wrong!
       </p>
-      We hit an internal server error, try again soon, or, if that doesn'twork, contact us.
+      We hit an internal server error, try again soon, or, if that doesn't work, contact us.
     </div>
   </div>
 </div>

--- a/frontend/src/ui/components/ErrorPage/displayMessages.ts
+++ b/frontend/src/ui/components/ErrorPage/displayMessages.ts
@@ -5,7 +5,7 @@ const messages = {
   },
   errorMessage: {
     defaultMessage:
-      "We hit an internal server error, try again soon, or, if that doesn't" +
+      "We hit an internal server error, try again soon, or, if that doesn't " +
       'work, contact us.',
     description: 'Error message.'
   }

--- a/registration/api/v2/serializers.py
+++ b/registration/api/v2/serializers.py
@@ -312,6 +312,18 @@ class OpenEdXInstanceConfigSerializer(serializers.ModelSerializer):
         else:
             return value
 
+    public_contact_email = serializers.EmailField(required=False)
+
+    # pylint: disable=arguments-differ
+    def validate(self, data):
+        """
+        Check for public contact email and override with user email.
+        """
+        public_contact_email = data.get('public_contact_email')
+        if not public_contact_email and 'user' in data:
+            data['public_contact_email'] = data['user'].email
+        return data
+
     class Meta:
         model = BetaTestApplication
         fields = (

--- a/registration/api/v2/serializers.py
+++ b/registration/api/v2/serializers.py
@@ -281,7 +281,7 @@ class OpenEdXInstanceConfigSerializer(serializers.ModelSerializer):
     draft_theme_config = ThemeSchemaSerializer(read_only=True)
     draft_static_content_overrides = StaticContentOverridesSerializer(read_only=True)
 
-    # LMS and Studio URLs (if the instance is provisisoned)
+    # LMS and Studio URLs (if the instance is provisioned)
     lms_url = serializers.SerializerMethodField()
     studio_url = serializers.SerializerMethodField()
 

--- a/registration/api/v2/serializers.py
+++ b/registration/api/v2/serializers.py
@@ -285,6 +285,8 @@ class OpenEdXInstanceConfigSerializer(serializers.ModelSerializer):
     lms_url = serializers.SerializerMethodField()
     studio_url = serializers.SerializerMethodField()
 
+    public_contact_email = serializers.EmailField(required=False)
+
     def get_lms_url(self, obj):
         """
         Returns instance LMS url if available
@@ -311,18 +313,6 @@ class OpenEdXInstanceConfigSerializer(serializers.ModelSerializer):
             raise ValidationError("User has reached limit of allowed Open edX instances.")
         else:
             return value
-
-    public_contact_email = serializers.EmailField(required=False)
-
-    # pylint: disable=arguments-differ
-    def validate(self, data):
-        """
-        Check for public contact email and override with user email.
-        """
-        public_contact_email = data.get('public_contact_email')
-        if not public_contact_email and 'user' in data:
-            data['public_contact_email'] = data['user'].email
-        return data
 
     class Meta:
         model = BetaTestApplication

--- a/registration/api/v2/views.py
+++ b/registration/api/v2/views.py
@@ -204,7 +204,6 @@ class OpenEdXInstanceConfigViewSet(
                 "public_contact_email": request.user.email
             })
 
-
         # Perform create as usual
         return super(OpenEdXInstanceConfigViewSet, self).create(request, *args, **kwargs)
 

--- a/registration/api/v2/views.py
+++ b/registration/api/v2/views.py
@@ -184,6 +184,8 @@ class OpenEdXInstanceConfigViewSet(
 
         This check if `external_domain` is filled, if so, generate a valid subdomain slug
         and fill in the field before passing it to the serializer.
+
+        Checks if public contact email is empty or not, if empty override it with user mail
         """
         external_domain = request.data.get('external_domain')
         if external_domain:
@@ -195,6 +197,13 @@ class OpenEdXInstanceConfigViewSet(
             self.request.data.update({
                 "subdomain": subdomain
             })
+
+        public_contact_email = request.data.get('public_contact_email')
+        if not public_contact_email:
+            self.request.data.update({
+                "public_contact_email": request.user.email
+            })
+
 
         # Perform create as usual
         return super(OpenEdXInstanceConfigViewSet, self).create(request, *args, **kwargs)

--- a/registration/tests/test_api.py
+++ b/registration/tests/test_api.py
@@ -347,7 +347,6 @@ class OpenEdXInstanceConfigAPITestCase(APITestCase):
         dict(instance_name=None),
         dict(instance_name=" "),
         dict(public_contact_email="invalid.email"),
-        dict(public_contact_email=None),
     )
     def test_instance_validation_failure(self, override):
         """


### PR DESCRIPTION
**Issue**: [BB-2444](https://tasks.opencraft.com/browse/BB-2444)

**Screenshots**(Updated):

![image](https://user-images.githubusercontent.com/8607745/82651220-7ea47f00-9c39-11ea-92f5-3138a56ae722.png)

![image](https://user-images.githubusercontent.com/8607745/82651244-882de700-9c39-11ea-83c1-1619536b5933.png)


Testing instructions:
* Go through the registration process by creating a new instance, check it works perfectly or not
* At the congratulation page, the message should be right.
* Go through by signing in and checking that the first time the public contact email should be similar to the user email you set when creating the instance.

**Reviewers**:
- [ ] @giovannicimolin 