### PR TITLE
BB-1848: Fix bug on status pill in the first deployment

### DIFF
--- a/frontend/src/console/components/RedeploymentToolbar/RedeploymentToolbar.tsx
+++ b/frontend/src/console/components/RedeploymentToolbar/RedeploymentToolbar.tsx
@@ -75,6 +75,7 @@ export const RedeploymentToolbar: React.FC<Props> = ({
         <CustomStatusPill
           loading={loading}
           redeploymentStatus={deploymentStatus}
+          deploymentType={deploymentType}
           cancelRedeployment={cancelDeploymentHandler}
         />
 

--- a/frontend/src/ui/components/CustomStatusPill/CustomStatusPill.tsx
+++ b/frontend/src/ui/components/CustomStatusPill/CustomStatusPill.tsx
@@ -1,7 +1,10 @@
 import * as React from 'react';
 import { WrappedMessage } from 'utils/intl';
 import { Tooltip, OverlayTrigger, Badge, Nav } from 'react-bootstrap';
-import { OpenEdXInstanceDeploymentStatusStatusEnum as DeploymentStatus } from 'ocim-client';
+import {
+  OpenEdXInstanceDeploymentStatusStatusEnum as DeploymentStatus,
+  OpenEdXInstanceDeploymentStatusDeploymentTypeEnum as DeploymentType
+} from 'ocim-client';
 
 import messages from './displayMessages';
 import './styles.scss';
@@ -9,12 +12,14 @@ import './styles.scss';
 interface Props {
   loading: boolean;
   redeploymentStatus: string | null;
+  deploymentType: string | null;
   cancelRedeployment: Function | undefined;
 }
 
 export const CustomStatusPill: React.FC<Props> = ({
   loading,
   redeploymentStatus,
+  deploymentType,
   cancelRedeployment
 }: Props) => {
   let dotColor = 'grey';
@@ -29,8 +34,19 @@ export const CustomStatusPill: React.FC<Props> = ({
       break;
     case DeploymentStatus.Provisioning:
       dotColor = '#ff9b04';
-      deploymentStatusText = 'runningDeployment';
-      tooltipText = 'runningDeploymentTooltip';
+      // If there's a deployment provisioning, but it's the
+      // first on (from registration), show preparing instance
+      // message.
+      if (deploymentType === DeploymentType.Registration) {
+        deploymentStatusText = 'preparingInstance';
+        tooltipText = 'preparingInstanceTooltip';
+      }
+      // If not, then this is a normal deployment, so show the usual
+      // running deployment message.
+      else {
+        deploymentStatusText = 'runningDeployment';
+        tooltipText = 'runningDeploymentTooltip';
+      }
       break;
     case DeploymentStatus.Preparing:
       dotColor = '#ff9b04';


### PR DESCRIPTION
This PR fixes a small bug in the status pill that shows the wrong deployment message in the first deployment.

**Testing instructions:**
1. Use the `master` branch.
2. Go to the registration form (http://localhost:3000) and create a new account (don't forget to activate the email).
3. Apply this diff to make testing easier:
```
diff --git a/registration/api/v2/views.py b/registration/api/v2/views.py
index 81fc8c2d..d36e54ed 100644
--- a/registration/api/v2/views.py
+++ b/registration/api/v2/views.py
@@ -547,7 +547,7 @@ class OpenEdxInstanceDeploymentViewSet(CreateAPIView, RetrieveDestroyAPIView, Ge
         data = {
             'undeployed_changes': undeployed_changes,
             'deployed_changes': deployed_changes,
-            'status': deployment_status.name,
+            'status': DeploymentState.provisioning.name,
             'deployment_type': deployment_type,
         }
```
4. Check that the status pill says deploying instead of preparing instance.
5. Checkout this branch.
6. Check that the status pill looks like this:
![image](https://user-images.githubusercontent.com/27893385/83035413-cc413300-a00f-11ea-8f48-e6303e0a8e2f.png)
