### PR TITLE
[SE-2666] Fix unexpected prefix purge

### DIFF
--- a/instance/models/utils.py
+++ b/instance/models/utils.py
@@ -586,13 +586,9 @@ class ConsulAgent:
     def purge(self):
         """
         Will remove the key/prefixed-key from Key-Value store.
-        If no key/prefixed-key is specified, all keys/prefixed-keys will be removed.
         :return: True if the operation succeeded, False otherwise.
         """
-        if not self.prefix:
-            return self._client.kv.delete(self.prefix, recurse=True)
-        else:
-            return self._client.kv.delete(self.prefix)
+        return self._client.kv.delete(self.prefix)
 
     @staticmethod
     def _cast_value(value):

--- a/instance/models/utils.py
+++ b/instance/models/utils.py
@@ -572,12 +572,6 @@ class ConsulAgent:
         stored['version'] = stored['version'] + 1
         return self._client.kv.put(self.prefix, json.dumps(stored).encode('utf-8'))
 
-    def remove_dict(self):
-        """
-        Remove a config dict using this instance's prefix.
-        """
-        self._client.kv.delete(self.prefix)
-
     def delete(self, key, **kwargs):
         """
         Will delete the given key/prefixed-key value from Consul's Key-Value store.
@@ -598,7 +592,7 @@ class ConsulAgent:
         if not self.prefix:
             return self._client.kv.delete(self.prefix, recurse=True)
         else:
-            return self._client.kv.delete(self.prefix, recurse=False)
+            return self._client.kv.delete(self.prefix)
 
     @staticmethod
     def _cast_value(value):

--- a/instance/models/utils.py
+++ b/instance/models/utils.py
@@ -591,10 +591,14 @@ class ConsulAgent:
 
     def purge(self):
         """
-        Will simply removes all keys/prefixed-keys from Key-Value store.
+        Will remove the key/prefixed-key from Key-Value store.
+        If no key/prefixed-key is specified, all keys/prefixed-keys will be removed.
         :return: True if the operation succeeded, False otherwise.
         """
-        return self._client.kv.delete(self.prefix, recurse=True)
+        if not self.prefix:
+            return self._client.kv.delete(self.prefix, recurse=True)
+        else:
+            return self._client.kv.delete(self.prefix, recurse=False)
 
     @staticmethod
     def _cast_value(value):

--- a/instance/tests/models/test_utils.py
+++ b/instance/tests/models/test_utils.py
@@ -851,21 +851,22 @@ class ConsulAgentTest(TestCase):
 
     def test_purge_with_prefix(self):
         """
-        Purging with prefix should only remove the prefixed keys with the given prefix.
+        Purging with prefix should only remove the key with the given prefix.
         All other values must not be touched.
         """
         prefix = 'nice-prefix'
         agent = ConsulAgent(prefix=prefix)
+        self.client.kv.put(prefix, 'only prefix value')
         self.client.kv.put(prefix + 'key', 'value')
         self.client.kv.put(prefix + 'another_key', 'another value')
         self.client.kv.put('dummy_key', '1')
 
         _, values = self.client.kv.get('', recurse=True)
-        self.assertEqual(len(values), 3)
+        self.assertEqual(len(values), 4)
 
         agent.purge()
         _, values = self.client.kv.get('', recurse=True)
-        self.assertEqual(len(values), 1)
+        self.assertEqual(len(values), 3)
 
     def test_cast_value(self):
         """

--- a/instance/tests/models/test_utils.py
+++ b/instance/tests/models/test_utils.py
@@ -849,25 +849,6 @@ class ConsulAgentTest(TestCase):
         _, values = self.client.kv.get('', recurse=True)
         self.assertIsNone(values)
 
-    def test_purge_with_prefix(self):
-        """
-        Purging with prefix should only remove the key with the given prefix.
-        All other values must not be touched.
-        """
-        prefix = 'nice-prefix'
-        agent = ConsulAgent(prefix=prefix)
-        self.client.kv.put(prefix, 'only prefix value')
-        self.client.kv.put(prefix + 'key', 'value')
-        self.client.kv.put(prefix + 'another_key', 'another value')
-        self.client.kv.put('dummy_key', '1')
-
-        _, values = self.client.kv.get('', recurse=True)
-        self.assertEqual(len(values), 4)
-
-        agent.purge()
-        _, values = self.client.kv.get('', recurse=True)
-        self.assertEqual(len(values), 3)
-
     def test_cast_value(self):
         """
         Test the supported casted values in our Consul agent. Currently supporting integers,
@@ -934,14 +915,6 @@ class ConsulAgentTest(TestCase):
         _, args, _ = mock_kv_put.mock_calls[0]
         self.assertEqual(args[0], self.agent.prefix)
         self.assertDictEqual({'key2': 'value2', 'version': 2}, json.loads(args[1].decode('utf-8')))
-
-    @patch.object(consul.Consul.KV, 'delete')
-    def test_remove_dict(self, mock_kv_delete):
-        """
-        Test delete a config dict.
-        """
-        self.agent.remove_dict()
-        mock_kv_delete.assert_called_with(self.agent.prefix)
 
     def tearDown(self):
         self.client.kv.delete('', recurse=True)

--- a/instance/tests/models/test_utils.py
+++ b/instance/tests/models/test_utils.py
@@ -833,21 +833,24 @@ class ConsulAgentTest(TestCase):
         _, values = self.client.kv.get('', recurse=True)
         self.assertEqual(len(values), 2)
 
-    def test_purge_no_prefix(self):
+    def test_purge_with_prefix(self):
         """
-        Purging with no prefix will remove all of the keys from Consul's Key-Value store
+        Purging with prefix should only remove the prefixed key.
+        All other values must not be touched.
         """
-        agent = ConsulAgent()
-        self.client.kv.put('key', 'value')
-        self.client.kv.put('another_key', 'another value')
+        prefix = 'nice-prefix'
+        agent = ConsulAgent(prefix=prefix)
+        self.client.kv.put(prefix, 'only prefix value')
+        self.client.kv.put(prefix + 'key', 'value')
+        self.client.kv.put(prefix + 'another_key', 'another value')
         self.client.kv.put('dummy_key', '1')
 
         _, values = self.client.kv.get('', recurse=True)
-        self.assertEqual(len(values), 3)
+        self.assertEqual(len(values), 4)
 
         agent.purge()
         _, values = self.client.kv.get('', recurse=True)
-        self.assertIsNone(values)
+        self.assertEqual(len(values), 3)
 
     def test_cast_value(self):
         """


### PR DESCRIPTION
This PR fixes the issue of consul purging all keys containing a prefix thus leading to unexpected deletions. 

**Issue:** [SE-2666](https://tasks.opencraft.com/browse/SE-2666)

**Testing Instructions:**
1. Checkout this branch and create an ocim instance such that it's id can be a prefix to already existing instance (use a non-critical instance)
2. Archive the instance and verify that only the consul data of the archived instance is removed and not the prefixed instance.


**Reviewers**

- [x] @pcockwell 
- [ ] @lgp171188 
