### PR TITLE
[SE-2743] Fix pr_watch in OCIM stage, which is often stuck in a retry loop doing GitHub API calls

### DIFF
--- a/pr_watch/github.py
+++ b/pr_watch/github.py
@@ -22,7 +22,7 @@ GitHub Service API - Helper functions
 
 # Imports #####################################################################
 
-from datetime import datetime
+from datetime import datetime, timedelta
 import functools
 import logging
 import operator
@@ -143,8 +143,11 @@ def get_pr_list_from_usernames(user_names, fork_name):
     if not user_names:
         return []
 
+    last_hour_dt = datetime.today() - timedelta(hours=1)
     authors = ' '.join('author:{author}'.format(author=author) for author in user_names)
-    q = 'is:open is:pr {authors} repo:{repo}'.format(authors=authors, repo=fork_name)
+    q = 'is:open is:pr {authors} repo:{repo} created:>{created_dt}'.format(authors=authors,
+                                                                           repo=fork_name,
+                                                                           created_dt=last_hour_dt)
     r_pr_list = get_object_from_url('https://api.github.com/search/issues?sort=created&q={}'.format(q))
 
     pr_list = []

--- a/pr_watch/github.py
+++ b/pr_watch/github.py
@@ -138,7 +138,7 @@ def get_pr_list_from_username(user_name, fork_name):
 
 def get_pr_list_from_usernames(user_names, fork_name):
     """
-    Retrieve the current active PRs for a given set of users
+    Retrieve active PRs from the previous hour for a given set of users
     """
     if not user_names:
         return []

--- a/pr_watch/github.py
+++ b/pr_watch/github.py
@@ -143,7 +143,7 @@ def get_pr_list_from_usernames(user_names, fork_name):
     if not user_names:
         return []
 
-    last_hour_dt = datetime.today() - timedelta(hours=1)
+    last_hour_dt = (datetime.today() - timedelta(hours=1)).date()
     authors = ' '.join('author:{author}'.format(author=author) for author in user_names)
     q = 'is:open is:pr {authors} repo:{repo} created:>{created_dt}'.format(authors=authors,
                                                                            repo=fork_name,

--- a/pr_watch/tasks.py
+++ b/pr_watch/tasks.py
@@ -44,7 +44,7 @@ logger = logging.getLogger(__name__)
 def watch_pr():
     """
     Automatically create sandboxes for PRs opened by members of the watched
-    organization on the watched repository
+    organization on the watched repository during the last hour
     """
     try:
         for watched_fork in WatchedFork.objects.filter(enabled=True):

--- a/pr_watch/tasks.py
+++ b/pr_watch/tasks.py
@@ -25,7 +25,7 @@ Worker tasks for development of Open edX
 import logging
 
 from huey.api import crontab
-from huey.contrib.djhuey import db_periodic_task
+from huey.contrib.djhuey import db_periodic_task, lock_task
 
 from instance.models.deployment import DeploymentType
 from instance.tasks import create_new_deployment
@@ -41,6 +41,7 @@ logger = logging.getLogger(__name__)
 # Tasks #######################################################################
 
 @db_periodic_task(crontab(minute='*/1'))
+@lock_task('watch_pr-lock')
 def watch_pr():
     """
     Automatically create sandboxes for PRs opened by members of the watched

--- a/pr_watch/tests/test_github.py
+++ b/pr_watch/tests/test_github.py
@@ -190,7 +190,6 @@ class GitHubTestCase(TestCase):
 
         mock_get_pr_by_number.side_effect = lambda fork_name, pr_number: [fork_name, pr_number]
 
-        print(github.get_pr_list_from_usernames(['itsjeyd', 'haikuginger'], 'edx/edx-platform'))
         self.assertEqual(
             github.get_pr_list_from_usernames(['itsjeyd', 'haikuginger'], 'edx/edx-platform'),
             [['edx/edx-platform', 9147], ['edx/edx-platform', 9146], ['edx/edx-platform', 15921]]


### PR DESCRIPTION
This PR reduce the scope of the filter used to check for new PR to avoid to many GitHub API calls.

**JIRA tickets**: [SE-2743](https://tasks.opencraft.com/browse/SE-2743)

**Author notes and concerns**:

1. I set 1 hour to check for PR created over the last hour. This expects that the previous 59 task calls already catch PR created before the last hour. This limit can be changed.

**Reviewers**
- [ ]  @pkulkark 
