### PR TITLE
SE-2211 Add FAQ page

### DIFF
--- a/frontend/src/global/constants.ts
+++ b/frontend/src/global/constants.ts
@@ -13,6 +13,7 @@ export const ENTERPRISE_COMPARISON_LINK =
 export const TOS_LINK = process.env.REACT_APP_TOS_LINK || '/#';
 export const PRIVACY_POLICY_LINK =
   process.env.REACT_APP_PRIVACY_POLICY_LINK || '/#';
+export const FAQ_PAGE_LINK = process.env.REACT_APP_FAQ_PAGE_LINK || '/#';
 
 export const INTERNAL_DOMAIN_NAME =
   process.env.REACT_APP_INTERNAL_DOMAIN_NAME || '.opencraft.hosting';

--- a/frontend/src/ui/components/Header/Header.tsx
+++ b/frontend/src/ui/components/Header/Header.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Container, Nav, Navbar } from 'react-bootstrap';
-import { CONTACT_US_LINK, ROUTES } from 'global/constants';
+import { CONTACT_US_LINK, FAQ_PAGE_LINK, ROUTES } from 'global/constants';
 import { NavLink, Route } from 'react-router-dom';
 import logo from 'assets/icons.svg';
 import './styles.scss';
@@ -22,6 +22,13 @@ export const Header: React.FC = () => {
         <Navbar.Collapse id="basic-navbar-nav">
           <Nav className="ml-auto">
             <Route path={ROUTES.Registration.HOME}>
+              <Nav.Link
+                className="nav-link"
+                target="_blank"
+                href={FAQ_PAGE_LINK}
+              >
+                FAQ
+              </Nav.Link>
               <NavLink className="nav-link" to={ROUTES.Auth.LOGIN}>
                 Login
               </NavLink>


### PR DESCRIPTION
Adds a FAQ page based on the document mentioned in the ticket, and adds a link to the said page on the header.

**JIRA ticket**: SE-2211

**Screenshots**:
Homepage with link to the page:
![screenshot_1](https://user-images.githubusercontent.com/4343949/85282824-059f7e00-b4aa-11ea-8f26-30ebad27150b.png)

~The FAQ page:~ This page has been removed, and instead the link would be to a opencraft.com page
![screenshot_2](https://user-images.githubusercontent.com/4343949/85282842-0b955f00-b4aa-11ea-98c3-1fce27fa5488.png)

**Testing instructions:**
- Checkout this branch.
- Enter new frontend subdirectory: cd frontend
- Build Ocim API client: `./scripts/build-api-client.sh`
- Reinstall dependencies: `npm install`
- Run frontend, npm start.
- Go to http://localhost:3000/
- You should see the link to FAQ on the header, which takes you to the FAQ page.

**Reviewers:**
- [ ] @gabrieldamours 