### PR TITLE
[SE-2599] Fix flaky integration tests

### DIFF
--- a/instance/models/utils.py
+++ b/instance/models/utils.py
@@ -572,12 +572,6 @@ class ConsulAgent:
         stored['version'] = stored['version'] + 1
         return self._client.kv.put(self.prefix, json.dumps(stored).encode('utf-8'))
 
-    def remove_dict(self):
-        """
-        Remove a config dict using this instance's prefix.
-        """
-        self._client.kv.delete(self.prefix)
-
     def delete(self, key, **kwargs):
         """
         Will delete the given key/prefixed-key value from Consul's Key-Value store.
@@ -591,10 +585,10 @@ class ConsulAgent:
 
     def purge(self):
         """
-        Will simply removes all keys/prefixed-keys from Key-Value store.
+        Will remove the key/prefixed-key from Key-Value store.
         :return: True if the operation succeeded, False otherwise.
         """
-        return self._client.kv.delete(self.prefix, recurse=True)
+        return self._client.kv.delete(self.prefix)
 
     @staticmethod
     def _cast_value(value):


### PR DESCRIPTION
This PR increases the retries for spawning new OpenedX appservers by 2, to avoid some integration test failures in CircleCI.

**JIRA tickets**: [SE-2599](https://tasks.opencraft.com/browse/SE-2599)

**Author notes and concerns**:

1. This is the first approach to solve this issue given by @lgp171188.
2. Not sure how to test it given the flaky nature of the failures. Maybe leave it open for a month or something like that to see if it happens again?

**Reviewers**
- [x] @mtyaka 
