### PR TITLE
[BB-2696] Allow configuring course visibility from Studio

### DIFF
--- a/instance/models/mixins/openedx_config.py
+++ b/instance/models/mixins/openedx_config.py
@@ -255,6 +255,10 @@ class OpenEdXConfigMixin(ConfigMixinBase):
             # Restart them every 1-2 days.
             "EDXAPP_CMS_MAX_REQ": 1000,
 
+            # Allow configuring the course visibility from Studio.
+            "EDXAPP_COURSE_CATALOG_VISIBILITY_PERMISSION": "see_in_catalog",
+            "EDXAPP_COURSE_ABOUT_VISIBILITY_PERMISSION": "see_about_page",
+
             # Celery workers
             "EDXAPP_WORKER_DEFAULT_STOPWAITSECS": 1200,
 


### PR DESCRIPTION
This PR adds the ansible variables that allow configuring the course visibility from Studio. See [here](https://github.com/edx/configuration/blob/master/playbooks/roles/edxapp/defaults/main.yml#L728-L729) for the defaults and see the assignment to the corresponding environment variables [here](https://github.com/edx/configuration/blob/master/playbooks/roles/edxapp/defaults/main.yml#L1244-L1245).

**Testing instructions**:
* Add the following to `lms.env.json`
  ```javascript
  {
    ...
    "COURSE_CATALOG_VISIBILITY_PERMISSION": "see_in_catalog",
    "COURSE_ABOUT_VISIBILITY_PERMISSION": "see_about_page"
    ...
  }
  ```
  or `lms.yml`
  ```yaml
  COURSE_CATALOG_VISIBILITY_PERMISSION: see_in_catalog
  COURSE_ABOUT_VISIBILITY_PERMISSION: see_about_page
  ```
* Restart LMS and Studio.
* Configure the course visibility settings in the `Advanced Settings` page of the course in Studio and for example, hide the course from the catalog and the about page.
* Verify that the course is hidden from the catalog and the about page is hidden as well. Since the home page is cached for anonymous users, this might take a few minutes to get applied on the home page.