### PR TITLE
SE-2865 Disable the new OCIM console for staff users

### DIFF
--- a/frontend/packages/api_client/src/apis/V2Api.ts
+++ b/frontend/packages/api_client/src/apis/V2Api.ts
@@ -580,7 +580,7 @@ export class V2Api extends runtime.BaseAPI {
     }
 
     /**
-     * Open edX Instance Configuration API.  This API can be used to manage the configuration for Open edX instances owned by clients.
+     * Endpoint for getting the list of instances owned by the current user.  If the user is staff, return a 400 error. This is used by the frontend to prevent staff users from accidentally accessing and updating other users\' instances (see SE-2865).
      * Get all instances owned by user
      */
     async instancesOpenedxConfigListRaw(): Promise<runtime.ApiResponse<Array<OpenEdXInstanceConfig>>> {
@@ -606,7 +606,7 @@ export class V2Api extends runtime.BaseAPI {
     }
 
     /**
-     * Open edX Instance Configuration API.  This API can be used to manage the configuration for Open edX instances owned by clients.
+     * Endpoint for getting the list of instances owned by the current user.  If the user is staff, return a 400 error. This is used by the frontend to prevent staff users from accidentally accessing and updating other users\' instances (see SE-2865).
      * Get all instances owned by user
      */
     async instancesOpenedxConfigList(): Promise<Array<OpenEdXInstanceConfig>> {

--- a/frontend/scripts/update-api-client.sh
+++ b/frontend/scripts/update-api-client.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 set -euxo pipefail
 
-rm -f packages/api_client/apis/*.ts
-rm -f packages/api_client/models/*.ts
+rm -f packages/api_client/src/apis/*.ts
+rm -f packages/api_client/src/models/*.ts
 
 docker run --rm --network="host" -v ${PWD}:/local \
     openapitools/openapi-generator-cli:v4.3.1 generate \

--- a/frontend/src/console/actions.ts
+++ b/frontend/src/console/actions.ts
@@ -225,9 +225,11 @@ export const listUserInstances = (): OcimThunkAction<
         data: response
       });
     })
-    .catch((e: any) => {
+    .catch(async (e: any) => {
+      const error = await e.json();
       dispatch({
-        type: Types.USER_INSTANCE_LIST_FAILURE
+        type: Types.USER_INSTANCE_LIST_FAILURE,
+        error
       });
     });
 };

--- a/frontend/src/console/components/ConsolePage/ConsolePage.tsx
+++ b/frontend/src/console/components/ConsolePage/ConsolePage.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { CustomizationSideMenu, RedeploymentToolbar } from 'console/components';
-import { EmailActivationAlertMessage } from 'ui/components';
+import { EmailActivationAlertMessage, ErrorPage } from 'ui/components';
+import { OCIM_API_BASE } from 'global/constants';
 import { Row, Col, Container } from 'react-bootstrap';
 import { WrappedMessage } from 'utils/intl';
 import { InstancesModel } from 'console/models';
@@ -114,6 +115,20 @@ export class ConsolePageComponent extends React.PureComponent<Props> {
       }
       return this.props.children;
     };
+    if (
+      this.props.error &&
+      this.props.error.code === 'NOT_ACCESSIBLE_TO_STAFF'
+    ) {
+      return (
+        <ErrorPage
+          messages={messages}
+          messageId="notAllowedForStaff"
+          values={{
+            link: (text: string) => <a href={OCIM_API_BASE}>{text}</a>
+          }}
+        />
+      );
+    }
 
     let deploymentLoading = true;
     if (this.props.activeInstance && this.props.activeInstance.loading) {

--- a/frontend/src/console/components/ConsolePage/displayMessages.ts
+++ b/frontend/src/console/components/ConsolePage/displayMessages.ts
@@ -2,6 +2,11 @@ const messages = {
   editCourses: {
     defaultMessage: 'Edit courses (Studio)',
     description: 'Label to Studio link.'
+  },
+  notAllowedForStaff: {
+    defaultMessage:
+      'This page is not accessible by staff users yet. Use <link>this link</link> instead.',
+    description: 'Error message for staff users'
   }
 };
 

--- a/frontend/src/console/models.ts
+++ b/frontend/src/console/models.ts
@@ -32,6 +32,7 @@ export interface DeploymentInfoModel {
 // a request. This allows us to individually update fields.
 export interface InstancesModel {
   loading: boolean;
+  error: any;
   activeInstance: {
     data: InstanceSettingsModel | null;
     feedback: Partial<InstanceSettingsModel>;
@@ -43,6 +44,7 @@ export interface InstancesModel {
 
 export const initialConsoleState: Readonly<InstancesModel> = {
   loading: false,
+  error: null,
   activeInstance: {
     data: null,
     feedback: {},

--- a/frontend/src/console/reducers.ts
+++ b/frontend/src/console/reducers.ts
@@ -37,6 +37,11 @@ export function consoleReducer(
           }
         }
       });
+    case Actions.Types.USER_INSTANCE_LIST_FAILURE:
+      return update(state, {
+        loading: { $set: false },
+        error: { $set: action.error }
+      });
     case Actions.Types.UPDATE_INSTANCE_INFO:
       return update(state, {
         activeInstance: {

--- a/frontend/src/ui/components/ErrorPage/ErrorPage.spec.tsx
+++ b/frontend/src/ui/components/ErrorPage/ErrorPage.spec.tsx
@@ -2,7 +2,23 @@ import React from 'react';
 import { setupComponentForTesting } from "utils/testing";
 import { ErrorPage } from './ErrorPage';
 
-it('renders without crashing', () => {
+it('renders with default message', () => {
     const tree = setupComponentForTesting(<ErrorPage />).toJSON();
+    expect(tree).toMatchSnapshot();
+});
+
+it('renders with custom message', () => {
+    const testMessages = {
+        testError: {
+            defaultMessage: 'Test Error Message',
+            description: ''
+        }
+    }
+    const tree = setupComponentForTesting(
+        <ErrorPage
+            messages={testMessages}
+            messageId="testError"
+        />
+    ).toJSON();
     expect(tree).toMatchSnapshot();
 });

--- a/frontend/src/ui/components/ErrorPage/ErrorPage.tsx
+++ b/frontend/src/ui/components/ErrorPage/ErrorPage.tsx
@@ -4,15 +4,37 @@ import { WrappedMessage } from 'utils/intl';
 import messages from './displayMessages';
 import './styles.scss';
 
-export const ErrorPage: React.FC = () => (
-  <div className="error-page">
-    <div className="error-container">
-      <Row className="error-page-content">
+interface ErrorPageProps {
+  messages?: any;
+  messageId?: string;
+  values?: any;
+}
+
+export const ErrorPage: React.FC<ErrorPageProps> = (props: ErrorPageProps) => {
+  let body;
+  if (props.messages && props.messageId) {
+    body = (
+      <WrappedMessage
+        id={props.messageId}
+        messages={props.messages}
+        values={props.values}
+      />
+    );
+  } else {
+    body = (
+      <>
         <p>
           <WrappedMessage id="somethingWrong" messages={messages} />
         </p>
         <WrappedMessage id="errorMessage" messages={messages} />
-      </Row>
+      </>
+    );
+  }
+  return (
+    <div className="error-page">
+      <div className="error-container">
+        <Row className="error-page-content">{body}</Row>
+      </div>
     </div>
-  </div>
-);
+  );
+};

--- a/frontend/src/ui/components/ErrorPage/__snapshots__/ErrorPage.spec.tsx.snap
+++ b/frontend/src/ui/components/ErrorPage/__snapshots__/ErrorPage.spec.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`renders without crashing 1`] = `
+exports[`renders with default message 1`] = `
 <div
   className="error-page"
 >
@@ -14,6 +14,22 @@ exports[`renders without crashing 1`] = `
         Something went wrong!
       </p>
       We hit an internal server error, try again soon, or, if that doesn't work, contact us.
+    </div>
+  </div>
+</div>
+`;
+
+exports[`renders with custom message 1`] = `
+<div
+  className="error-page"
+>
+  <div
+    className="error-container"
+  >
+    <div
+      className="error-page-content row"
+    >
+      Test Error Message
     </div>
   </div>
 </div>

--- a/frontend/src/ui/components/ErrorPage/styles.scss
+++ b/frontend/src/ui/components/ErrorPage/styles.scss
@@ -30,6 +30,7 @@
           margin: 0 auto;
           max-width: 700px;
           justify-content: center;
+          white-space: pre-wrap;
       }
   }
 }

--- a/registration/api/v2/views.py
+++ b/registration/api/v2/views.py
@@ -401,6 +401,23 @@ class OpenEdXInstanceConfigViewSet(
 
             return Response(status=status.HTTP_200_OK, data=application.draft_static_content_overrides)
 
+    def list(self, request, *args, **kwargs):
+        """
+        Endpoint for getting the list of instances owned by the current user.
+
+        If the user is staff, return a 400 error. This is used by the frontend to prevent
+        staff users from accidentally accessing and updating other users' instances (see SE-2865).
+        """
+        if request.user.is_staff:
+            return Response(
+                status=status.HTTP_400_BAD_REQUEST,
+                data={
+                    'code': 'NOT_ACCESSIBLE_TO_STAFF',
+                    'details': "Not allowed for staff users"
+                }
+            )
+        return super(OpenEdXInstanceConfigViewSet, self).list(request, *args, **kwargs)
+
     def get_queryset(self):
         """
         Get `BetaTestApplication` instances owned by current user.


### PR DESCRIPTION
This PR disables the new OCIM console for staff users

**JIRA tickets**: [SE-2865](https://tasks.opencraft.com/browse/SE-2865)

**Screenshots**:
<img width="1272" alt="Screen Shot 2020-07-07 at 12 33 39" src="https://user-images.githubusercontent.com/4343949/86735955-ca2bb480-c050-11ea-86af-73c171e2399c.png">

**Testing instructions**:

- Checkout this branch.
- Enter new frontend subdirectory: `cd frontend`
- Build Ocim API client: `./scripts/build-api-client.sh`
- Reinstall dependencies: `npm install`
- Run tests - `npm test`
- Run frontend - `npm start`
- Go to `http://localhost:3000/` and login as a staff user
- You should see the above error page.
- Logout and login as a normal user - you should be able to see the OCIM console as usual.

**Reviewers**
- [ ] @mtyaka