### PR TITLE
[SE-2729] OCIM add instance description field

### DIFF
--- a/instance/api/instance.py
+++ b/instance/api/instance.py
@@ -124,7 +124,7 @@ class InstanceViewSet(viewsets.ReadOnlyModelViewSet):
         """
         Update notes attribute of selected instance.
         """
-        if not request.user.is_staff:
+        if not request.user.is_staff or not request.user.is_superuser:
             return Response(
                 {"error": "You do not have permissions to edit this field."},
                 status=status.HTTP_403_FORBIDDEN

--- a/instance/api/instance.py
+++ b/instance/api/instance.py
@@ -124,6 +124,11 @@ class InstanceViewSet(viewsets.ReadOnlyModelViewSet):
         """
         Update notes attribute of selected instance.
         """
+        if not request.user.is_staff:
+            return Response(
+                {"error": "You do not have permissions to edit this field."},
+                status=status.HTTP_403_FORBIDDEN
+            )
         if 'notes' not in request.data:
             return Response({'status': 'No notes value provided.'})
 

--- a/instance/serializers/instance.py
+++ b/instance/serializers/instance.py
@@ -115,6 +115,15 @@ class InstanceReferenceDetailedSerializer(InstanceReferenceBasicSerializer):
     """
     summary_only = False
 
+    def __init__(self, *args, **kwargs):
+        super(InstanceReferenceDetailedSerializer, self).__init__(*args, **kwargs)
+
+        if 'context' in kwargs:
+            if 'request' in kwargs['context']:
+                request = kwargs['context']['request']
+                if not request.user.is_staff:
+                    self.fields.pop('notes')
+
 
 class InstanceLogSerializer(serializers.ModelSerializer):
     """

--- a/instance/serializers/instance.py
+++ b/instance/serializers/instance.py
@@ -121,7 +121,7 @@ class InstanceReferenceDetailedSerializer(InstanceReferenceBasicSerializer):
         if 'context' in kwargs:
             if 'request' in kwargs['context']:
                 request = kwargs['context']['request']
-                if not request.user.is_staff:
+                if not request.user.is_staff or not request.user.is_superuser:
                     self.fields.pop('notes')
 
 

--- a/instance/static/html/instance/details.html
+++ b/instance/static/html/instance/details.html
@@ -28,7 +28,7 @@
   </div>
 </div>
 
-<div class="panel" ng-controller="Details">
+<div class="panel" ng-controller="Details" ng-if="showNotes">
   <div class="row">
     <div class="large-10 columns">
       <h3>Notes <a ng-click="isEditingNotes=true"><i class="fa fa-edit"></i></a></h3>

--- a/instance/static/js/src/instance.js
+++ b/instance/static/js/src/instance.js
@@ -155,6 +155,8 @@ app.controller("Details", ['$scope', '$state', '$stateParams', 'OpenCraftAPI',
             $scope.isEditingNotes = false;
             $scope.originalNotes = "";
 
+            $scope.showNotes = false;
+
             $scope.refresh();
         };
 
@@ -239,7 +241,13 @@ app.controller("Details", ['$scope', '$state', '$stateParams', 'OpenCraftAPI',
                     $scope.is_spawning_appserver = false;
                 }
                 $scope.old_appserver_count = instance.appserver_count;
-                $scope.originalNotes = $scope.instance.notes;
+                if ('notes' in $scope.instance) {
+                    $scope.originalNotes = $scope.instance.notes;
+                    $scope.showNotes = true;
+                } else {
+                    $scope.showNotes = false;
+                }
+
             });
         };
 


### PR DESCRIPTION
This PR adds filter to instance `notes` field to display them only for `staff` and `superuser` users only.

**JIRA ticket**: [SE-2729](https://tasks.opencraft.com/browse/SE-2729)

**Reviewers**
- [x] @swalladge 
