### PR TITLE
Fix Ocim integration test failures

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -169,11 +169,16 @@ jobs:
       - run:
           name: Run Consul
           command: |
-            echo Running consul agent to connect to the integration consul server
             sudo wget -P /tmp https://releases.hashicorp.com/consul/1.2.1/consul_1.2.1_linux_amd64.zip
             sudo unzip /tmp/consul_1.2.1_linux_amd64.zip -d /usr/local/bin
             mkdir -p /tmp/consul-data
-            consul agent -retry-join haproxy-integration.net.opencraft.hosting -data-dir /tmp/consul-data
+            if [[ "<< parameters.tests_type >>" == "test.integration" ]] ; then
+              echo Running consul agent to connect to the integration consul server
+              consul agent -retry-join $CONSUL_SERVERS -encrypt $CONSUL_ENCRYPT -data-dir /tmp/consul-data
+            else
+              echo Running a local consul agent
+              consul agent -dev
+            fi
           background: true
       - save_cache:
           key: dependencies-{{ checksum "requirements.txt" }}
@@ -260,7 +265,7 @@ jobs:
             sudo wget -P /tmp https://releases.hashicorp.com/consul/1.2.1/consul_1.2.1_linux_amd64.zip
             sudo unzip /tmp/consul_1.2.1_linux_amd64.zip -d /usr/local/bin
             mkdir -p /tmp/consul-data
-            consul agent -retry-join haproxy-integration.net.opencraft.hosting -data-dir /tmp/consul-data
+            consul agent -retry-join $CONSUL_SERVERS -encrypt $CONSUL_ENCRYPT -data-dir /tmp/consul-data
           background: true
       - run:
           name: Wait for Redis

--- a/instance/models/openedx_appserver.py
+++ b/instance/models/openedx_appserver.py
@@ -331,7 +331,7 @@ class OpenEdXAppServer(AppServer, OpenEdXAppConfiguration, AnsibleAppServerMixin
             variables=self.lms_user_settings,
         )
 
-    def manage_services_playbook(self, action, services="all"):
+    def manage_services_playbook(self, action, services="edxapp_worker:"):
         """
         Return a Playbook instance for creating LMS users.
         """
@@ -610,9 +610,9 @@ class OpenEdXAppServer(AppServer, OpenEdXAppConfiguration, AnsibleAppServerMixin
         taking tasks from the celery queues.
         """
         if active:
-            action = 'start'
+            action = 'started'
         else:
-            action = 'stop'
+            action = 'stopped'
 
         playbook = self.manage_services_playbook(action=action)
         _, returncode = self._run_playbook(

--- a/instance/tests/integration/utils.py
+++ b/instance/tests/integration/utils.py
@@ -27,7 +27,7 @@ import time
 import requests
 
 
-def get_url_contents(url, auth=None, attempts=3, delay=15, verify_ssl=True):
+def get_url_contents(url, auth=None, attempts=10, delay=60, verify_ssl=True):
     """
     Connect to the given URL and returns its contents as a string.
     Does several attempts in case the first one failed.
@@ -53,7 +53,7 @@ def get_url_contents(url, auth=None, attempts=3, delay=15, verify_ssl=True):
         time.sleep(delay)
 
 
-def check_url_accessible(url, auth=None, attempts=3, delay=15):
+def check_url_accessible(url, auth=None, attempts=10, delay=60):
     """
     Check that the given URL is accessible and that it returns a success status code.
 

--- a/instance/tests/integration/utils.py
+++ b/instance/tests/integration/utils.py
@@ -20,11 +20,14 @@
 Integration tests - helper functions.
 """
 
+import logging
 import pathlib
 import socket
 import time
 
 import requests
+
+logger = logging.getLogger(__name__)
 
 
 def get_url_contents(url, auth=None, attempts=10, delay=60, verify_ssl=True):
@@ -36,6 +39,7 @@ def get_url_contents(url, auth=None, attempts=10, delay=60, verify_ssl=True):
     Raises an exception if there is an HTTP error.
     """
     ca_path = str(pathlib.Path(__file__).parent / "certs" / "lets-encrypt-staging-ca.pem")
+    total_attempts = attempts
 
     while True:
         attempts -= 1
@@ -48,6 +52,7 @@ def get_url_contents(url, auth=None, attempts=10, delay=60, verify_ssl=True):
             res.raise_for_status()
             return res.text
         except Exception:  # pylint: disable=broad-except
+            logger.error('Attempt: %d - Unable to retrieve %s. ', total_attempts - attempts, url)
             if not attempts:
                 raise
         time.sleep(delay)

--- a/instance/tests/models/test_openedx_appserver.py
+++ b/instance/tests/models/test_openedx_appserver.py
@@ -657,7 +657,7 @@ class OpenEdXAppServerTestCase(TestCase):
             source_repo=os.path.join(settings.SITE_ROOT, 'playbooks/manage_services'),
             playbook_path='manage_services.yml',
             requirements_path='requirements.txt',
-            variables='services: all\nsupervisord_action: start\n'
+            variables="services: 'edxapp_worker:'\nsupervisord_action: started\n"
         )
 
         appserver.manage_instance_services(active=True)

--- a/playbooks/manage_services/manage_services.yml
+++ b/playbooks/manage_services/manage_services.yml
@@ -7,5 +7,7 @@
   become: yes
   tasks:
     - name: Change state of supervisord managed services
-      command: /edx/bin/supervisorctl {{ supervisord_action }} {{ services }}
-      retries: 3
+      supervisorctl:
+        name:  "{{ services }}"
+        state: "{{ supervisord_action }}"
+        supervisorctl_path: /edx/bin/supervisorctl


### PR DESCRIPTION
This PR
* Adds changes to only start/stop the celery workers on appserver activation/deactivation. This prevents the unit tests related to Consul from being skipped. This has to be tested and verified on stage.
* Fixes the consul configuration which was breaking unit and integration tests - enables consul encryption for the integration tests and the cleanup job and runs consul in dev mode for everything else.
* Increases the retries and the delay between retries when checking whether the integration test instance is up or not. Also adds logging to show the retries.