### PR TITLE
[SE-2865] Update URL for old OCIM

### DIFF
--- a/frontend/src/console/components/ConsolePage/ConsolePage.tsx
+++ b/frontend/src/console/components/ConsolePage/ConsolePage.tsx
@@ -144,7 +144,9 @@ export class ConsolePageComponent extends React.PureComponent<Props> {
           messages={messages}
           messageId="notAllowedForStaff"
           values={{
-            link: (text: string) => <a href={OCIM_API_BASE}>{text}</a>
+            link: (text: string) => (
+              <a href={`${OCIM_API_BASE}/instance`}>{text}</a>
+            )
           }}
         />
       );


### PR DESCRIPTION
See #602 for complete details

**JIRA tickets**: [SE-2865](https://tasks.opencraft.com/browse/SE-2865)

This is a follow-up to that PR, where the URL has been updated from `/` to `/instance`, as the former one redirects back to the new console on stage

**Reviewers**: @mtyaka