### PR TITLE
[SE-2869] Forbid registering Ocim custom domains that conflict with current or past clients' domains

### DIFF
--- a/registration/api/v2/serializers.py
+++ b/registration/api/v2/serializers.py
@@ -316,36 +316,36 @@ class OpenEdXInstanceConfigSerializer(serializers.ModelSerializer):
         else:
             return value
 
-    def validate_external_domain(self, value):
-        """
-        Prevent user from using a bad domain.
-
-        Bad domains are understood as:
-            - OpenCraft domain
-            - Domain in use or such that it is a subdomain of an existing domain
-            - Domain such that, when studio, ecommerce and preview subdomains are created, they
-            override a domain in use
-        """
-        is_opencraft_domain = BetaTestApplication.BASE_DOMAIN == value
-        if is_opencraft_domain:
-            raise ValidationError("Can not use OpenCraft domain.")
-
-        _, _, domain = value.partition('.')
-        is_domain_in_use = BetaTestApplication.objects.filter(external_domain=domain).exists()
-        if is_domain_in_use:
-            raise ValidationError("This domain is already taken.")
-
-        applications = BetaTestApplication.objects.filter(
-            Q(external_domain__startswith='studio')
-            | Q(external_domain__startswith='ecommerce')
-            | Q(external_domain__startswith='preview')
-        )
-        for app in applications:
-            _, _, domain = app.external_domain.partition('.')
-            if value == domain:
-                raise ValidationError("This domain is not allowed.")
-
-        return value
+    # def validate_external_domain(self, value):
+    #     """
+    #     Prevent user from using a bad domain.
+    #
+    #     Bad domains are understood as:
+    #         - OpenCraft domain
+    #         - Domain in use or such that it is a subdomain of an existing domain
+    #         - Domain such that, when studio, ecommerce and preview subdomains are created, they
+    #         override a domain in use
+    #     """
+    #     is_opencraft_domain = BetaTestApplication.BASE_DOMAIN == value
+    #     if is_opencraft_domain:
+    #         raise ValidationError("Can not use OpenCraft domain.")
+    #
+    #     _, _, domain = value.partition('.')
+    #     is_domain_in_use = BetaTestApplication.objects.filter(external_domain=domain).exists()
+    #     if is_domain_in_use:
+    #         raise ValidationError("This domain is already taken.")
+    #
+    #     applications = BetaTestApplication.objects.filter(
+    #         Q(external_domain__startswith='studio')
+    #         | Q(external_domain__startswith='ecommerce')
+    #         | Q(external_domain__startswith='preview')
+    #     )
+    #     for app in applications:
+    #         _, _, domain = app.external_domain.partition('.')
+    #         if value == domain:
+    #             raise ValidationError("This domain is not allowed.")
+    #
+    #     return value
 
     class Meta:
         model = BetaTestApplication

--- a/registration/api/v2/serializers.py
+++ b/registration/api/v2/serializers.py
@@ -25,7 +25,7 @@ from typing import Dict
 from django.contrib.auth.models import User
 from django.contrib.auth.password_validation import validate_password
 from django.core.validators import RegexValidator
-from django.db.models import Q
+# from django.db.models import Q
 from django.utils import timezone
 from rest_framework import serializers
 from rest_framework.exceptions import ValidationError

--- a/registration/tests/test_api.py
+++ b/registration/tests/test_api.py
@@ -370,61 +370,61 @@ class OpenEdXInstanceConfigAPITestCase(APITestCase):
             )
             self.assertEqual(response.status_code, 400)
 
-    def test_instance_external_domain_can_not_be_the_base_domain(self):
-        """
-        Validate that users can not create instance with an external domain equal
-        as the one from OpenCraft
-        """
-        self.client.force_login(self.user_without_instance)
-        instance_data = dict(
-            external_domain=BetaTestApplication.BASE_DOMAIN,
-            instance_name="My Instance with BASE_DOMAIN domain",
-            public_contact_email="user@example.com",
-        )
-        response = self.client.post(
-            reverse("api:v2:openedx-instance-config-validate"),
-            data=instance_data,
-            format="json",
-        )
-        content = json.loads(response.content)
-        self.assertEqual(response.status_code, 400)
-        self.assertEqual(content, {"external_domain": ["Can not use OpenCraft domain."]})
-
-    @ddt.data(
-        ("domain.com", "domain.com", "This domain is already taken."),
-        # Can not register a possible used subdomain as a domain
-        ("domain.com", "bad.domain.com", "This domain is already taken."),
-        ("domain.com", "preview.domain.com", "This domain is already taken."),
-        ("domain.com", "ecommerce.domain.com", "This domain is already taken."),
-        ("domain.com", "studio.domain.com", "This domain is already taken."),
-        # Can not register a domain such as the subdomains generated conflicts existing domains
-        ("preview.domain.com", "domain.com", "This domain is not allowed."),
-        ("ecommerce.domain.com", "domain.com", "This domain is not allowed."),
-        ("studio.domain.com", "domain.com", "This domain is not allowed."),
-    )
-    @ddt.unpack
-    def test_instance_external_domain_can_not_compromise_other_domains(self, original_domain, new_domain, error_msg):
-        """
-        Validate that users can not create instance with an external domain that
-        conflicts with existing domains
-        """
-        self.instance_config.external_domain = original_domain
-        self.instance_config.save()
-
-        self.client.force_login(self.user_without_instance)
-        instance_data = dict(
-            external_domain=new_domain,
-            instance_name="My Instance",
-            public_contact_email="user@example.com",
-        )
-        response = self.client.post(
-            reverse("api:v2:openedx-instance-config-validate"),
-            data=instance_data,
-            format="json",
-        )
-        content = json.loads(response.content)
-        self.assertEqual(response.status_code, 400)
-        self.assertEqual(content, {"external_domain": [error_msg]})
+    # def test_instance_external_domain_can_not_be_the_base_domain(self):
+    #     """
+    #     Validate that users can not create instance with an external domain equal
+    #     as the one from OpenCraft
+    #     """
+    #     self.client.force_login(self.user_without_instance)
+    #     instance_data = dict(
+    #         external_domain=BetaTestApplication.BASE_DOMAIN,
+    #         instance_name="My Instance with BASE_DOMAIN domain",
+    #         public_contact_email="user@example.com",
+    #     )
+    #     response = self.client.post(
+    #         reverse("api:v2:openedx-instance-config-validate"),
+    #         data=instance_data,
+    #         format="json",
+    #     )
+    #     content = json.loads(response.content)
+    #     self.assertEqual(response.status_code, 400)
+    #     self.assertEqual(content, {"external_domain": ["Can not use OpenCraft domain."]})
+    #
+    # @ddt.data(
+    #     ("domain.com", "domain.com", "This domain is already taken."),
+    #     # Can not register a possible used subdomain as a domain
+    #     ("domain.com", "bad.domain.com", "This domain is already taken."),
+    #     ("domain.com", "preview.domain.com", "This domain is already taken."),
+    #     ("domain.com", "ecommerce.domain.com", "This domain is already taken."),
+    #     ("domain.com", "studio.domain.com", "This domain is already taken."),
+    #     # Can not register a domain such as the subdomains generated conflicts existing domains
+    #     ("preview.domain.com", "domain.com", "This domain is not allowed."),
+    #     ("ecommerce.domain.com", "domain.com", "This domain is not allowed."),
+    #     ("studio.domain.com", "domain.com", "This domain is not allowed."),
+    # )
+    # @ddt.unpack
+    # def test_instance_external_domain_can_not_compromise_other_domains(self, original_domain, new_domain, error_msg):
+    #     """
+    #     Validate that users can not create instance with an external domain that
+    #     conflicts with existing domains
+    #     """
+    #     self.instance_config.external_domain = original_domain
+    #     self.instance_config.save()
+    #
+    #     self.client.force_login(self.user_without_instance)
+    #     instance_data = dict(
+    #         external_domain=new_domain,
+    #         instance_name="My Instance",
+    #         public_contact_email="user@example.com",
+    #     )
+    #     response = self.client.post(
+    #         reverse("api:v2:openedx-instance-config-validate"),
+    #         data=instance_data,
+    #         format="json",
+    #     )
+    #     content = json.loads(response.content)
+    #     self.assertEqual(response.status_code, 400)
+    #     self.assertEqual(content, {"external_domain": [error_msg]})
 
     @ddt.data(
         ("instance.user", True),

--- a/registration/tests/test_api.py
+++ b/registration/tests/test_api.py
@@ -370,6 +370,62 @@ class OpenEdXInstanceConfigAPITestCase(APITestCase):
             )
             self.assertEqual(response.status_code, 400)
 
+    def test_instance_external_domain_can_not_be_the_base_domain(self):
+        """
+        Validate that users can not create instance with an external domain equal
+        as the one from OpenCraft
+        """
+        self.client.force_login(self.user_without_instance)
+        instance_data = dict(
+            external_domain=BetaTestApplication.BASE_DOMAIN,
+            instance_name="My Instance with BASE_DOMAIN domain",
+            public_contact_email="user@example.com",
+        )
+        response = self.client.post(
+            reverse("api:v2:openedx-instance-config-validate"),
+            data=instance_data,
+            format="json",
+        )
+        content = json.loads(response.content)
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {"external_domain": ["Can not use OpenCraft domain."]})
+
+    @ddt.data(
+        ("domain.com", "domain.com", "This domain is already taken."),
+        # Can not register a possible used subdomain as a domain
+        ("domain.com", "bad.domain.com", "This domain is already taken."),
+        ("domain.com", "preview.domain.com", "This domain is already taken."),
+        ("domain.com", "ecommerce.domain.com", "This domain is already taken."),
+        ("domain.com", "studio.domain.com", "This domain is already taken."),
+        # Can not register a domain such as the subdomains generated conflicts existing domains
+        ("preview.domain.com", "domain.com", "This domain is not allowed."),
+        ("ecommerce.domain.com", "domain.com", "This domain is not allowed."),
+        ("studio.domain.com", "domain.com", "This domain is not allowed."),
+    )
+    @ddt.unpack
+    def test_instance_external_domain_can_not_compromise_other_domains(self, original_domain, new_domain, error_msg):
+        """
+        Validate that users can not create instance with an external domain that
+        conflicts with existing domains
+        """
+        self.instance_config.external_domain = original_domain
+        self.instance_config.save()
+
+        self.client.force_login(self.user_without_instance)
+        instance_data = dict(
+            external_domain=new_domain,
+            instance_name="My Instance",
+            public_contact_email="user@example.com",
+        )
+        response = self.client.post(
+            reverse("api:v2:openedx-instance-config-validate"),
+            data=instance_data,
+            format="json",
+        )
+        content = json.loads(response.content)
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {"external_domain": [error_msg]})
+
     @ddt.data(
         ("instance.user", True),
         ("noinstance.user", False),


### PR DESCRIPTION
This PR prevents users from using invalid or conflicting domains

**JIRA tickets**: [SE-2869](https://tasks.opencraft.com/browse/SE-2869)

**Testing instructions**:

This PR already provides tests, but for manual testing you can try:
- Using ``opencraft.hosting`` as a domain
- Using as domain a subdomain from an instance. For example, using ``test.domain.com`` when ``domain.com`` already exists
- Using a domain such that, when creating ``studio``, ``ecommerce`` or ``studio`` subdomains, it overrides an existing domain. For example, try using ``domain.com`` when ``studio.domain.com`` was used as a domain.

**Reviewers**
- [ ]  @swalladge 
