### PR TITLE
[SE-2948] Remove redirect to preliminary page

### DIFF
--- a/instance/models/mixins/load_balanced.py
+++ b/instance/models/mixins/load_balanced.py
@@ -108,7 +108,11 @@ class LoadBalancedInstance(models.Model):
             return [], []
         self.logger.info("Configuring load balancer to point to the preliminary page.")
         backend_name = "be-preliminary-page-{}".format(primary_key)
-        config = "    server preliminary-page {}:80".format(settings.PRELIMINARY_PAGE_SERVER_IP)
+        ca_file_path = "/etc/ssl/certs/ca-certificates.crt"
+        config = "    server preliminary-page {}:443 ssl verify required ca-file {}".format(
+            settings.PRELIMINARY_PAGE_SERVER_IP,
+            ca_file_path,
+        )
         if settings.PRELIMINARY_PAGE_HOSTNAME:
             config += "\n    http-request set-header Host '{}'".format(settings.PRELIMINARY_PAGE_HOSTNAME)
         backend_map = [(domain, backend_name) for domain in self.get_load_balanced_domains()]

--- a/instance/tests/models/test_load_balanced_mixin.py
+++ b/instance/tests/models/test_load_balanced_mixin.py
@@ -201,7 +201,9 @@ class LoadBalancedInstanceTestCase(TestCase):
         instance = OpenEdXInstanceFactory()
         _, [(_, config)] = instance.get_preliminary_page_config(instance.ref.pk)
         self.assertIn(
-            "server preliminary-page {}:80".format(settings.PRELIMINARY_PAGE_SERVER_IP),
+            "server preliminary-page {}:443 ssl verify required ca-file /etc/ssl/certs/ca-certificates.crt".format(
+                settings.PRELIMINARY_PAGE_SERVER_IP
+            ),
             config
         )
         self.assertNotIn('http-request set-header Host', config)
@@ -215,7 +217,9 @@ class LoadBalancedInstanceTestCase(TestCase):
         instance = OpenEdXInstanceFactory()
         _, [(_, config)] = instance.get_preliminary_page_config(instance.ref.pk)
         self.assertIn(
-            "server preliminary-page {}:80".format(settings.PRELIMINARY_PAGE_SERVER_IP),
+            "server preliminary-page {}:443 ssl verify required ca-file /etc/ssl/certs/ca-certificates.crt".format(
+                settings.PRELIMINARY_PAGE_SERVER_IP
+            ),
             config
         )
         self.assertIn(

--- a/instance/tests/models/test_openedx_instance.py
+++ b/instance/tests/models/test_openedx_instance.py
@@ -508,7 +508,7 @@ class OpenEdXInstanceTestCase(TestCase):
         Verify the load balancer configuration given in backend_map and config.
         """
         [(backend, config_str)] = config
-        self.assertRegex(config_str, r"\bserver\b.*\b{}:80\b".format(ip_address))
+        self.assertRegex(config_str, r"\bserver\b.*\b{}:(80|443)\b".format(ip_address))
         self.assertCountEqual(backend_map, [(domain, backend) for domain in domain_names])
 
     def _check_load_balancer_configuration_prefix_domains(self,


### PR DESCRIPTION
When no appservers are active, instance LMS and Studio URLs should not redirect the user, but just display contents of default.opencraft.com. Have applied the patch manually to the below instance on stage too, for testing purposes.

**JIRA tickets**: [SE-2948](https://tasks.opencraft.com/browse/SE-2948)

**Sandbox URL**: https://sid-test-2.stage.opencraft.hosting (The DNS has 3 IP addresses, so you might see the old deployment on IPs other than 54.36.101.120)

**Testing instructions**:

1. Run `curl --insecure -v --header "Host:se-2870-test.opencraft.hosting" https://54.36.101.120` and verify 301 Moved Permanently response.
2. Run `curl --insecure -v --header "Host:sid-test-2.stage.opencraft.hosting" https://54.36.101.120` and verify 200 OK is returned, with content of default.opencraft.com
3. Verify that `backend be-edxins-sid-test-2sta-567` section of `/etc/haproxy/haproxy.cfg` on stage haproxy has the updated code.

**Reviewers**
- [ ] @mtyaka 