### PR TITLE
[BB-2450] Fix server error

### DIFF
--- a/frontend/src/console/components/NoticeBoard/NoticeBoard.spec.tsx
+++ b/frontend/src/console/components/NoticeBoard/NoticeBoard.spec.tsx
@@ -1,12 +1,13 @@
 import React from 'react';
 
+import update from 'immutability-helper';
+
 import { OpenEdXInstanceDeploymentStatusStatusEnum as DeploymentStatus } from 'ocim-client';
 import { setupComponentForTesting } from 'utils/testing';
 
 import { NoticeBoard } from './NoticeBoard'
 
-
-it('Renders all notification types without crashing', () => {
+describe('NoticeBoard tests', () => {
   const deployedChanges = [
     [
       'change',
@@ -93,37 +94,60 @@ it('Renders all notification types without crashing', () => {
     status, date, deployedChanges
   }));
 
-  const tree = setupComponentForTesting(
-    <NoticeBoard />,
-    {
-      console: {
-        loading: false,
-        activeInstance: {
-          data: {
-            id: 1,
-            instanceName: "test",
-            subdomain: "test",
-            lmsUrl: "test-url",
-            studioUrl: "test-url",
-            isEmailVerified: true,
-          },
-          deployment: {
-            status: "preparing",
-            undeployedChanges: [],
-            deployedChanges: null,
-            type: 'admin',
-          }
-        },
-        instances: [{
+  const state = {
+    console: {
+      loading: false,
+      activeInstance: {
+        data: {
           id: 1,
           instanceName: "test",
           subdomain: "test",
-        }],
-        notifications: notifications,
-        notificationsLoading: false
-      }
+          lmsUrl: "test-url",
+          studioUrl: "test-url",
+          isEmailVerified: true,
+        },
+        deployment: {
+          status: "preparing",
+          undeployedChanges: [],
+          deployedChanges: null,
+          type: 'admin',
+        }
+      },
+      instances: [{
+        id: 1,
+        instanceName: "test",
+        subdomain: "test",
+      }],
+      notifications: notifications,
+      notificationsLoading: false
     }
-  ).toJSON();
+  };
 
-  expect(tree).toMatchSnapshot();
+  it('Renders all notification types without crashing', () => {
+    const tree = setupComponentForTesting(
+      <NoticeBoard />, state, jest.fn()
+    ).toJSON();
+
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('Renders message about non-existent instance if email is not verified', () => {
+    const tree = setupComponentForTesting(
+      <NoticeBoard getNotifications={() => {}}/>,
+      update(state, {
+        console: {
+          activeInstance: {
+            data: {
+              isEmailVerified: {
+                $set: false
+              }
+            }
+          }
+        }
+      }),
+      jest.fn(),
+    ).toJSON();
+
+    expect(tree).toMatchSnapshot();
+  });
 });

--- a/frontend/src/console/components/NoticeBoard/NoticeBoard.tsx
+++ b/frontend/src/console/components/NoticeBoard/NoticeBoard.tsx
@@ -7,7 +7,7 @@ import { OpenEdXInstanceDeploymentStatusStatusEnum as DeploymentStatus } from 'o
 import { Col, Collapse, Nav, Row } from 'react-bootstrap';
 
 import { getNotifications } from 'console/actions';
-import { DeploymentNotificationModel } from 'console/models';
+import { DeploymentNotificationModel, InstancesModel } from 'console/models';
 import { WrappedMessage } from 'utils/intl';
 
 import messages from './displayMessages';
@@ -19,6 +19,7 @@ interface ActionProps {
   getNotifications: Function;
 }
 interface Props extends ActionProps {
+  activeInstance: InstancesModel['activeInstance'];
   notifications: Array<DeploymentNotificationModel>;
   loading: boolean;
 }
@@ -180,6 +181,19 @@ const NoticeBoardComponent: React.FC<Props> = (props: Props) => {
     />
   ));
 
+  let isEmailVerified = true;
+  if (props.activeInstance && props.activeInstance.data) {
+    isEmailVerified = props.activeInstance.data.isEmailVerified;
+  }
+
+  const pageContent = isEmailVerified ? (
+    notifications
+  ) : (
+    <p>
+      <WrappedMessage id="noActiveInstance" messages={messages} />
+    </p>
+  );
+
   return (
     <ConsolePage showSidebar={false} contentLoading={props.loading}>
       <Row className="justify-content-center">
@@ -189,7 +203,7 @@ const NoticeBoardComponent: React.FC<Props> = (props: Props) => {
               <WrappedMessage id="noticeBoard" messages={messages} />
             </p>
           </div>
-          {notifications}
+          {pageContent}
         </Col>
       </Row>
     </ConsolePage>
@@ -198,6 +212,7 @@ const NoticeBoardComponent: React.FC<Props> = (props: Props) => {
 
 export const NoticeBoard = connect<{}, ActionProps, {}, Props, RootState>(
   (state: RootState) => ({
+    activeInstance: state.console.activeInstance,
     notifications: state.console.notifications,
     loading: state.console.notificationsLoading
   }),

--- a/frontend/src/console/components/NoticeBoard/__snapshots__/NoticeBoard.spec.tsx.snap
+++ b/frontend/src/console/components/NoticeBoard/__snapshots__/NoticeBoard.spec.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Renders all notification types without crashing 1`] = `
+exports[`NoticeBoard tests Renders all notification types without crashing 1`] = `
 <div
   className="console-page"
 >
@@ -1400,6 +1400,74 @@ exports[`Renders all notification types without crashing 1`] = `
                 </div>
               </div>
             </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`NoticeBoard tests Renders message about non-existent instance if email is not verified 1`] = `
+<div
+  className="console-page"
+>
+  <div
+    className="title-container"
+  >
+    <h1>
+      <a
+        className="header-link"
+        href="test-url"
+      >
+        test
+        <i
+          className="instance-link fas fa-link fa-xs"
+        />
+      </a>
+    </h1>
+    <h2>
+      <a
+        className="header-link"
+        href="test-url"
+      >
+        Edit courses (Studio)
+      </a>
+    </h2>
+  </div>
+  <div
+    className="d-flex justify-content-center align-middle email-activation-alert"
+  >
+    <i
+      className="alert-icon fas fa-exclamation-triangle fa-xs"
+    />
+    One of your email addresses is pending confirmation. Please confirm it to begin managing your Open edX instance.
+  </div>
+  <div
+    className="console-page-container"
+  >
+    <div
+      className="console-page-content row"
+    >
+      <div
+        className="container-fluid"
+      >
+        <div
+          className="justify-content-center row"
+        >
+          <div
+            className="col-md-7"
+          >
+            <div
+              className="notice-board-heading"
+            >
+              <p>
+                Notice Board
+              </p>
+            </div>
+            <p>
+              There are no notifications available because your instance has not yet been created.
+            </p>
           </div>
         </div>
       </div>

--- a/frontend/src/console/components/NoticeBoard/displayMessages.ts
+++ b/frontend/src/console/components/NoticeBoard/displayMessages.ts
@@ -29,6 +29,12 @@ const messages = {
     defaultMessage: 'Notice Board',
     description: 'Notice board heading.'
   },
+  noActiveInstance: {
+    defaultMessage:
+      'There are no notifications available because your instance has not yet been created.',
+    description:
+      'Message to users who have not confirmed their email and therefore have no instance.'
+  },
   noDetails: {
     defaultMessage: 'No redeployment details.',
     description:

--- a/frontend/src/utils/testing.tsx
+++ b/frontend/src/utils/testing.tsx
@@ -10,7 +10,8 @@ import { createRootReducer } from '../global/reducers';
 
 export const setupComponentForTesting = (
   reactContent: JSX.Element,
-  storeContents = {}
+  storeContents = {},
+  dispatchMock?: (...args: any[]) => any
 ) => {
   const middleware = applyMiddleware(thunk);
 
@@ -19,6 +20,10 @@ export const setupComponentForTesting = (
     storeContents,
     middleware
   );
+
+  if (dispatchMock) {
+    store.dispatch = dispatchMock;
+  }
 
   return renderer.create(
     <IntlProvider textComponent={React.Fragment} locale="en">

--- a/registration/api/v2/views.py
+++ b/registration/api/v2/views.py
@@ -182,8 +182,12 @@ class NotificationsViewSet(GenericViewSet):
         if application is None:
             application = self.get_application()
 
+        instance = application.instance
+        if instance is None:
+            return OpenEdXDeployment.objects.none()
+
         queryset = OpenEdXDeployment.objects.filter(
-            instance=application.instance.ref
+            instance=instance.ref
         )
 
         return self.limit_queryset(queryset)
@@ -224,7 +228,7 @@ class NotificationsViewSet(GenericViewSet):
             notifications.append({
                 "deployed_changes": [],
                 "status": DeploymentState.preparing.name,
-                "date": application.instance.created,
+                "date": application.created,
             })
 
         # Configuration diff relates only to last created deployment, so if

--- a/registration/tests/test_api.py
+++ b/registration/tests/test_api.py
@@ -1047,7 +1047,7 @@ class NotificationAPITestCase(APITestCase):
         changes if there are no deployments yet.
         """
 
-        instance = self._setup_user_instance()
+        self._setup_user_instance()
 
         url = reverse("api:v2:notifications-list")
         response = self.client.get(url)
@@ -1061,7 +1061,7 @@ class NotificationAPITestCase(APITestCase):
             {
                 "deployed_changes": [],
                 "status": "preparing",
-                "date": instance.created.isoformat().replace("+00:00", "Z"),
+                "date": self.instance_config.created.isoformat().replace("+00:00", "Z"),
             },
             response.data,
         )


### PR DESCRIPTION
This is a follow-up PR with fix for https://github.com/open-craft/opencraft/pull/591. It adds fix for notifications endpoint and message for `Status & Notification` page when user has no instance.

**JIRA tickets**:
- [BB-2450](https://tasks.opencraft.com/browse/BB-2450)

**Dependencies**: None

**Screenshots**:
![Screenshot_2020-07-22_19-34-37](https://user-images.githubusercontent.com/18251194/88209638-ab860a00-cc5b-11ea-94cb-ac274d5c65be.png)

**Testing instructions**:

1. Register, but don't verify email.
2. Go to `Status & Notifications` page.
3. You should see message like on screenshot.

**Reviewers**
- [x] @Agrendalath
- [ ] @xitij2000 
