### PR TITLE
[SE-2497] Avoid sending deployment failure urgent e-mails in deployments triggered by OpenCraft members

### DIFF
--- a/instance/models/mixins/utilities.py
+++ b/instance/models/mixins/utilities.py
@@ -33,6 +33,7 @@ from django.dispatch import receiver
 from django.views.debug import ExceptionReporter
 
 from instance.signals import appserver_spawned
+from instance.models.deployment import DeploymentType, Deployment
 
 logger = logging.getLogger(__name__)
 
@@ -147,10 +148,16 @@ def send_urgent_alert_on_permanent_deployment_failure(sender, **kwargs):
     """
     instance = kwargs['instance']
     appserver = kwargs['appserver']
+    deployment_id = kwargs['deployment_id']
 
     # Only sending critical alerts for failures in registered clients' instances, not in test/sandboxes
     if not instance.betatestapplication_set.exists():
         return
+
+    if deployment_id is not None:
+        deployment = Deployment.objects.get(pk=deployment_id)
+        if deployment.type in (DeploymentType.admin.name, DeploymentType.batch.name, DeploymentType.pr.name):
+            return
 
     if appserver is None and instance.provisioning_failure_notification_emails:
         logger.warning(

--- a/instance/models/openedx_instance.py
+++ b/instance/models/openedx_instance.py
@@ -357,7 +357,7 @@ class OpenEdXInstance(
                 self.tags.remove(success_tag)
 
             # Warn spawn failed after given attempts
-            appserver_spawned.send(sender=self.__class__, instance=self, appserver=None)
+            appserver_spawned.send(sender=self.__class__, instance=self, appserver=None, deployment_id=deployment_id)
             return None
 
         self.logger.info('Provisioned new app server, %s', app_server.name)
@@ -373,7 +373,7 @@ class OpenEdXInstance(
             # use task.make_appserver_active to allow disabling others
             app_server.make_active()
 
-        appserver_spawned.send(sender=self.__class__, instance=self, appserver=app_server)
+        appserver_spawned.send(sender=self.__class__, instance=self, appserver=app_server, deployment_id=deployment_id)
 
         return app_server.pk
 

--- a/instance/signals.py
+++ b/instance/signals.py
@@ -29,4 +29,4 @@ import django.dispatch
 
 # Emitted after an appserver has been spawned
 # After all attempts have been tried, and the appserver activated if applicable
-appserver_spawned = django.dispatch.Signal(providing_args=['instance', 'appserver'])
+appserver_spawned = django.dispatch.Signal(providing_args=['instance', 'appserver', 'deployment_id'])

--- a/instance/tests/models/test_openedx_instance.py
+++ b/instance/tests/models/test_openedx_instance.py
@@ -40,9 +40,11 @@ import yaml
 from instance import gandi
 from instance.gandi import GandiV5API
 from instance.models.appserver import Status as AppServerStatus
+from instance.models.deployment import DeploymentType
 from instance.models.instance import InstanceReference
 from instance.models.load_balancer import LoadBalancingServer
 from instance.models.openedx_appserver import OpenEdXAppServer
+from instance.models.openedx_deployment import OpenEdXDeployment
 from instance.models.openedx_instance import OpenEdXInstance, OpenEdXAppConfiguration
 from instance.models.server import OpenStackServer, Server, Status as ServerStatus
 from instance.models.utils import WrongStateException
@@ -467,6 +469,98 @@ class OpenEdXInstanceTestCase(TestCase):
         self.assertEqual(instance.appserver_set.count(), 5)
 
         self.assertEqual(len(django_mail.outbox), 0)
+
+    @ddt.data(DeploymentType.admin, DeploymentType.batch, DeploymentType.pr)
+    @patch_services
+    def test_spawn_appserver_failed_all_attempts_dont_send_emails_if_admin(self, mocks, deployment_type, mock_consul):
+        """
+        Test what happens when spawning an AppServer fails repeatedly (5 out of 5 attempts).
+        Given that the appserver spawn is launched from members of OpenCraft, we shouldn't send the email.
+        """
+        mocks.mock_run_ansible_playbooks.return_value = (['log: provisioning failed'], 1)
+        mocks.mock_create_server.side_effect = [Mock(id='test-run-provisioning-server'), None]
+        mocks.os_server_manager.add_fixture('test-run-provisioning-server', 'openstack/api_server_2_active.json')
+
+        instance = OpenEdXInstanceFactory(sub_domain='test.spawn')
+        failure_emails = ['provisionfailed@localhost']
+        instance.provisioning_failure_notification_emails = failure_emails  # noqa pylint: disable=invalid-name
+        user = get_user_model().objects.create_user(username='test', email='test@example.com')
+
+        UserProfile.objects.create(
+            user=user,
+            full_name='test name',
+        )
+        BetaTestApplication.objects.create(
+            user=user,
+            subdomain='test',
+            instance=instance,
+            instance_name='Test instance',
+            project_description='Test instance creation.',
+            public_contact_email=user.email,
+        )
+        self.assertEqual(instance.betatestapplication_set.count(), 1)
+
+        self.assertEqual(instance.appserver_set.count(), 0)
+
+        # Create the deployment, setting the deployment type
+        deployment = OpenEdXDeployment.objects.create(
+            instance_id=instance.ref.id,
+            type=deployment_type,
+        )
+        with self.assertRaises(ApplicationNotReady):
+            instance.spawn_appserver(num_attempts=5, deployment_id=deployment.pk)
+
+        # each attempt did create a server (though with a failed status)
+        self.assertEqual(instance.appserver_set.count(), 5)
+
+        # Given these deployment types, no email should be sended
+        self.assertEqual(len(django_mail.outbox), 0)
+
+    @ddt.data(DeploymentType.user, DeploymentType.periodic, DeploymentType.registration, DeploymentType.unknown)
+    @patch_services
+    def test_spawn_appserver_failed_all_attempts_send_emails_if_not_admin(self, mocks, deployment_type, mock_consul):
+        """
+        Test what happens when spawning an AppServer fails repeatedly (5 out of 5 attempts).
+        Given that the appserver spawn is launched from members of OpenCraft, we shouldn't send the email.
+        """
+        mocks.mock_run_ansible_playbooks.return_value = (['log: provisioning failed'], 1)
+        mocks.mock_create_server.side_effect = [Mock(id='test-run-provisioning-server'), None]
+        mocks.os_server_manager.add_fixture('test-run-provisioning-server', 'openstack/api_server_2_active.json')
+
+        instance = OpenEdXInstanceFactory(sub_domain='test.spawn')
+        failure_emails = ['provisionfailed@localhost']
+        instance.provisioning_failure_notification_emails = failure_emails  # noqa pylint: disable=invalid-name
+        user = get_user_model().objects.create_user(username='test', email='test@example.com')
+
+        UserProfile.objects.create(
+            user=user,
+            full_name='test name',
+        )
+        BetaTestApplication.objects.create(
+            user=user,
+            subdomain='test',
+            instance=instance,
+            instance_name='Test instance',
+            project_description='Test instance creation.',
+            public_contact_email=user.email,
+        )
+        self.assertEqual(instance.betatestapplication_set.count(), 1)
+
+        self.assertEqual(instance.appserver_set.count(), 0)
+
+        # Create the deployment, setting the deployment type
+        deployment = OpenEdXDeployment.objects.create(
+            instance_id=instance.ref.id,
+            type=deployment_type,
+        )
+        with self.assertRaises(ApplicationNotReady):
+            instance.spawn_appserver(num_attempts=5, deployment_id=deployment.pk)
+
+        # each attempt did create a server (though with a failed status)
+        self.assertEqual(instance.appserver_set.count(), 5)
+
+        # Given these deployment types, at least one email should be sended
+        self.assertNotEqual(len(django_mail.outbox), 0)
 
     @patch_services
     @patch('instance.models.openedx_appserver.OpenEdXAppServer.provision', return_value=True)


### PR DESCRIPTION
This PR add a validation to avoid sending emails to users on appserver spawn failures if the action was created by a member of OpenCraft

**JIRA tickets**: [SE-2497](https://tasks.opencraft.com/browse/SE-2497)

**Testing instructions**
- Create a new deployment from the new interface, make it fail and check email is sended
- Redeploy instances using ``instance_redeploy`` command and check that email is not sended
- Create a new deployment from the manage site and check that no email is sent if it fails

**Reviewers**
- [ ]  @pkulkark 
