### PR TITLE
SE-2743: Create a setting to disable monitoring of PRs.

### DIFF
--- a/opencraft/settings.py
+++ b/opencraft/settings.py
@@ -387,6 +387,10 @@ GITHUB_ACCESS_TOKEN = env('GITHUB_ACCESS_TOKEN')
 DEFAULT_FORK = env('DEFAULT_FORK', default='edx/edx-platform')
 DEFAULT_EDX_PLATFORM_REPO_URL = 'https://github.com/{}.git'.format(DEFAULT_FORK)
 
+# Whether to actively watch forks for new pull requests. Set to false if this instance is not responsible for
+# auto-creating sandboxes.
+WATCH_PRS = env.bool('WATCH_PRS', default=True)
+
 # Open edX Instance and App Server Settings  ##################################
 
 # Time in seconds to wait before making a force termination for servers.
@@ -778,7 +782,7 @@ PRELIMINARY_PAGE_HOSTNAME = env('PRELIMINARY_PAGE_HOSTNAME', default=None)
 # If using the new load balancer, this setting must be set to True, as the
 # load balancing configuration is done by Consul Template on the load balancers,
 # without needing any direct action from Ocim on the load balancers.
-# !!! This should only be set after the new loab balancers are configured and
+# !!! This should only be set after the new load balancers are configured and
 # tested to be working !!!
 DISABLE_LOAD_BALANCER_CONFIGURATION = env.bool(
     'DISABLE_LOAD_BALANCER_CONFIGURATION',

--- a/pr_watch/tasks.py
+++ b/pr_watch/tasks.py
@@ -24,6 +24,7 @@ Worker tasks for development of Open edX
 
 import logging
 
+from django.conf import settings
 from huey.api import crontab
 from huey.contrib.djhuey import db_periodic_task
 
@@ -46,6 +47,8 @@ def watch_pr():
     Automatically create sandboxes for PRs opened by members of the watched
     organization on the watched repository
     """
+    if not settings.WATCH_PRS:
+        return
     try:
         for watched_fork in WatchedFork.objects.filter(enabled=True):
             usernames = list(

--- a/pr_watch/tests/test_tasks.py
+++ b/pr_watch/tests/test_tasks.py
@@ -313,3 +313,18 @@ class TasksTestCase(TestCase):
         tasks.watch_pr()
         self.assertEqual(mock_create_new_deployment.call_count, 0)
         self.assertEqual(WatchedPullRequest.objects.count(), 0)
+
+    @patch('pr_watch.github.get_commit_id_from_ref')
+    @patch('pr_watch.tasks.create_new_deployment')
+    @patch('pr_watch.tasks.get_pr_list_from_usernames')
+    @override_settings(DEFAULT_INSTANCE_BASE_DOMAIN='awesome.hosting.org', WATCH_PRS=False)
+    def test_watching_disabled(
+            self, mock_get_pr_list_from_usernames, mock_create_new_deployment, mock_get_commit_id_from_ref,
+    ):
+        """
+        Verifies that watch_pr exits early if WATCH_PRS is disabled.
+        """
+        tasks.watch_pr()
+        mock_get_pr_list_from_usernames.assert_not_called()
+        mock_create_new_deployment.assert_not_called()
+        mock_get_commit_id_from_ref.assert_not_called()


### PR DESCRIPTION
[SE-2743](https://tasks.opencraft.com/browse/SE-2743)

This change allows for the PR watch task to be disabled in environments where it is not needed.

NOTE: Stage will need a new environment variable to use this feature, `WATCH_PRS=false`