### PR TITLE
[SE-2878] Removes Deprecated nginx_discovery_gunicorn_hosts Variable from Docs

### DIFF
--- a/documentation/howtos.md
+++ b/documentation/howtos.md
@@ -29,8 +29,6 @@ ecommerce_create_demo_data: false
 SANDBOX_ENABLE_DISCOVERY: yes
 SANDBOX_ENABLE_ECOMMERCE: yes
 DISCOVERY_VERSION: "{{ ECOMMERCE_VERSION }}"
-nginx_discovery_gunicorn_hosts:
-    - "127.0.0.1"
 COMMON_HOSTNAME: ""
 ECOMMERCE_PAYMENT_PROCESSOR_CONFIG:
     partn_id: # this is arbitrary, limited to 8 characters; will be used later


### PR DESCRIPTION
Removes deprecated `nginx_discovery_gunicorn_hosts`  from *Configuring Ecommerce and Course Discovery* documentation. 
That variable has been last seen in gingko, [sneak a peek here](https://github.com/open-craft/configuration/blob/opencraft-release/ginkgo.1/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/discovery.j2#L12-L16).

**JIRA tickets**: SE-2878

**Testing instructions**:

1. Build the documentation for Ocim.
1. Make sure the changes done to the markdown file appear online.

**Reviewers**
- [ ] @toxinu 
