### PR TITLE
Use NRQL conditions instead of Synthetics.

### DIFF
--- a/documentation/monitoring.md
+++ b/documentation/monitoring.md
@@ -8,7 +8,7 @@ On Synthetics, monitors can be created to the check liveness of an endpoint/URL 
 New Relic Alerts allows configuring the alerting behaviour. An alert has two main components:
 
 * **Alert Policy**: An alert policy is a group of one or more alert conditions. A policy has two settings that apply to all of its conditions: incident preference and notification channels. The incident preference is used to configure how an incident is created - per error, per condition or per policy and the notification channels are the various modes of sending out alert notifications like email, PagerDuty etc. A policy should be created before adding conditions to it.
-* **Alert Conditions**: An alert condition is a combination of monitored data source, such as a Synthetics Monitor, and thresholds that define the behavior that will be considered a violation. Synthetics only reports if the pings succeeded or not, so our threshold is to check if the ping failed.
+* **Alert Conditions**: An alert condition is a combination of monitored data source, such as a Synthetics Monitor, and thresholds that define the behavior that will be considered a violation. In Ocim we use [`NRQL`](https://docs.newrelic.com/docs/query-your-data/nrql-new-relic-query-language/get-started/nrql-syntax-clauses-functions) alert conditions, which allow us to set up alert thresholds so that alerts are only triggered after a monitor has failed several times in a row. This helps us avoid false alerts caused by temporary network blips.
 
 Each **Alert Policy** contains one or more **Alert Conditions**  which specify the alerting behaviour.
 

--- a/instance/models/mixins/openedx_monitoring.py
+++ b/instance/models/mixins/openedx_monitoring.py
@@ -83,8 +83,8 @@ class OpenEdXMonitoringMixin:
                 # and create one if it doesn't. This helps when the alert condition
                 # wasn't created in a previous invocation due to some issue.
                 if not monitor.new_relic_alert_conditions.exists():
-                    alert_condition_id = newrelic.add_alert_condition(
-                        alert_policy.id, monitor.id, urls_to_monitor_dict[url]
+                    alert_condition_id = newrelic.add_alert_nrql_condition(
+                        alert_policy.id, url, urls_to_monitor_dict[url]
                     )
                     monitor.new_relic_alert_conditions.create(id=alert_condition_id, alert_policy=alert_policy)
             else:
@@ -95,8 +95,8 @@ class OpenEdXMonitoringMixin:
             self.logger.info('Creating New Relic Synthetics monitor for new public URL %s', url)
             new_monitor_id = newrelic.create_synthetics_monitor(url)
             monitor = self.new_relic_availability_monitors.create(pk=new_monitor_id)
-            alert_condition_id = newrelic.add_alert_condition(
-                alert_policy.id, new_monitor_id, urls_to_monitor_dict[url]
+            alert_condition_id = newrelic.add_alert_nrql_condition(
+                alert_policy.id, url, urls_to_monitor_dict[url]
             )
             monitor.new_relic_alert_conditions.create(id=alert_condition_id, alert_policy=alert_policy)
 

--- a/opencraft/settings.py
+++ b/opencraft/settings.py
@@ -768,6 +768,9 @@ NEWRELIC_ADMIN_USER_API_KEY = env('NEWRELIC_ADMIN_USER_API_KEY', default=None)
 # The basic auth password needed to access the node exporter.
 NODE_EXPORTER_PASSWORD = env('NODE_EXPORTER_PASSWORD', default=None)
 
+# Thresholds for NRQL alert conditions
+NEWRELIC_NRQL_ALERT_CONDITION_DURATION = env('NEWRELIC_NRQL_ALERT_CONDITION_DURATION', default='16')
+
 # Load balancing ##############################################################
 
 # The load-balancing server given in the form ssh_username@server.domain will be created


### PR DESCRIPTION
NRQL makes alerting much more flexible.

The main change for now is that alerts are triggered only after any of the Synthetic monitors fails three times in a row to avoid alerts due to temporary networks blips.

**Test instructions**

1. If you don't already have `ADMINS` setting set in your local `.env` file, set it to your email (ie. `ADMINS='[["Matjaz Admin", "matjaz@opencraft.com"]]'`.
1. Set `NEWRELIC_ADMIN_USER_API_KEY` and `NEWRELIC_LICENSE_KEY` in your local `.env` file. You can find them on the production Ocim VM's `.env` file.
1. Start the django shell (`make shell`).
1. Get a reference to an `OpenEdXInstace` (or create a new one if you don't have an existing instance in your devstack).
1. Run `instance.enable_monitoring()`. Make sure that there are no errors.
1. Log into NewRelic and go to 'Alerts & AI -> Policies'. Search by the URL of your test instance and verify that the policy alerts look correct.
1. Run `instance.disable_monitoring()`. 
1. Verify that the policy for your instance has been removed from NewRelic.
1. Don't forget to remove `NEWRELIC_ADMIN_USER_API_KEY` and `NEWRELIC_LICENSE_KEY` from your local `.env` file!