### PR TITLE
SE-3079 bugfix: conditional instance ref inline admin

### DIFF
--- a/instance/admin.py
+++ b/instance/admin.py
@@ -79,7 +79,7 @@ class OpenEdXInstanceAdmin(admin.ModelAdmin): # pylint: disable=missing-docstrin
         # Doesn't show the inline instance for new objects since we have custom
         # logic for creating InstanceReference objects
         if obj is None or obj.pk is None:
-            self.inlines = []
+            return []
         return super().get_inline_instances(request, obj)
 
 


### PR DESCRIPTION
The `get_inline_instances` method should return a list of
admin classes to inline.

Previously, it was modifying `self.inlines`, which is a
static class variable, causing weird behaviour. Sometimes,
the inline admin was not included for existing instances.

**Test instructions**:

- visit `/admin/instance/openedxinstance/`
- click 'add open edx instance'
- verify that the instance reference inline form is **not** included at the bottom of the page
- find an existing instance and edit it
- verify that the instance reference inline form **is** included at the bottom of the page

**Reviewers**:

- [ ] @nizarmah