### PR TITLE
[BB-2801] Update default Open EdX release to Juniper

### DIFF
--- a/documentation/howtos.md
+++ b/documentation/howtos.md
@@ -54,7 +54,7 @@ ECOMMERCE_REPOS:
     REPO: 'ecommerce.git'
     # Use a branch which contains this fix:
     # https://github.com/open-craft/ecommerce/pull/13/files
-    VERSION: opencraft-release/ironwood.2
+    VERSION: opencraft-release/juniper.2
     DESTINATION: "{{ ecommerce_code_dir }}"
     SSH_KEY: '{{ ECOMMERCE_GIT_IDENTITY }}'
 

--- a/opencraft/settings.py
+++ b/opencraft/settings.py
@@ -418,7 +418,7 @@ DEFAULT_CONFIGURATION_VERSION = env('DEFAULT_CONFIGURATION_VERSION', default=DEF
 
 # Git ref for stable Open edX release. Used as a default refspec for
 # configuration, edx-platform, forum, notifier, xqueue, and certs when creating production instances.
-OPENEDX_RELEASE_STABLE_REF = env('OPENEDX_RELEASE_STABLE_REF', default='open-release/ironwood.2')
+OPENEDX_RELEASE_STABLE_REF = env('OPENEDX_RELEASE_STABLE_REF', default='open-release/juniper.2')
 
 # The edx-platform repository used by default for production instances
 STABLE_EDX_PLATFORM_REPO_URL = env(
@@ -430,7 +430,7 @@ STABLE_EDX_PLATFORM_COMMIT = env('STABLE_EDX_PLATFORM_COMMIT', default=OPENEDX_R
 STABLE_CONFIGURATION_REPO_URL = env(
     'STABLE_CONFIGURATION_REPO_URL', default=DEFAULT_CONFIGURATION_REPO_URL
 )
-STABLE_CONFIGURATION_VERSION = env('STABLE_CONFIGURATION_VERSION', default='opencraft-release/ironwood.2')
+STABLE_CONFIGURATION_VERSION = env('STABLE_CONFIGURATION_VERSION', default='opencraft-release/juniper.2')
 
 # The name of the security group to use for edxapp App servers.
 # This is used to set appropriate firewall rules to prevent external access to


### PR DESCRIPTION
Updated default settings to use Juniper release and also fixed an issue with the forum heartbeat on Juniper.

**JIRA tickets**:
- [BB-2801](https://tasks.opencraft.com/browse/BB-2801)

**Dependencies**:
This PR depends on:
2. https://github.com/open-craft/ansible-secrets/pull/196

**Testing instructions**:
1. Deploy the changes and verify that a working Juniper instance is spawned.

**Author notes and concerns**:

**Reviewers**
- [ ] @lgp171188 