### PR TITLE
SE-3056 Update marketing links

### DIFF
--- a/instance/models/mixins/openedx_config.py
+++ b/instance/models/mixins/openedx_config.py
@@ -45,7 +45,6 @@ class OpenEdXConfigMixin(ConfigMixinBase):
                 "8.8.8.8",
                 "8.8.4.4"
             ],
-
             # HTTP authentication
             "COMMON_ENABLE_BASIC_AUTH": True,
             "COMMON_HTPASSWD_USER": self.instance.http_auth_user,
@@ -77,8 +76,8 @@ class OpenEdXConfigMixin(ConfigMixinBase):
                     # because we also add other extended checks
                     "openedx.core.djangoapps.heartbeat.default_checks.check_celery",
                 ],
+                # rewrite marketing links:
                 "MKTG_URL_OVERRIDES": {
-                    # rewrite marketing links:
                     # remove blog link - not supported yet
                     "BLOG": "",
                     # use different contact page

--- a/instance/models/mixins/openedx_config.py
+++ b/instance/models/mixins/openedx_config.py
@@ -436,11 +436,18 @@ class OpenEdXConfigMixin(ConfigMixinBase):
                 ],
             })
 
+        if "MKTG_URL_OVERRIDES" not in template["EDXAPP_LMS_ENV_EXTRA"]:
+            template["EDXAPP_LMS_ENV_EXTRA"]["MKTG_URL_OVERRIDES"] = {}
+
+        # rewrite marketing links:
+        # remove blog link - not supported yet
+        template["EDXAPP_LMS_ENV_EXTRA"]["MKTG_URL_OVERRIDES"]["BLOG"] = ""
+        # use different contact page
+        template["EDXAPP_LMS_ENV_EXTRA"]["MKTG_URL_OVERRIDES"]["CONTACT"] = "/contact"
+
         if self.privacy_policy_url:
             # Custom Privacy Policy
-            template["EDXAPP_LMS_ENV_EXTRA"]["MKTG_URL_OVERRIDES"] = {
-                "PRIVACY": self.privacy_policy_url,
-            }
+            template["EDXAPP_LMS_ENV_EXTRA"]["MKTG_URL_OVERRIDES"]["PRIVACY"] = self.privacy_policy_url
 
         # The dotted import path to the forum heartbeat function has changed in Juniper.
         # So use the old path only for the older releases.

--- a/instance/models/mixins/openedx_config.py
+++ b/instance/models/mixins/openedx_config.py
@@ -77,6 +77,13 @@ class OpenEdXConfigMixin(ConfigMixinBase):
                     # because we also add other extended checks
                     "openedx.core.djangoapps.heartbeat.default_checks.check_celery",
                 ],
+                "MKTG_URL_OVERRIDES": {
+                    # rewrite marketing links:
+                    # remove blog link - not supported yet
+                    "BLOG": "",
+                    # use different contact page
+                    "CONTACT": "/contact",
+                }
             },
 
             "EDXAPP_LMS_NGINX_PORT": 80,
@@ -435,15 +442,6 @@ class OpenEdXConfigMixin(ConfigMixinBase):
                     for github_username in check_github_users(self.admin_users)
                 ],
             })
-
-        if "MKTG_URL_OVERRIDES" not in template["EDXAPP_LMS_ENV_EXTRA"]:
-            template["EDXAPP_LMS_ENV_EXTRA"]["MKTG_URL_OVERRIDES"] = {}
-
-        # rewrite marketing links:
-        # remove blog link - not supported yet
-        template["EDXAPP_LMS_ENV_EXTRA"]["MKTG_URL_OVERRIDES"]["BLOG"] = ""
-        # use different contact page
-        template["EDXAPP_LMS_ENV_EXTRA"]["MKTG_URL_OVERRIDES"]["CONTACT"] = "/contact"
 
         if self.privacy_policy_url:
             # Custom Privacy Policy

--- a/instance/models/mixins/openedx_site_configuration.py
+++ b/instance/models/mixins/openedx_site_configuration.py
@@ -36,7 +36,10 @@ class OpenEdXSiteConfigurationMixin(models.Model):
         """
         Return the ansible variables to set the SiteConfiguration parameters.
         """
-        site_configuration_settings = {}
+        site_configuration_settings = {
+            # default site configuration
+            'CONTACT_US_CUSTOM_LINK': '/contact',
+        }
 
         if self.static_content_overrides:
             static_content_overrides = {k: v for k, v in self.static_content_overrides.items() if k != 'version'}

--- a/instance/tests/models/test_openedx_appserver.py
+++ b/instance/tests/models/test_openedx_appserver.py
@@ -1025,6 +1025,7 @@ class SiteConfigurationSettingsTestCase(TestCase):
             'EDXAPP_SITE_CONFIGURATION': [
                 {
                     'values': {
+                        'CONTACT_US_CUSTOM_LINK': '/contact',
                         'static_template_about_content': 'Hello world!',
                         'homepage_overlay_html': 'Welcome to the LMS!',
                     }

--- a/instance/tests/models/test_openedx_instance.py
+++ b/instance/tests/models/test_openedx_instance.py
@@ -253,12 +253,14 @@ class OpenEdXInstanceTestCase(TestCase):
         self.assertEqual(configuration_vars['COMMON_HOSTNAME'], appserver.server_hostname)
         self.assertEqual(configuration_vars['EDXAPP_PLATFORM_NAME'], instance.name)
         self.assertEqual(configuration_vars['EDXAPP_CONTACT_EMAIL'], instance.email)
+
+        self.assertEqual(configuration_vars['EDXAPP_LMS_ENV_EXTRA']['MKTG_URL_OVERRIDES']['BLOG'], '')
+        self.assertEqual(configuration_vars['EDXAPP_LMS_ENV_EXTRA']['MKTG_URL_OVERRIDES']['CONTACT'], '/contact')
+
         if privacy_policy_url:
             self.assertEqual(
-                configuration_vars['EDXAPP_LMS_ENV_EXTRA']['MKTG_URL_OVERRIDES'],
-                {
-                    'PRIVACY': 'http://example.com/default-test-spawn-privacy',
-                }
+                configuration_vars['EDXAPP_LMS_ENV_EXTRA']['MKTG_URL_OVERRIDES']['PRIVACY'],
+                'http://example.com/default-test-spawn-privacy',
             )
         else:
             self.assertNotIn('MKTG_URL_OVERRIDES', configuration_vars)

--- a/instance/tests/models/test_openedx_site_configuration_mixin.py
+++ b/instance/tests/models/test_openedx_site_configuration_mixin.py
@@ -40,7 +40,16 @@ class OpenEdXSiteConfigurationMixinsTestCase(TestCase):
         require setting SiteConfiguration variables.
         """
         instance = OpenEdXInstanceFactory()
-        self.assertEqual(instance.get_site_configuration_settings(), '')
+        expected_variables = {
+            'EDXAPP_SITE_CONFIGURATION': [
+                {
+                    'values': {
+                        'CONTACT_US_CUSTOM_LINK': '/contact',
+                    }
+                }
+            ]
+        }
+        self.assertEqual(yaml.safe_load(instance.get_site_configuration_settings()), expected_variables)
 
     def test_static_content_overrides_set(self):
         """
@@ -60,6 +69,7 @@ class OpenEdXSiteConfigurationMixinsTestCase(TestCase):
             'EDXAPP_SITE_CONFIGURATION': [
                 {
                     'values': {
+                        'CONTACT_US_CUSTOM_LINK': '/contact',
                         'static_template_about_content': 'Hello world!',
                         'static_template_contact_content': 'Email: nobody@example.com',
                         'homepage_overlay_html': 'Welcome to the LMS!',
@@ -85,6 +95,7 @@ class OpenEdXSiteConfigurationMixinsTestCase(TestCase):
             'EDXAPP_SITE_CONFIGURATION': [
                 {
                     'values': {
+                        'CONTACT_US_CUSTOM_LINK': '/contact',
                         'static_template_about_content': 'வணக்கம்!',
                         'homepage_overlay_html': 'வணக்கம்',
                     }
@@ -109,6 +120,7 @@ class OpenEdXSiteConfigurationMixinsTestCase(TestCase):
             'EDXAPP_SITE_CONFIGURATION': [
                 {
                     'values': {
+                        'CONTACT_US_CUSTOM_LINK': '/contact',
                         'static_template_about_content': '<p class="paragraph" id=\'hello\'>Hello world!</p>',
                         'homepage_overlay_html': '<h1>Welcome to the LMS!</h1>',
                     }


### PR DESCRIPTION
This PR is about updating marketing links for edx instances.

## Changes

### 1. Blog link removed
It is enough to update ENV variable `MKTG_URL_OVERRIDES` to have empty 'BLOG' key.

### 2. Contact page url changed
It require to add such value `"CONTACT_US_CUSTOM_LINK":"/contact"` to the `SiteConfiguration` ([related edx-platform code here](https://github.com/edx/edx-platform/blob/master/lms/djangoapps/branding/api.py#L285)) 


#### Issue
When OpenEdXInstance create full configuration object, it use ansible.dit_merge function to merge all configs. 

[This function ignore list and just replace it](https://github.com/open-craft/opencraft/blob/master/instance/ansible.py#L78) without going through list items and copying one by one.

So if instance.configuration_extra_settings doesn't have  `EDXAPP_SITE_CONFIGURATION` [hardcoded value](https://github.com/open-craft/opencraft/pull/629/files#diff-acb4f1b5a942f182074cf3b6e59a66e3R41) will works as expected.

But if instance.configuration_extra_settings have `EDXAPP_SITE_CONFIGURATION` it will completely replace list, and we need manually set `CONTACT_US_CUSTOM_LINK` to point to the proper page.


**Example configuration**
Default SiteConfiguration values.
Also here we don't have site_id, wasn't able to test if it will work, need to run it on staging (or at least on configured OCIM).
```
'EDXAPP_SITE_CONFIGURATION': [
    {
        'values': {
            'CONTACT_US_CUSTOM_LINK': '/contact'
        }
    }
]
```

`Instance.configuration_extra_settings` have `EDXAPP_SITE_CONFIGURATION`

```
'EDXAPP_SITE_CONFIGURATION': [
     {
        'site_id': 1,
        'values': {
            'ACTIVATION_EMAIL_SUPPORT_LINK': '',
            'CONTACT_US_ENABLE': False
        }
    }
]
```

## Testing instruction
- Deploy new appServer
- Check that footer links were changed as expected


## Author notes and concerns
1. Contact page will be changed for all instances, which doesn't have EDXAPP_SITE_CONFIGURATION in Instance.configuration_extra_settings
2. If Instance.configuration_extra_settings have EDXAPP_SITE_CONFIGURATION we need to add `"CONTACT_US_CUSTOM_LINK":"/contact"` manually
3. I was thinking to update [ansible.dict_merge()](https://github.com/open-craft/opencraft/blob/master/instance/ansible.py#L78) function to properly merge list items, but it is dangerous to do, because we don't know which list_1 item should be merged with list_2 item.
4. Not sure if we need site_id for default object (need to test it somewhere):
```
'EDXAPP_SITE_CONFIGURATION': [
    {
        # 'site_id': 1, by default? or it will be populated?
        'values': {
            'CONTACT_US_CUSTOM_LINK': '/contact'
        }
    }
]
```


## Reviewers:
- [ ] @mavidser 