### PR TITLE
[SE-3040] Enables Auto Commit for MYSQLdb When Retrieving Cursor for DB

### DIFF
--- a/instance/models/mixins/openedx_database.py
+++ b/instance/models/mixins/openedx_database.py
@@ -198,6 +198,7 @@ class OpenEdXDatabaseMixin(MySQLInstanceMixin, MongoDBInstanceMixin, RabbitMQIns
             port=self.mysql_server.port,
             database=db_name,
         )
+        conn.autocommit(True)
         return conn.cursor()
 
     def _get_mysql_user_name(self, suffix):


### PR DESCRIPTION
Previously, any preupgrade sql commands ran would not be committed to the MySQL database. So, this PR enables auto commit in order to commit any changes during `instance_redeploy` to the MySQL database. 

**JIRA tickets**: SE-3040

**Testing instructions**:

TBD

**Reviewers**
- [ ] TBD