### PR TITLE
SE-3154 + SE-3175 Updates for Juniper auth and forum issues

### DIFF
--- a/instance/models/mixins/openedx_config.py
+++ b/instance/models/mixins/openedx_config.py
@@ -96,6 +96,10 @@ class OpenEdXConfigMixin(ConfigMixinBase):
             "EDXAPP_LOGIN_REDIRECT_WHITELIST": [self.instance.studio_domain, ],
             "EDXAPP_SESSION_COOKIE_DOMAIN": '.{}'.format(self.instance.domain),
 
+            # Use secure SameSite cookies
+            "EDXAPP_CSRF_COOKIE_SECURE": True,
+            "EDXAPP_SESSION_COOKIE_SECURE": True,
+
             # Run a command to delete expired sessions once a day. The time is random and different in each server
             # to avoid the case when all servers connect to the database at exactly the same time.
             # It's fine to use random numbers here because this function is called just once per appserver and the

--- a/instance/models/mixins/openedx_config.py
+++ b/instance/models/mixins/openedx_config.py
@@ -29,6 +29,7 @@ class OpenEdXConfigMixin(ConfigMixinBase):
         """
         return any(release_name in self.openedx_release for release_name in releases)
 
+    # pylint: disable=too-many-branches, useless-suppression
     def _get_configuration_variables(self):
         """
         Creates and returns a dictionary of ansible configuration variables for the instance
@@ -456,6 +457,19 @@ class OpenEdXConfigMixin(ConfigMixinBase):
             hb_app = "openedx.core.djangoapps.heartbeat"
             template["EDXAPP_CMS_ENV_EXTRA"]["ADDL_INSTALLED_APPS"].append(hb_app)
             template["EDXAPP_LMS_ENV_EXTRA"]["ADDL_INSTALLED_APPS"].append(hb_app)
+
+        # See https://github.com/edx/cs_comments_service/pull/323
+        if self._is_openedx_release_in(['ironwood']):
+            # See https://github.com/open-craft/cs_comments_service/pull/5
+            template["forum_source_repo"] = "https://github.com/open-craft/cs_comments_service.git"
+            template["forum_version"] = "opencraft-release/ironwood.2"
+        if self._is_openedx_release_in(['juniper']):
+            # See https://github.com/open-craft/cs_comments_service/pull/6
+            # TODO: Once https://github.com/edx/cs_comments_service/pull/323 merges,
+            # update to use edx for forum_source_repo, and "open-release/juniper.master" for forum_version(s).
+            template["forum_source_repo"] = "https://github.com/open-craft/cs_comments_service.git"
+            template["forum_version"] = "opencraft-release/juniper.2"
+            template["FORUM_VERSION"] = "opencraft-release/juniper.2"
 
         return template
 


### PR DESCRIPTION
Configuration changes to address issues noted during Juniper upgrades.

**Use secure cookies with default SameSite=None policy**

7401806 Updates the default instance configuration to set:

```yaml
EDXAPP_CSRF_COOKIE_SECURE: true
EDXAPP_SESSION_COOKIE_SECURE: true
```

**Forum dependencies build error**

Loss of a pinned dependency in cs_comments_service requires using our custom branch until the issue is merged upstream.

679dd78 Applies this for juniper and ironwood deployments.

**Sandbox**

* LMS: https://se3154.sandbox.stage.opencraft.hosting/
* Studio: https://studio.se3154.sandbox.stage.opencraft.hosting/

**Testing instructions**

Deployed to Ocim stage, see sandbox links above.  Since we don't have LetsEncrypt certificates set up for stage instances, you'll have to accept the self-signed cert to do this testing.

Using Chrome, Firefox, and Safari:

1. Register a new user account.
1. Activate the account (see email).
1. Logout
1. Login again
1. Enrol in the DemoX course, and navigate to the discussion forum
1. Ensure you can post a message there.

**Author Notes & Concerns**

1. Initially added `DCS_SESSION_COOKIE_SAMESITE: "Lax"`, but reverted due to [unknown unintended side effects on auth to 3rd party apps like LTI](https://github.com/open-craft/opencraft/pull/631#discussion_r473127288).
1. Have hard-coded a `FORUM_VERSION` on open-craft's own fork, but this is intended to be temporary until upstream changes merge.

**Reviewers**

- [ ] @nizarmah 

CC @clemente 
