### PR TITLE
[SE-2497] Avoid sending deployment failure urgent e-mails in deployments triggered by OpenCraft members

### DIFF
--- a/instance/models/openedx_instance.py
+++ b/instance/models/openedx_instance.py
@@ -357,7 +357,7 @@ class OpenEdXInstance(
                 self.tags.remove(success_tag)
 
             # Warn spawn failed after given attempts
-            appserver_spawned.send(sender=self.__class__, instance=self, appserver=None)
+            appserver_spawned.send(sender=self.__class__, instance=self, appserver=None, deployment_id=deployment_id)
             return None
 
         self.logger.info('Provisioned new app server, %s', app_server.name)
@@ -373,7 +373,7 @@ class OpenEdXInstance(
             # use task.make_appserver_active to allow disabling others
             app_server.make_active()
 
-        appserver_spawned.send(sender=self.__class__, instance=self, appserver=app_server)
+        appserver_spawned.send(sender=self.__class__, instance=self, appserver=app_server, deployment_id=deployment_id)
 
         return app_server.pk
 

--- a/instance/signals.py
+++ b/instance/signals.py
@@ -29,4 +29,4 @@ import django.dispatch
 
 # Emitted after an appserver has been spawned
 # After all attempts have been tried, and the appserver activated if applicable
-appserver_spawned = django.dispatch.Signal(providing_args=['instance', 'appserver'])
+appserver_spawned = django.dispatch.Signal(providing_args=['instance', 'appserver', 'deployment_id'])

--- a/instance/tests/models/test_openedx_instance.py
+++ b/instance/tests/models/test_openedx_instance.py
@@ -40,9 +40,11 @@ import yaml
 from instance import gandi
 from instance.gandi import GandiV5API
 from instance.models.appserver import Status as AppServerStatus
+from instance.models.deployment import DeploymentType
 from instance.models.instance import InstanceReference
 from instance.models.load_balancer import LoadBalancingServer
 from instance.models.openedx_appserver import OpenEdXAppServer
+from instance.models.openedx_deployment import OpenEdXDeployment
 from instance.models.openedx_instance import OpenEdXInstance, OpenEdXAppConfiguration
 from instance.models.server import OpenStackServer, Server, Status as ServerStatus
 from instance.models.utils import WrongStateException
@@ -466,6 +468,82 @@ class OpenEdXInstanceTestCase(TestCase):
         # each attempt did create a server (though with a failed status)
         self.assertEqual(instance.appserver_set.count(), 5)
 
+        self.assertEqual(len(django_mail.outbox), 0)
+
+    @ddt.data(DeploymentType.user, DeploymentType.periodic, DeploymentType.registration, DeploymentType.unknown)
+    @patch_services
+    def test_spawn_appserver_failed_all_attempts_send_emails_if_external(self, mocks, deployment_type, mock_consul):
+        """
+        Test what happens when spawning an AppServer fails repeatedly (5 out of 5 attempts).
+        Given that the appserver spawn is launched from users, we should send the email.
+        """
+        mocks.mock_run_ansible_playbooks.return_value = (['log: provisioning failed'], 1)
+
+        instance = OpenEdXInstanceFactory(sub_domain='test.spawn')
+        failure_emails = ['provisionfailed@localhost']
+        instance.provisioning_failure_notification_emails = failure_emails  # noqa pylint: disable=invalid-name
+        user = get_user_model().objects.create_user(username='test', email='test@example.com')
+
+        UserProfile.objects.create(
+            user=user,
+            full_name='test name',
+        )
+        BetaTestApplication.objects.create(
+            user=user,
+            subdomain='test',
+            instance=instance,
+            instance_name='Test instance',
+            project_description='Test instance creation.',
+            public_contact_email=user.email,
+        )
+
+        # Create the deployment, setting the deployment type
+        deployment = OpenEdXDeployment.objects.create(
+            instance_id=instance.ref.id,
+            type=deployment_type,
+        )
+        with self.assertRaises(ApplicationNotReady):
+            instance.spawn_appserver(num_attempts=5, deployment_id=deployment.pk)
+
+        # Given these deployment types, at least one email should be sended
+        self.assertGreater(len(django_mail.outbox), 0)
+
+    @ddt.data(DeploymentType.admin, DeploymentType.batch, DeploymentType.pr)
+    @patch_services
+    def test_spawn_appserver_failed_all_attempts_do_not_send_emails_if_internal(self, mocks, deployment_type, mock_consul):
+        """
+        Test what happens when spawning an AppServer fails repeatedly (5 out of 5 attempts).
+        Given that the appserver spawn is launched from members of OpenCraft, we shouldn't send the email.
+        """
+        mocks.mock_run_ansible_playbooks.return_value = (['log: provisioning failed'], 1)
+
+        instance = OpenEdXInstanceFactory(sub_domain='test.spawn')
+        failure_emails = ['provisionfailed@localhost']
+        instance.provisioning_failure_notification_emails = failure_emails  # noqa pylint: disable=invalid-name
+        user = get_user_model().objects.create_user(username='test', email='test@example.com')
+
+        UserProfile.objects.create(
+            user=user,
+            full_name='test name',
+        )
+        BetaTestApplication.objects.create(
+            user=user,
+            subdomain='test',
+            instance=instance,
+            instance_name='Test instance',
+            project_description='Test instance creation.',
+            public_contact_email=user.email,
+        )
+
+        # Create the deployment, setting the deployment type
+        deployment = OpenEdXDeployment.objects.create(
+            instance_id=instance.ref.id,
+            type=deployment_type,
+        )
+        with self.assertRaises(ApplicationNotReady):
+            instance.spawn_appserver(num_attempts=5, deployment_id=deployment.pk)
+
+        # Given these deployment types, at least one email should be sended
         self.assertEqual(len(django_mail.outbox), 0)
 
     @patch_services


### PR DESCRIPTION
This PR add a validation to avoid sending emails to users on appserver spawn failures if the action was created by a member of OpenCraft

Mostly copied from https://github.com/open-craft/opencraft/pull/617, the only major difference is that [this test](https://github.com/open-craft/opencraft/pull/617/files#diff-7ef807e87ca84698c66a33909fb5a8e8R347) is no longer needed (and in the original PR it always passes anyway, so it doesn't test anything).

**JIRA tickets**: [SE-2497](https://tasks.opencraft.com/browse/SE-2497)

**Testing instructions**

* Create a new deployment from the new interface, make it fail and check email is sended
* Redeploy instances using instance_redeploy command and check that email is not sended
* Create a new deployment from the manage site and check that no email is sent if it fails

**Reviewers**

 @pkulkark  @mtyaka 