### PR TITLE
[BB-2859] Implement Matomo tracking in Ocim

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1121,6 +1121,19 @@
       "resolved": "https://registry.npmjs.org/@csstools/normalize.css/-/normalize.css-10.1.0.tgz",
       "integrity": "sha512-ij4wRiunFfaJxjB0BdrYHIH8FxBJpOwNPhhAcunlmPdXudL1WQV1qoP9un6JsEBAgQH+7UXyyjh0g7jTxXK6tg=="
     },
+    "@datapunt/matomo-tracker-js": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@datapunt/matomo-tracker-js/-/matomo-tracker-js-0.2.1.tgz",
+      "integrity": "sha512-XI4xXpBS4S3BKl9wO6uda7GM/LUreS2N5Ep1cAtpIrKm4pZXTwF5Du/Qpv1HyBWoEjjCpRM7jIvyfrcVzEAQqg=="
+    },
+    "@datapunt/matomo-tracker-react": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@datapunt/matomo-tracker-react/-/matomo-tracker-react-0.2.1.tgz",
+      "integrity": "sha512-7PN+IsjF5rL85U52dSbY1tsdrBIkAp/qRS3eLWZSK2seLk4KoluuKUoVZRH/FvVX/nv43GKtjooYErui3UPH4Q==",
+      "requires": {
+        "@datapunt/matomo-tracker-js": "^0.2.1"
+      }
+    },
     "@formatjs/intl-displaynames": {
       "version": "1.2.9",
       "resolved": "https://registry.npmjs.org/@formatjs/intl-displaynames/-/intl-displaynames-1.2.9.tgz",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -29,6 +29,7 @@
     ]
   },
   "dependencies": {
+    "@datapunt/matomo-tracker-react": "^0.2.1",
     "@fortawesome/fontawesome-free": "^5.13.0",
     "@testing-library/jest-dom": "^5.7.0",
     "@testing-library/react": "^10.0.4",

--- a/frontend/src/console/components/RedeploymentToolbar/RedeploymentToolbar.tsx
+++ b/frontend/src/console/components/RedeploymentToolbar/RedeploymentToolbar.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { useMatomo } from '@datapunt/matomo-tracker-react';
 import { WrappedMessage } from 'utils/intl';
 import { Button, Modal } from 'react-bootstrap';
 import { CustomStatusPill } from 'ui/components';
@@ -27,6 +28,16 @@ export const RedeploymentToolbar: React.FC<Props> = ({
 
   const handleCloseModal = () => setShow(false);
   const handleShowModal = () => setShow(true);
+  const { trackEvent } = useMatomo();
+
+  const performDeploymentHandler = () => {
+    trackEvent({
+      category: 'deployment',
+      action: 'click-deploy',
+      name: 'Deploy'
+    });
+    performDeployment();
+  };
 
   let deploymentDisabled: boolean = true;
   let cancelDeploymentDisabled: boolean = true;
@@ -82,9 +93,7 @@ export const RedeploymentToolbar: React.FC<Props> = ({
           className="float-right loading"
           variant="primary"
           size="lg"
-          onClick={() => {
-            performDeployment();
-          }}
+          onClick={performDeploymentHandler}
           disabled={deploymentDisabled}
         >
           <WrappedMessage

--- a/frontend/src/global/constants.ts
+++ b/frontend/src/global/constants.ts
@@ -21,6 +21,15 @@ export const INTERNAL_DOMAIN_NAME =
 export const GANDI_REFERRAL_LINK =
   process.env.REACT_APP_GANDI_REFERRAL_LINK || 'https://gandi.link/';
 
+export const MATOMO_BASE_URL = process.env.REACT_APP_MATOMO_BASE_URL || '';
+
+export const MATOMO_SITE_ID = process.env.REACT_APP_MATOMO_SITE_ID || '1';
+
+export const MATOMO_MY_DOMAIN = process.env.REACT_APP_MATOMO_MY_DOMAIN || '';
+
+export const MATOMO_ALIAS_DOMAIN =
+  process.env.REACT_APP_MATOMO_ALIAS_DOMAIN || '';
+
 export interface StringIndexedArray {
   [key: string]: any;
 }

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -9,15 +9,18 @@ import * as serviceWorker from './serviceWorker';
 import '@fortawesome/fontawesome-free/css/all.min.css';
 import './styles/app.scss';
 import { App } from './ui/components';
+import { MatomoTracker } from './utils/MatomoTracker';
 
 ReactDOM.render(
-  <IntlProvider locale="en" textComponent={React.Fragment}>
-    <Provider store={store}>
-      <ConnectedRouter history={history}>
-        <App />
-      </ConnectedRouter>
-    </Provider>
-  </IntlProvider>,
+  <MatomoTracker>
+    <IntlProvider locale="en" textComponent={React.Fragment}>
+      <Provider store={store}>
+        <ConnectedRouter history={history}>
+          <App />
+        </ConnectedRouter>
+      </Provider>
+    </IntlProvider>
+  </MatomoTracker>,
   document.getElementById('root')
 );
 

--- a/frontend/src/registration/actions.ts
+++ b/frontend/src/registration/actions.ts
@@ -179,7 +179,7 @@ export const submitRegistration = (
 
           dispatch({
             type: Types.REGISTRATION_VALIDATION_SUCCESS,
-            userData,
+            data: userData,
             nextStep
           });
           if (nextStep) {

--- a/frontend/src/registration/components/CongratulationsPage/CongratulationsPage.tsx
+++ b/frontend/src/registration/components/CongratulationsPage/CongratulationsPage.tsx
@@ -6,16 +6,19 @@ import { Button } from 'react-bootstrap';
 import { WrappedMessage } from 'utils/intl';
 import { RegistrationSteps, ROUTES } from 'global/constants';
 import { RedirectToCorrectStep } from 'registration/components';
+import { MatomoUserIdTracker } from 'utils/MatomoTracker';
 import { submitRegistration } from '../../actions';
 import { RegistrationPage } from '../RegistrationPage';
 import messages from './displayMessages';
 import './styles.scss';
+import { RegistrationModel } from '../../models';
 
 interface ActionProps {
   submitRegistration: Function;
 }
 
 interface Props extends ActionProps {
+  registrationData: RegistrationModel;
   currentRegistrationStep: RegistrationSteps;
 }
 
@@ -37,6 +40,7 @@ export class CongratulationsPage extends React.PureComponent<Props, State> {
           currentPageStep={4}
           currentRegistrationStep={this.props.currentRegistrationStep}
         />
+        <MatomoUserIdTracker userId={this.props.registrationData.username} />
         <div className="congrats-page">
           <h1>
             <WrappedMessage messages={messages} id="congrats" />

--- a/frontend/src/ui/components/App/App.tsx
+++ b/frontend/src/ui/components/App/App.tsx
@@ -1,12 +1,27 @@
 import React from 'react';
 import { Container } from 'react-bootstrap';
+import { useMatomo } from '@datapunt/matomo-tracker-react';
+import { useHistory } from 'react-router';
 import { Footer, Header, Main } from '..';
 import './styles.scss';
 
-export const App: React.FC = () => (
-  <Container fluid className="app-container">
-    <Header />
-    <Main />
-    <Footer />
-  </Container>
-);
+export const App: React.FC = () => {
+  const { trackPageView } = useMatomo();
+  React.useEffect(() => {
+    trackPageView({});
+  }, [trackPageView]);
+
+  const history = useHistory();
+  React.useEffect(() => {
+    return history.listen(location => {
+      trackPageView({});
+    });
+  }, [trackPageView, history]);
+  return (
+    <Container fluid className="app-container">
+      <Header />
+      <Main />
+      <Footer />
+    </Container>
+  );
+};

--- a/frontend/src/utils/MatomoTracker.tsx
+++ b/frontend/src/utils/MatomoTracker.tsx
@@ -1,0 +1,81 @@
+import React, { ReactNode } from 'react';
+import {
+  createInstance,
+  MatomoProvider,
+  useMatomo
+} from '@datapunt/matomo-tracker-react';
+import {
+  MATOMO_ALIAS_DOMAIN,
+  MATOMO_BASE_URL,
+  MATOMO_MY_DOMAIN,
+  MATOMO_SITE_ID
+} from '../global/constants';
+
+interface MatomoTrackerProps {
+  children: ReactNode;
+}
+
+interface MatomoAdditionalConfiguration {
+  [propName: string]: any;
+}
+
+interface MatomoConfiguration {
+  urlBase: string;
+  siteId: number;
+  configurations?: MatomoAdditionalConfiguration;
+}
+
+interface MatomoUserIdTrackerProps {
+  userId: string;
+}
+
+/*
+ * This wrapper component initializes the Matomo tracking by wrapping the children
+ * elements, if the tracking is enabled by providing a valid value for the 'MATOMO_BASE_URL'
+ * constant. It allows tracking page views, events and the user id, when available.
+ *
+ * The 'MATOMO_ALIAS_DOMAIN' constant allows the cross-domain linking of another site with
+ * this site so that they are treated as the same site in Matomo.
+ */
+export const MatomoTracker: React.FC<MatomoTrackerProps> = (
+  props: MatomoTrackerProps
+) => {
+  let element = props.children;
+  if (MATOMO_BASE_URL) {
+    const matomoConfiguration: MatomoConfiguration = {
+      urlBase: MATOMO_BASE_URL,
+      siteId: parseInt(MATOMO_SITE_ID, 10)
+    };
+    if (MATOMO_ALIAS_DOMAIN) {
+      const myDomain = `*.${MATOMO_MY_DOMAIN}`;
+      const aliasDomain = `*.${MATOMO_ALIAS_DOMAIN}`;
+      matomoConfiguration.configurations = {
+        enableCrossDomainLinking: true,
+        setDomains: [myDomain, aliasDomain]
+      };
+    }
+    element = (
+      <MatomoProvider value={createInstance(matomoConfiguration)}>
+        {props.children}
+      </MatomoProvider>
+    );
+  }
+  return <>{element}</>;
+};
+
+/**
+ * This is a component passes the provided user id to Matomo if Matomo tracking is enabled.
+ * The 'pushInstruction' function exposed by the 'useMatomo()' hook is used to do this.
+ *
+ * This component is needed as all the components in the registration process are classes and hence
+ * the 'yseMatomo' hook cannot be directly used in those components.
+ */
+export const MatomoUserIdTracker: React.FC<MatomoUserIdTrackerProps> = (
+  props: MatomoUserIdTrackerProps
+) => {
+  const { pushInstruction } = useMatomo();
+  if (MATOMO_BASE_URL && props.userId) {
+    pushInstruction('setUserId', props.userId);
+  }
+  return null;
+};


### PR DESCRIPTION
This PR implements Matomo tracking in the Ocim frontend. The tracking data will be sent to the Matomo instance configured at build-time using the `REACT_APP_MATOMO_BASE_URL` environment variable. If it is not configured, the frontend will not perform any tracking using Matomo at all.

**Testing instructions**:
* Check out the source branch of this PR.
* Install the JavaScript library dependencies by running `npm install` from the `frontend/` directory.
* Build the Ocim API client by running the `build-api-client.sh` script inside the `scripts` directory.
* Start the Ocim backend application inside the devstack vagrant VM by running `make dev.up`.
* Set up a local Matomo instance by using `docker-compose` and the below contents in a `docker-compose.yml` file.
  ```yaml
  ---
  version: "2"
  services:
    matomo:
      container_name: matomo
      image: matomo:3-apache
      volumes:
        - ./matomo-data:/var/www/html
      environment:
        - MATOMO_DATABASE_HOST=mysql
        - MATOMO_DATABASE_ADAPTER="mysql"
        - MATOMO_DATABASE_TABLES_PREFIX=matomo_
        - MATOMO_DATABASE_USERNAME=matomo
        - MATOMO_DATABASE_PASSWORD=analytics
        - MATOMO_DATABASE_DBNAME=matomo
      ports:
        - 8080:80
    mysql:
      container_name: mysql
      image: mysql:5.6
      volumes:
        - ./mysql-data:/var/lib/mysql
      environment:
        - MYSQL_ROOT_PASSWORD=dolphinuser
        - MYSQL_DATABASE=matomo
        - MYSQL_USER=matomo
        - MYSQL_PASSWORD=analytics
  ```
* Open http://localhost:8080 and complete the Matomo installation process using the wizard. Add http://localhost:3000 as a site at the end of the installation process.
* If Matomo complains about expecting to run at http://localhost instead of http://localhost:8080, edit `./matomo-data/config/config.inc.php` and add `localhost:8080` to the list of trusted hosts.

  ```php
  trusted_hosts[] = "localhost:8080"
  ```
* Set the environment variable `REACT_APP_MATOMO_BASE_URL` to `'http://localhost:8080'` and the `REACT_APP_MATOMO_SITE_ID` environment variable to `1` (or the appropriate site ID if you have created more than one site in Matomo).
* Start the frontend app by running `npm start`.
* The Ocim frontend app should open up in the browser and there should be no errors in the page or the output of the `npm` command run in the previous step`.
* Open the `Network` section of the browser developer tools and verify that the `matomo.js` JavaScript file was loaded.
* Go through the registration process and verify that a request to the Matomo instance with the page tracking data (don't have to actually check the data) is made on all page navigation operations.
* Complete the registration process and log in to the Ocim console.
* Navigate to the various pages in the console and verify that the page navigation is still tracked.
* Log in to Matomo and verify that all the visits and the page navigation is tracked.
* In case there is no data, it could be because your browser has an ad-blocker or privacy settings (like Do Not Track etc.) that might be blocking Matomo or asking Matomo to not track you. For proper verification, test this in a fresh browser profile with all the privacy and tracking protections, DNT disabled.
* Stop the frontend app and unset the `REACT_APP_*` environment variables set in a previous step.
* Start the frontend app again and open the site in a fresh browser profile without any existing data and all the privacy/tracking protections disabled.
* Go through the registration process and also navigate between the pages in the console.
* Verify that there is no Matomo tracking done.

**Author notes and concerns**:
* The Matomo React libraries are included in the build process and likely included in the page even when the tracking is not enabled. While there are some ways to do a conditional import of the library, they appear to involve a lot of workarounds and may involve ejecting the React app. So I have not tried to do any of those things.
* The tracking of the user's email address is not yet implemented.