### PR TITLE
BB-2883 Allow instantce_statistics_csv to receive multiple domains; Create trial_instances_report on cronjob

### DIFF
--- a/opencraft/settings.py
+++ b/opencraft/settings.py
@@ -874,6 +874,14 @@ if FILEBEAT_LOGSTASH_HOSTS:
 INSTANCE_LOGS_SERVER_HOST = env('INSTANCE_LOGS_SERVER_HOST', default=logs_server_host_default)
 INSTANCE_LOGS_SERVER_SSH_USERNAME = env('INSTANCE_LOGS_SERVER_SSH_USERNAME', default='ubuntu')
 
+# Trial Instances Report ######################################################
+
+TRIAL_INSTANCES_REPORT_RECIPIENTS = env.json('TRIAL_INSTANCES_REPORT_RECIPIENTS', default=['billing@opencraft.com'])
+
+# Crontab schedule for the Trial Instances Report.
+# Format is '<minute> <hour> <day> <month> <day_of_week>' like normal crontabs
+TRIAL_INSTANCES_REPORT_SCHEDULE = env('TRIAL_INSTANCES_REPORT_SCHEDULE', default='0 2 1 * *')
+
 # Instances ###################################################################
 
 # User Console - React SPA

--- a/playbooks/collect_activity/collect_activity.yml
+++ b/playbooks/collect_activity/collect_activity.yml
@@ -6,9 +6,7 @@
   vars:
     # This should be overridden to be more unique.
     local_output_dir: /tmp/
-    local_output_filename: "{{ inventory_hostname }}"
     remote_output_filename: /tmp/activity_report
-    config_section: "{{ inventory_hostname }}"
     extra_script_arguments: ""
   tasks:
     # We have to do a copy+command pair here (instead of script) in order to get
@@ -25,7 +23,7 @@
       shell: >
         . /edx/app/edxapp/edxapp_env &&
         /edx/bin/python.edxapp /tmp/collect_activity.py
-        --config-section {{ config_section }}
+        --config-section {{ config_section | default(inventory_hostname) }}
         --out {{ remote_output_filename }}
         {{ extra_script_arguments }}
       register: stats_results
@@ -41,7 +39,7 @@
     - name: Fetch stats
       fetch:
         src: '{{ remote_output_filename }}'
-        dest: '{{ local_output_dir }}/{{ local_output_filename }}'
+        dest: '{{ local_output_dir }}/{{ local_output_filename | default(inventory_hostname) }}'
         flat: yes
       register: fetch_results
 

--- a/playbooks/collect_activity/stats.py
+++ b/playbooks/collect_activity/stats.py
@@ -1,6 +1,7 @@
 #!/edx/bin/python.edxapp
 # pylint: skip-file
 
+from __future__ import print_function
 from argparse import ArgumentParser
 import gzip
 import os
@@ -96,6 +97,6 @@ if __name__ == '__main__':
     # Output the data in ConfigParser format to stdout and to a file.
     config.write(sys.stdout)
     if args.out:
-        print('Writing to file passed via parameter: {filename}'.format(filename=args.out), sys.stderr)
+        print('Writing to file passed via parameter: {filename}'.format(filename=args.out), file=sys.stderr)
         with open(args.out, 'w') as output_file:
             config.write(output_file)

--- a/playbooks/collect_instance_statistics/collect_elasticsearch_data.yml
+++ b/playbooks/collect_instance_statistics/collect_elasticsearch_data.yml
@@ -37,7 +37,7 @@
       command: >
         {{ ansible_env.HOME }}/instance_activity_venv/bin/python /tmp/query_elasticsearch.py
           --out {{ remote_output_filename }}
-          --name-prefix {{ server_name_prefix }}
+          --name-prefixes {{ server_name_prefixes }}
           --start-date {{ start_date }}
           --end-date {{ end_date }}
       register: stats_results

--- a/playbooks/collect_instance_statistics/query_elasticsearch.py
+++ b/playbooks/collect_instance_statistics/query_elasticsearch.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 # pylint: skip-file
 
+from __future__ import print_function
 from argparse import ArgumentParser
 from datetime import datetime, timedelta
 from elasticsearch import Elasticsearch
@@ -25,9 +26,9 @@ if __name__ == '__main__':
 
     parser = ArgumentParser()
     parser.add_argument(
-        '--name-prefix',
+        '--name-prefixes',
         default=None,
-        help='The fully qualified domain name to filter results by. FORMAT: YYYY-MM-DD',
+        help='Comma-separated name prefixes to filter results by. Each will be run sequentially',
         required=True
     )
     parser.add_argument(
@@ -52,57 +53,61 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     client = Elasticsearch()
-
-    unique_ips = set()
-    total_hits = 0
-
-    # Start at start_date and go until end_date, incrementing by 1 day
-    # (at the end of the loop)
-    date = args.start_date
-    while date <= args.end_date:
-        es_index = 'filebeat-{date}'.format(date=date.strftime("%Y.%m.%d"))
-
-        # Query for the host matching the name_prefix
-        # Only query access log data, and ignore heartbeat or xqueue/get_queuelen requests
-        search = Search(using=client, index=es_index) \
-            .query("match_phrase", host=args.name_prefix) \
-            .query("match_phrase", source="/edx/var/log/nginx/access.log") \
-            .exclude("match_phrase", request="heartbeat") \
-            .exclude("match_phrase", request="xqueue/get_queuelen")
-
-        # Aggregate the unique hits by proxy_ip
-        search.aggs.bucket("unique_hits", "terms", size=10000, field="proxy_ip.keyword")
-
-        # Python slice syntax is used to set the `from` and `size`
-        # parameters for the search, which we want set to 0
-        response = search[0:0].execute()
-
-        for bucket in response["aggregations"]["unique_hits"]["buckets"]:
-            ip = bucket["key"]
-
-            # Ignore requests without a proxy_ip
-            if ip == "-":
-                continue
-
-            unique_ips.add(ip)
-            total_hits += bucket["doc_count"]
-
-        date += timedelta(days=1)
-
-    stats = {
-        'unique_hits': len(unique_ips),
-        'total_hits': total_hits,
-    }
-
-    # Build the ConfigParser data.
     config = ConfigParser()
-    config.add_section(args.name_prefix)
-    for key, value in stats.items():
-        config.set(args.name_prefix, key, str(value))
+
+    name_prefixes = args.name_prefixes.split(',')
+
+    for name_prefix in name_prefixes:
+
+        unique_ips = set()
+        total_hits = 0
+
+        # Start at start_date and go until end_date, incrementing by 1 day
+        # (at the end of the loop)
+        date = args.start_date
+        while date <= args.end_date:
+            es_index = 'filebeat-{date}'.format(date=date.strftime("%Y.%m.%d"))
+
+            # Query for the host matching the name_prefix
+            # Only query access log data, and ignore heartbeat or xqueue/get_queuelen requests
+            search = Search(using=client, index=es_index) \
+                .query("match_phrase", host=name_prefix) \
+                .query("match_phrase", source="/edx/var/log/nginx/access.log") \
+                .exclude("match_phrase", request="heartbeat") \
+                .exclude("match_phrase", request="xqueue/get_queuelen")
+
+            # Aggregate the unique hits by proxy_ip
+            search.aggs.bucket("unique_hits", "terms", size=10000, field="proxy_ip.keyword")
+
+            # Python slice syntax is used to set the `from` and `size`
+            # parameters for the search, which we want set to 0
+            response = search[0:0].execute()
+
+            for bucket in response["aggregations"]["unique_hits"]["buckets"]:
+                ip = bucket["key"]
+
+                # Ignore requests without a proxy_ip
+                if ip == "-":
+                    continue
+
+                unique_ips.add(ip)
+                total_hits += bucket["doc_count"]
+
+            date += timedelta(days=1)
+
+        stats = {
+            'unique_hits': len(unique_ips),
+            'total_hits': total_hits,
+        }
+
+        # Build the ConfigParser data
+        config.add_section(name_prefix)
+        for key, value in stats.items():
+            config.set(name_prefix, key, str(value))
 
     # Output the data in ConfigParser format to stdout and to a file.
     config.write(sys.stdout)
     if args.out:
-        print('Writing to file passed via parameter: {filename}'.format(filename=args.out), sys.stderr)
+        print('Writing to file passed via parameter: {filename}'.format(filename=args.out), file=sys.stderr)
         with open(args.out, 'w') as output_file:
             config.write(output_file)

--- a/reports/tasks.py
+++ b/reports/tasks.py
@@ -1,0 +1,123 @@
+"""
+Worker tasks for reporting
+"""
+
+# Imports #####################################################################
+
+from datetime import datetime, timedelta
+import logging
+
+from django.conf import settings
+from django.core.mail import EmailMessage
+from django.core.management import call_command
+from huey.api import crontab
+from huey.contrib.djhuey import db_periodic_task
+
+from instance.models.openedx_instance import OpenEdXInstance
+
+
+# Logging #####################################################################
+
+logger = logging.getLogger(__name__)
+
+
+# Constants ###################################################################
+
+# Defaults to '0 2 1 * *' which is the first of every month at 2AM UTC
+TRIAL_INSTANCES_REPORT_SCHEDULE = getattr(settings, 'TRIAL_INSTANCES_REPORT_SCHEDULE',
+                                          '0 2 1 * *').split()
+
+TRIAL_INSTANCES_REPORT_SCHEDULE_MINUTE = TRIAL_INSTANCES_REPORT_SCHEDULE[0]
+TRIAL_INSTANCES_REPORT_SCHEDULE_HOUR = TRIAL_INSTANCES_REPORT_SCHEDULE[1]
+TRIAL_INSTANCES_REPORT_SCHEDULE_DAY = TRIAL_INSTANCES_REPORT_SCHEDULE[2]
+TRIAL_INSTANCES_REPORT_SCHEDULE_MONTH = TRIAL_INSTANCES_REPORT_SCHEDULE[3]
+TRIAL_INSTANCES_REPORT_SCHEDULE_DAY_OF_WEEK = TRIAL_INSTANCES_REPORT_SCHEDULE[4]
+
+
+# Tasks #######################################################################
+
+# Run on the 1st of every month
+@db_periodic_task(
+    crontab(
+        minute=TRIAL_INSTANCES_REPORT_SCHEDULE_MINUTE,
+        hour=TRIAL_INSTANCES_REPORT_SCHEDULE_HOUR,
+        day=TRIAL_INSTANCES_REPORT_SCHEDULE_DAY,
+        month=TRIAL_INSTANCES_REPORT_SCHEDULE_MONTH,
+        day_of_week=TRIAL_INSTANCES_REPORT_SCHEDULE_DAY_OF_WEEK
+    )
+)
+def send_trial_instances_report(recipients=settings.TRIAL_INSTANCES_REPORT_RECIPIENTS):
+    """
+    Generate and send a trial instance data report
+
+    This task runs on the first of every month at 2AM
+    """
+
+    if not recipients:
+        logger.warning('No recipients listed for Trial Instances Report. It will not be generated.')
+        return True
+
+    # Get instances with an active betatestapplication and
+    # whose InstanceReference has an active OpenEdXAppServer
+    instances = OpenEdXInstance.objects.exclude(
+        betatestapplication__isnull=True
+    ).filter(
+        ref_set__openedxappserver_set___is_active=True
+    )
+
+    domains = [instance.external_lms_domain or instance.internal_lms_domain for instance in instances]
+
+    # Start with the beginning of this month
+    beginning_of_this_month = datetime.utcnow().date().replace(day=1)
+
+    # Get last month by subtracting one day from the beginning of
+    # this month to get the last day of last month
+    # Finally, replace the day with 1, to get the first day of last month
+    end_of_last_month = (beginning_of_this_month - timedelta(days=1))
+    beginning_of_last_month = end_of_last_month.replace(day=1)
+
+    csv_filename = '/tmp/trial_instances_report.csv'
+
+    email_subject = "{month_and_year} Trial Instances".format(
+        month_and_year=end_of_last_month.strftime("%B %Y")
+    )
+
+    try:
+        call_command(
+            'instance_statistics_csv',
+            out=csv_filename,
+            domains=','.join(domains),
+            start_date=beginning_of_last_month.strftime("%Y-%m-%d"),
+            end_date=end_of_last_month.strftime("%Y-%m-%d")
+        )
+    except SystemExit:
+        # The command exited prematurely. Send failure email to recipients
+        logger.error('`instance_statistics_csv` command failed. Sending notification email')
+        email_subject += ' Failure'
+        email = EmailMessage(
+            email_subject,
+            'Unable to generate a Trial Instances Report due to failure of `instance_statistics_csv` command',
+            settings.DEFAULT_FROM_EMAIL,
+            recipients
+        )
+        email.send()
+        return False
+
+    text_message = (
+        'Please find attached a CSV with the statistics for '
+        '{month_and_year} for all instances with an active '
+        'Beta Test Application'.format(
+            month_and_year=end_of_last_month.strftime("%B %Y")
+        )
+    )
+
+    email = EmailMessage(
+        email_subject,
+        text_message,
+        settings.DEFAULT_FROM_EMAIL,
+        recipients
+    )
+
+    email.attach_file(csv_filename)
+
+    return email.send()


### PR DESCRIPTION
Modifies the `instance_statistics_csv` command to allow for multiple domains. Also uses this new version in a new task to send a trial instances report to emails set in `settings.TRIAL_INSTANCES_REPORT_RECIPIENTS`

**JIRA tickets**:
[BB-2883](https://tasks.opencraft.com/browse/BB-2883)

**Screenshots**:

![trial_instance_report_email](https://user-images.githubusercontent.com/829980/92096538-35032d00-ee01-11ea-802c-a07579262e18.png)
![trial_instance_report_csv](https://user-images.githubusercontent.com/829980/92096541-36345a00-ee01-11ea-9cc0-60f4b28fd89a.png)


**Testing instructions**:

Test on functionality on staging:

1. Generate the public SSH key for `www-data@stage.manage.opencraft.com`  using `ssh-keygen -y -f ~/.ssh/id_rsa`
2. Add public key to `authorized_keys` file on `logs.opencraft.com`
3. Set `INSTANCE_LOGS_SERVER_HOST` to `logs.opencraft.com` in `.env` file on `stage.manage.opencraft.com`
4. Run
```
make manage -- instance_statistics_csv --domains daniel.stage.opencraft.hosting,piotr.stage.opencraft.hosting,gabrieltesting.stage.opencraft.hosting
```
5. Wait for resulting output

Test task on staging:

1. Generate the public SSH key for `www-data@stage.manage.opencraft.com`  using `ssh-keygen -y -f ~/.ssh/id_rsa`
2. Add public key to `authorized_keys` file on `logs.opencraft.com`
3. Set `INSTANCE_LOGS_SERVER_HOST` to `logs.opencraft.com` in `.env` file on `stage.manage.opencraft.com`
4. Set `TRIAL_INSTANCE_REPORT_RECIPIENTS` to `'["YOUR_EMAIL@opencraft.com"]'` in `.env` file on `stage.manage.opencraft.com`
5. Edit `reports/tasks.py` and change this line
```
@db_periodic_task(crontab(day='1', hour='2', minute='0'))
```
to this
```
@db_periodic_task(crontab(minute='*/5'))
```
6. Start the web process with `make run` (in the web screen tab) and wait 5-6 minutes
7. Check your email for a resulting CSV

**Reviewers**
- [ ] @lgp171188 