### PR TITLE
Add a health check endpoint to ocim

### DIFF
--- a/opencraft/urls.py
+++ b/opencraft/urls.py
@@ -33,6 +33,7 @@ import opencraft.views as views
 # URL Patterns ################################################################
 
 urlpatterns = [
+    url(r'^health_check/', views.HealthCheckView.as_view(), name='health_check'),
     url(r'^grappelli/', include('grappelli.urls')),
     url(r'^admin/', admin.site.urls),
     url(r'^api/', include('api.urls', namespace='api')),


### PR DESCRIPTION
Adds a health check endpoint to OCIM which verifies the postgres, redis and consul connections.

**JIRA tickets**: [SE-3021](https://tasks.opencraft.com/browse/SE-3021)

**Testing instructions**:

- Run `make test.unit`
- Make sure postgres, redis and consul are running, then visit `/health_check` URL on ocim. Now take down services one by one and verify the non-200 response from the health check page.

**Author notes**:
- If postgres is unavailable then the view isn't even called as ocim fails at trying to log the request in the database. I've still added the verification code to the view in case the logging behaviour ever changes in the future.

**Reviewers**
- [ ] @mtyaka 
- [ ] @lgp171188 