### PR TITLE
[SE-2955] Undo rename of logistration toggle button

### DIFF
--- a/frontend/packages/api_client/src/models/ThemeSchema.ts
+++ b/frontend/packages/api_client/src/models/ThemeSchema.ts
@@ -240,7 +240,7 @@ export interface ThemeSchema {
      * @type {boolean}
      * @memberof ThemeSchema
      */
-    customizeLogistrationBtn?: boolean;
+    customizeLogistrationActionBtn?: boolean;
     /**
      * 
      * @type {string}
@@ -385,7 +385,7 @@ export function ThemeSchemaFromJSONTyped(json: any, ignoreDiscriminator: boolean
         'btnRegisterHoverBg': !exists(json, 'btn-register-hover-bg') ? undefined : json['btn-register-hover-bg'],
         'btnRegisterHoverColor': !exists(json, 'btn-register-hover-color') ? undefined : json['btn-register-hover-color'],
         'btnRegisterHoverBorderColor': !exists(json, 'btn-register-hover-border-color') ? undefined : json['btn-register-hover-border-color'],
-        'customizeLogistrationBtn': !exists(json, 'customize-logistration-btn') ? undefined : json['customize-logistration-btn'],
+        'customizeLogistrationActionBtn': !exists(json, 'customize-logistration-action-btn') ? undefined : json['customize-logistration-action-btn'],
         'btnLogistrationBg': !exists(json, 'btn-logistration-bg') ? undefined : json['btn-logistration-bg'],
         'btnLogistrationColor': !exists(json, 'btn-logistration-color') ? undefined : json['btn-logistration-color'],
         'btnLogistrationBorderColor': !exists(json, 'btn-logistration-border-color') ? undefined : json['btn-logistration-border-color'],
@@ -450,7 +450,7 @@ export function ThemeSchemaToJSON(value?: ThemeSchema | null): any {
         'btn-register-hover-bg': value.btnRegisterHoverBg,
         'btn-register-hover-color': value.btnRegisterHoverColor,
         'btn-register-hover-border-color': value.btnRegisterHoverBorderColor,
-        'customize-logistration-btn': value.customizeLogistrationBtn,
+        'customize-logistration-action-btn': value.customizeLogistrationActionBtn,
         'btn-logistration-bg': value.btnLogistrationBg,
         'btn-logistration-color': value.btnLogistrationColor,
         'btn-logistration-border-color': value.btnLogistrationBorderColor,

--- a/frontend/src/console/components/ButtonCustomizationPage/ButtonCustomizationPage.tsx
+++ b/frontend/src/console/components/ButtonCustomizationPage/ButtonCustomizationPage.tsx
@@ -54,7 +54,13 @@ export const ButtonCustomizationPage: React.FC<ButtonCustomizationPageProps> = (
     ]
   };
 
-  const customizationProp = `customize${props.buttonName}Btn`;
+  let customizationProp = `customize${props.buttonName}Btn`;
+  if (props.buttonName === 'Logistration') {
+    // Logistration toggle doesn't follow the common naming convention, hence setting it explicitly.
+    // See SE-2955 for discussion.
+    customizationProp = `customizeLogistrationActionBtn`;
+  }
+
   const allStylesDefined = Object.values(styles)
     .map(category =>
       category.every(style => themeData[style as keyof typeof themeData])

--- a/instance/schemas/theming.py
+++ b/instance/schemas/theming.py
@@ -95,7 +95,7 @@ theme_schema_v1 = {
         "btn-register-hover-bg": ref("color"),
         "btn-register-hover-color": ref("color"),
         "btn-register-hover-border-color": ref("color"),
-        "customize-logistration-btn": ref("flag"),
+        "customize-logistration-action-btn": ref("flag"),
         "btn-logistration-bg": ref("color"),
         "btn-logistration-color": ref("color"),
         "btn-logistration-border-color": ref("color"),
@@ -130,7 +130,7 @@ theme_schema_v1 = {
             "btn-register-hover-color",
             "btn-register-hover-border-color",
         ],
-        "customize-logistration-btn": [
+        "customize-logistration-action-btn": [
             "btn-logistration-bg",
             "btn-logistration-color",
             "btn-logistration-border-color",


### PR DESCRIPTION
Reverts #12 changes and adds special handling for logistration toggle name to preserve compatibility with forked themes.

**JIRA Ticket:** [SE-2955](https://tasks.opencraft.com/browse/SE-2955)

**Testing instructions:**

1. Add this branch to OCIM's settings while using this [PR branch](https://github.com/open-craft/opencraft/tree/mavidser/se-2955-fix-ui-toggle).
2. Make changes to logistration button via console, verify the UI on the deployed appserver.

**Sandbox**: https://mavidser.stage.opencraft.hosting/

**Reviewers:**

[ ] @mtyaka 