### PR TITLE
[SE-3136] Add client instance name to New Relic monitoring condition name

### DIFF
--- a/instance/tests/models/test_openedx_monitoring_mixins.py
+++ b/instance/tests/models/test_openedx_monitoring_mixins.py
@@ -106,18 +106,23 @@ class OpenEdXMonitoringTestCase(TestCase):
         )
 
         # Check that alert emails have been set up
-        created_condition_urls = set()
+        created_conditions = set()
         list_of_emails_added = []
 
         for add_call in mock_newrelic.add_alert_nrql_condition.call_args_list:
-            created_condition_urls.add(add_call[0][1])
+            created_conditions.add((add_call[0][1], add_call[0][2]))
 
         for add_call in mock_newrelic.add_email_notification_channel.call_args_list:
             list_of_emails_added.append(add_call[0][0])
 
         self.assertEqual(
-            created_condition_urls,
-            set([instance.url, instance.studio_url, instance.lms_preview_url, instance.lms_extended_heartbeat_url])
+            created_conditions,
+            set([
+                (instance.url, 'LMS of {}'.format(instance.name)),
+                (instance.studio_url, 'Studio of {}'.format(instance.name)),
+                (instance.lms_preview_url, 'Preview of {}'.format(instance.name)),
+                (instance.lms_extended_heartbeat_url, 'Extended heartbeat of {}'.format(instance.name)),
+            ])
         )
         self.assertEqual(set(list_of_emails_added), set(expected_monitor_emails))
         mock_newrelic.add_notification_channels_to_policy.assert_called_with(


### PR DESCRIPTION
This PR is adding client instance name to New Relic monitoring condition name to be able to find root cause of incidents faster and improve the investigation experience. In case the name is too long, it will be truncated due to limitations.

**Dependencies**: None

**Screenshots**:

<img width="1348" alt="Screenshot 2020-09-11 at 9 53 11" src="https://user-images.githubusercontent.com/19173947/92887271-a439dc00-f414-11ea-813e-08376f0941c3.png">

**Merge deadline**: None

**Testing instructions**:

1. If you don't already have `ADMINS` setting set in your local `.env` file, set it to your email (ie. `ADMINS='[["Gabor Admin", "gabor@opencraft.com"]]'`.
2. Set `NEWRELIC_ADMIN_USER_API_KEY` and `NEWRELIC_LICENSE_KEY` in your local `.env` file. You can find them on the production Ocim VM's `.env` file.
3. Start the django shell (`make shell`).
4. Get a reference to an `OpenEdXInstace` (or create a new one if you don't have an existing instance in your devstack).
5. Run `instance.enable_monitoring()`. Make sure that there are no errors.
6. Log into NewRelic and go to 'Alerts & AI -> Policies'. Search by the URL of your test instance and verify that the policy alerts look correct.
7. Run `instance.disable_monitoring()`. 
8. Verify that the policy for your instance has been removed from NewRelic.
9. Don't forget to remove `NEWRELIC_ADMIN_USER_API_KEY` and `NEWRELIC_LICENSE_KEY` from your local `.env` file!

**Author notes and concerns**:

1. The format of **the condition name was not finalized beforehand**, so I'm opened to discuss other ideas too.
2. In case the condition name reaches the maximum (64) characters and the instance name is one long word, the instance name will be replaced by `...`. Example faulty condition name: `Preview of ...` [1] [2]

[1] In my opinion, this shouldn't be an issue since it would mean that the instance name should be at least 42 characters long without any whitespace. Number 42 is built up from: length of the longest "prefix" with formatting extracted from 64, the current maximum length. So: `64 - len("Extended heartbeat of ")`
[2] The 64 length is not confirmed by NewRelic developers yet. Currently, I'm investigating the max length with the help of New Relic, but **I think, this shouldn't be a blocker**, since an institution name which is equal to or longer than 42 chars is really rare.