### PR TITLE
SE-3310 Ensure prod instances email urgent on monitoring fail and alerts auto close once resolved

### DIFF
--- a/instance/newrelic.py
+++ b/instance/newrelic.py
@@ -184,7 +184,7 @@ def add_alert_nrql_condition(policy_id, monitor_url, name):
                 'type': 'static',
                 'name': name,
                 'enabled': True,
-                'value_function': 'single_value',
+                'value_function': 'sum',
                 'terms': [{
                     'duration': settings.NEWRELIC_NRQL_ALERT_CONDITION_DURATION,
                     'threshold': '1',

--- a/instance/tests/test_newrelic.py
+++ b/instance/tests/test_newrelic.py
@@ -254,7 +254,7 @@ class NewRelicTestCase(TestCase):
                 'type': 'static',
                 'name': condition_name,
                 'enabled': True,
-                'value_function': 'single_value',
+                'value_function': 'sum',
                 'terms': [{
                     'duration': '11',
                     'threshold': '1',

--- a/registration/provision.py
+++ b/registration/provision.py
@@ -93,6 +93,7 @@ def _provision_instance(sender, **kwargs):
 
         if settings.PROD_APPSERVER_FAIL_EMAILS:
             application.instance.provisioning_failure_notification_emails = settings.PROD_APPSERVER_FAIL_EMAILS
+            application.instance.additional_monitoring_emails = settings.PROD_APPSERVER_FAIL_EMAILS
             application.instance.save()
         application.save()
         # At this point we know the user has confirmed their email and set up an instance.

--- a/registration/tests/test_provision.py
+++ b/registration/tests/test_provision.py
@@ -78,6 +78,7 @@ class ApprovalTestCase(TestCase):
         self.assertEqual(instance.email, application.public_contact_email)
         self.assertEqual(instance.lms_users.get(), user)
         self.assertEqual(instance.provisioning_failure_notification_emails, settings.PROD_APPSERVER_FAIL_EMAILS)
+        self.assertEqual(instance.additional_monitoring_emails, settings.PROD_APPSERVER_FAIL_EMAILS)
 
     def test_provision_instance_check_theme_deployed(self):
         """


### PR DESCRIPTION
Otherwise we only get paged on a provision failure; ping monitoring
previously would only email the settings.ADMINS emails.

**Test instructions**:

- register a new account, choose instance settings, and confirm your email
- view the settings of the new instance
- verify that additional_monitoring_emails has the PROD_APPSERVER_FAIL_EMAILS added
- verify that the corresponding newrelic alert policy for the new instance has ADMINS _and_ PROD_APPSERVER_FAIL_EMAILS set in the notification channels
- do something to take the instance offline (change the dns records, stop the lms service, etc.)
- verify that newrelic alerts open
- put the instance back online
- verify the newrelic alerts/incidents auto close after a few minutes.

**Reviewers**:

- [x] @giovannicimolin 
- [ ] @lgp171188 