### PR TITLE
[BB-3004] Increase code jail timeout to prevent failing on first run

### DIFF
--- a/instance/models/mixins/openedx_config.py
+++ b/instance/models/mixins/openedx_config.py
@@ -412,6 +412,10 @@ class OpenEdXConfigMixin(ConfigMixinBase):
                     "FUNCTION": "retirement_lms_retire",
                 },
             ],
+
+            "EDXAPP_CODE_JAIL_LIMITS": {
+                "REALTIME": 6
+            }
         }
 
         if self.smtp_relay_settings:


### PR DESCRIPTION
New Juniper instances, code jail seems to throw an error while running for the first time. It has been observed that increasing timeout helps. This PR increases code jail timeout from 3 sec to 6 sec.

**JIRA tickets**: https://tasks.opencraft.com/browse/BB-3004

~~**Discussions**:~~

**Dependencies**: None

~~**Screenshots**:~~

~~**Sandbox URL**:~~

**Merge deadline**: "None"

**Testing instructions**:

1. Provision a new juniper instance.
2. Visit - https://lms_ocim_link_here/courses/course-v1:edX+DemoX+Demo_Course/courseware/interactive_demonstrations/basic_questions/?activate_block_id=block-v1%3AedX%2BDemoX%2BDemo_Course%2Btype%40sequential%2Bblock%40basic_questions
3. Submit Chemical equation
4. It should not show any error log. It would just check if the given value is correct or incorrect.

**Author notes and concerns**:
N/A

**Reviewers**
- [ ] @0x29a 

~~**Settings**~~