### PR TITLE
[BB-2164] Erase Ocim trial user data after X months

### DIFF
--- a/instance/tasks.py
+++ b/instance/tasks.py
@@ -305,8 +305,7 @@ if settings.CLEANUP_OLD_BETATEST_USERS:
             days=settings.DELETE_OLD_BETATEST_USER_DAYS
         )
 
-        User = get_user_model()
-        queryset = User.objects.filter(
+        queryset = get_user_model().objects.filter(
             # has a beta test application
             betatestapplication__isnull=False,
 
@@ -331,14 +330,13 @@ if settings.CLEANUP_OLD_BETATEST_USERS:
             last_login__lte=inactive_cutoff
         )
 
-
         # mark user as inactive. Update ``Profile.modified`` to current time.
         users_to_inactive = queryset.filter(is_active=True)
-        logger.info('Marking {} users as inactive.'.format(users_to_inactive.count()))
+        logger.info('Marking %s users as inactive.', users_to_inactive.count())
         users_to_inactive.update(is_active=False)
         UserProfile.objects.filter(user__in=users_to_inactive).update(modified=timezone.now())
 
         # deletes inactive users that last modified ``DELETE_USER_DAYS`` ago.
         users_to_delete = queryset.filter(is_active=False, profile__modified__lte=delete_cutoff)
-        logger.info('Deleting {} users'.format(users_to_delete.count()))
+        logger.info('Deleting %s users.', users_to_delete.count())
         users_to_delete.delete()

--- a/instance/tasks.py
+++ b/instance/tasks.py
@@ -27,6 +27,7 @@ import logging
 from typing import Optional, List
 
 from django.conf import settings
+from django.contrib.auth import get_user_model
 from django.db import connection
 from django.utils import timezone
 from huey.api import crontab
@@ -37,6 +38,7 @@ from instance.models.openedx_appserver import OpenEdXAppServer
 from instance.models.openedx_deployment import OpenEdXDeployment
 from instance.models.openedx_instance import OpenEdXInstance
 from instance.utils import sufficient_time_passed
+from userprofile.models import UserProfile
 from pr_watch import github
 
 
@@ -268,3 +270,75 @@ def delete_old_logs():
     logger.info(query)
     with connection.cursor() as cursor:
         cursor.execute(query)
+
+
+if settings.CLEANUP_OLD_BETATEST_USERS:
+
+    @db_periodic_task(crontab(day='3', hour='0', minute='0'))
+    def cleanup_old_betatest_users():
+        """
+        Delete old betatest users.
+
+        Finds users that meet following conditions -
+            - Associated with a betatest application
+            - Not a staff or superuser
+            - Not a paid user
+            - Associated instance doesn't exists or already deleted
+            - Betatest application created at least ``INACTIVE_USER_DAYS`` days ago
+            - Last logged in at least ``INACTIVE_USER_DAYS`` days ago
+
+        If those users are still active, marks as inactive. Updated ``UserProfile.modified``
+        to track when marked as inactive.
+
+        If those users are inactive for at least ``DELETE_USER_DAYS`` days, deletes them.
+
+        So this actually deletes an active old user after ``INACTIVE_USER_DAYS + DELETE_USER_DAYS`` days.
+
+        This job runs Wednesday, every week.
+        """
+
+        inactive_cutoff = timezone.now() - timezone.timedelta(
+            days=settings.INACTIVE_OLD_BETATEST_USER_DAYS
+        )
+
+        delete_cutoff = timezone.now() - timezone.timedelta(
+            days=settings.DELETE_OLD_BETATEST_USER_DAYS
+        )
+
+        User = get_user_model()
+        queryset = User.objects.filter(
+            # has a beta test application
+            betatestapplication__isnull=False,
+
+            # are not staff or superuser
+            is_staff=False,
+            is_superuser=False,
+
+            # don't belong to any organization (ex. opencraft)
+            profile__organization=None,
+
+            # not paid user
+            profile__accept_paid_support=False,
+
+            # instances doesn't exists or already deleted
+            profile__instancereference__isnull=True,
+            openedxinstance__isnull=True,
+            openedxappserver__isnull=True,
+            betatestapplication__instance__isnull=True,
+
+            # at least specified days old
+            betatestapplication__created__lte=inactive_cutoff,
+            last_login__lte=inactive_cutoff
+        )
+
+
+        # mark user as inactive. Update ``Profile.modified`` to current time.
+        users_to_inactive = queryset.filter(is_active=True)
+        logger.info('Marking {} users as inactive.'.format(users_to_inactive.count()))
+        users_to_inactive.update(is_active=False)
+        UserProfile.objects.filter(user__in=users_to_inactive).update(modified=timezone.now())
+
+        # deletes inactive users that last modified ``DELETE_USER_DAYS`` ago.
+        users_to_delete = queryset.filter(is_active=False, profile__modified__lte=delete_cutoff)
+        logger.info('Deleting {} users'.format(users_to_delete.count()))
+        users_to_delete.delete()

--- a/opencraft/settings.py
+++ b/opencraft/settings.py
@@ -886,6 +886,14 @@ TRIAL_INSTANCES_REPORT_RECIPIENTS = env.json('TRIAL_INSTANCES_REPORT_RECIPIENTS'
 # Format is '<minute> <hour> <day> <month> <day_of_week>' like normal crontabs
 TRIAL_INSTANCES_REPORT_SCHEDULE = env('TRIAL_INSTANCES_REPORT_SCHEDULE', default='0 2 1 * *')
 
+# User inactive and delete ####################################################
+
+CLEANUP_OLD_BETATEST_USERS = env('CLEANUP_OLD_BETATEST_USERS', default=True)
+
+INACTIVE_OLD_BETATEST_USER_DAYS = env('INACTIVE_OLD_BETATEST_USER_DAYS', default=90)
+
+DELETE_OLD_BETATEST_USER_DAYS = env('DELETE_OLD_BETATEST_USER_DAYS', default=30)
+
 # Instances ###################################################################
 
 # User Console - React SPA


### PR DESCRIPTION
This PR introduces a new periodic task, that deletes old beta test users.

**JIRA tickets**: https://tasks.opencraft.com/browse/BB-2164

~~**Discussions**:~~

**Dependencies**: None

~~**Screenshots**:~~

~~**Sandbox URL**:~~

**Merge deadline**: "None"

**Testing instructions**:

1. Create couple of beta test instances
2. Set ``INACTIVE_OLD_BETATEST_USER_DAYS = 1``
3. Set ``DELETE_OLD_BETATEST_USER_DAYS = 1`` 
4. Manually change ``BetaTestApplication.created`` to an old date
5. Manually change corresponding user's ``last_login`` to an old date
6. Delete deployed instances, keep ``BetaTestApplication`` model instance
7. Run Huey 
8. Users should be inactive now.
9. Change ``UserProfile.modified`` to an old date
10. Run Huey
11. Users will be deleted, also all data with ``on_delete=CASCADE`` will be deleted.

**Author notes and concerns**:

1. Not sure if this is what we should do

**Reviewers**
- [ ] @0x29a 

~~**Settings**~~