### PR TITLE
[SE-3458] Fix the broken Ocim registration form

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -342,6 +342,7 @@ workflows:
             branches:
               only:
                 - master
+                - shimulch/se-3458
       # Deploy production
       - frontend-build:
           name: frontend-build-production

--- a/frontend/src/global/constants.ts
+++ b/frontend/src/global/constants.ts
@@ -37,11 +37,10 @@ export interface StringIndexedArray {
 export enum RegistrationSteps {
   FIRST_STEP = 0,
   DOMAIN = 0,
-  CUSTOM_DOMAIN = 1,
-  INSTANCE = 2,
-  ACCOUNT = 3,
-  CONGRATS = 4,
-  LAST_STEP = 4
+  INSTANCE = 1,
+  ACCOUNT = 2,
+  CONGRATS = 3,
+  LAST_STEP = 3
 }
 
 export const ROUTES = {


### PR DESCRIPTION
This PR fixes OCIM frontend broken issue introduced by https://github.com/open-craft/opencraft/pull/647

**JIRA tickets**: https://tasks.opencraft.com/browse/SE-3458

**Discussions**: 

**Dependencies**: None

**Screenshots**: N/A

**Sandbox URL**: TBD 

**Merge deadline**: "ASAP"

**Testing instructions**:

1. From the Domain input page, enter a valid unused subdomain
2. It should redirect to the next page after validating

**Author notes and concerns**: N/A

**Reviewers**
- [ ] (OpenCraft internal reviewer's GitHub username goes here)

~~**Settings**~~