### PR TITLE
SE-3222 Extend EDXAPP_SITE_CONFIGURATION with default values

### DIFF
--- a/instance/models/openedx_appserver.py
+++ b/instance/models/openedx_appserver.py
@@ -387,12 +387,18 @@ class OpenEdXAppServer(AppServer, OpenEdXAppConfiguration, AnsibleAppServerMixin
 
         default_site_values = default_site_configurations['EDXAPP_SITE_CONFIGURATION'][0]
         result = []
-        for site_settings in confvars.get('EDXAPP_SITE_CONFIGURATION', []):
+        existed_site_settings = confvars.get('EDXAPP_SITE_CONFIGURATION', [])
+        for site_settings in existed_site_settings:
             default_values_copy = copy.deepcopy(default_site_values)
             default_values_copy['values'].update(site_settings['values'])
 
             site_settings['values'] = default_values_copy['values']
             result.append(site_settings)
+
+        if not existed_site_settings:
+            default_values_copy = copy.deepcopy(default_site_values)
+            result.append({'values': default_values_copy['values']})
+
         confvars['EDXAPP_SITE_CONFIGURATION'] = result
         return confvars
 

--- a/instance/models/openedx_appserver.py
+++ b/instance/models/openedx_appserver.py
@@ -19,6 +19,7 @@
 """
 Instance app models - Open EdX AppServer models
 """
+import copy
 import os
 import yaml
 
@@ -250,7 +251,6 @@ class OpenEdXAppServer(AppServer, OpenEdXAppConfiguration, AnsibleAppServerMixin
         'configuration_database_settings',
         'configuration_storage_settings',
         'configuration_theme_settings',
-        'configuration_site_configuration_settings',
         'configuration_secret_keys',
         # The extra settings should stay at the end of this list to allow manual overrides of all settings.
         'configuration_extra_settings',
@@ -374,6 +374,29 @@ class OpenEdXAppServer(AppServer, OpenEdXAppConfiguration, AnsibleAppServerMixin
             playbooks.append(self.enable_bulk_emails_playbook())
         return playbooks + super().get_playbooks()
 
+    def merge_site_configuration_settings(self, confvars):
+        """
+        Merge default site_configuration_settings with extra configuration settings
+
+        configuration_settings - may override default values
+        """
+        default_site_configurations = yaml.load(
+            self.configuration_site_configuration_settings,
+            Loader=yaml.SafeLoader
+        )
+
+        default_site_values = default_site_configurations['EDXAPP_SITE_CONFIGURATION'][0]
+        result = []
+        for site_settings in confvars.get('EDXAPP_SITE_CONFIGURATION', []):
+            default_values_copy = copy.deepcopy(default_site_values)
+            default_values_copy['values'].update(site_settings['values'])
+
+            site_settings['values'] = default_values_copy['values']
+            result.append(site_settings)
+        confvars['EDXAPP_SITE_CONFIGURATION'] = result
+        return confvars
+
+
     def create_configuration_settings(self):
         """
         Generate the configuration settings.
@@ -386,6 +409,8 @@ class OpenEdXAppServer(AppServer, OpenEdXAppConfiguration, AnsibleAppServerMixin
             additional_vars = getattr(self, attr_name)
             additional_vars = yaml.load(additional_vars, Loader=yaml.SafeLoader) if additional_vars else {}
             confvars = ansible.dict_merge(confvars, additional_vars)
+
+        confvars = self.merge_site_configuration_settings(confvars)
         vars_str = yaml.dump(confvars, default_flow_style=False)
         self.logger.debug('Vars.yml:\n%s', vars_str)
         return vars_str

--- a/instance/tests/models/test_openedx_site_configuration_mixin.py
+++ b/instance/tests/models/test_openedx_site_configuration_mixin.py
@@ -140,10 +140,10 @@ class OpenEdXSiteConfigurationMixinsTestCase(TestCase):
                 {
                     'values': {
                         'override': True,
-                        'CONTACT_US_CUSTOM_LINK': '/random/place/'
-                    }
-                }
-            ]
+                        'CONTACT_US_CUSTOM_LINK': '/random/place/',
+                    },
+                },
+            ],
         }
         instance.configuration_extra_settings = yaml.dump(
             configuration_extra_settings,
@@ -165,8 +165,8 @@ class OpenEdXSiteConfigurationMixinsTestCase(TestCase):
                     'CONTACT_US_CUSTOM_LINK': '/random/place/',
                     'static_template_about_content': 'static_template_about_content',
                     'homepage_overlay_html': 'homepage_overlay_html',
-                }
-            }
+                },
+            },
         ]
 
         configuration_settings = yaml.load(app_server.configuration_settings, Loader=yaml.SafeLoader)
@@ -182,22 +182,22 @@ class OpenEdXSiteConfigurationMixinsTestCase(TestCase):
             "EDXAPP_SITE_CONFIGURATION": [
                 {
                     "values": {
-                        "SOME_SETTING": "some value"
-                    }
+                        "SOME_SETTING": "some value",
+                    },
                 },
                 {
                     "domain": "some-specific-site.com",
                     "values": {
-                        "SPECIFIC_SETTING": "specific value"
-                    }
+                        "SPECIFIC_SETTING": "specific value",
+                    },
                 },
                 {
                     "site_id": 3,
                     "values": {
-                        "CONTACT_US_CUSTOM_LINK": "/custom-contact"
-                    }
-                }
-            ]
+                        "CONTACT_US_CUSTOM_LINK": "/custom-contact",
+                    },
+                },
+            ],
         }, default_flow_style=False)
         instance.static_content_overrides = {
             'version': 0,
@@ -212,7 +212,7 @@ class OpenEdXSiteConfigurationMixinsTestCase(TestCase):
                     "CONTACT_US_CUSTOM_LINK": "/contact",
                     'static_template_about_content': 'TEST override!',
                     'homepage_overlay_html': 'Text override!',
-                }
+                },
             },
             {
                 "domain": "some-specific-site.com",
@@ -221,7 +221,7 @@ class OpenEdXSiteConfigurationMixinsTestCase(TestCase):
                     "CONTACT_US_CUSTOM_LINK": "/contact",
                     'static_template_about_content': 'TEST override!',
                     'homepage_overlay_html': 'Text override!',
-                }
+                },
             },
             {
                 "site_id": 3,
@@ -229,8 +229,8 @@ class OpenEdXSiteConfigurationMixinsTestCase(TestCase):
                     "CONTACT_US_CUSTOM_LINK": "/custom-contact",
                     'static_template_about_content': 'TEST override!',
                     'homepage_overlay_html': 'Text override!',
-                }
-            }
+                },
+            },
         ]
         configuration_settings = yaml.load(app_server.configuration_settings, Loader=yaml.SafeLoader)
         self.assertEqual(configuration_settings['EDXAPP_SITE_CONFIGURATION'], expected_variables)


### PR DESCRIPTION
This PR introduce new merge function for `EDXAPP_SITE_CONFIGURATION` settings. 

**Testing instructions**
This instruction is meant to be run locally:

1. Create a new OpenEDXInstance
2. Open OCIM django shell `make shell`
3. Get created instance: 
```python
>>> instance = OpenEdXInstance.objects.last()
```
4. Create new appserver (without spawning actual deployment, we are care only about app server final configuration)
```python
>>> instance._create_owned_appserver()
```
5. Open UI, check that `Combined ansible vars -> EDXAPP_SITE_CONFIGURATION` looks like this:
```yaml
EDXAPP_SITE_CONFIGURATION:
- values:
    CONTACT_US_CUSTOM_LINK: /contact
```
6. Open instance settings (django admin page `http://localhost:5000/admin/instance/openedxinstance/`)
7. Update `Configuration extra settings`:
```yaml
DEMO_CREATE_STAFF_USER: false
SANDBOX_ENABLE_CERTIFICATES: false
demo_test_users: []
EDXAPP_SITE_CONFIGURATION:
- values:
    CONTACT_US_CUSTOM_LINK: /override-contact-us-link
    TEST_VAR: /test
```
8. Repeat step **4**
9. Open UI, check that `Combined ansible vars -> EDXAPP_SITE_CONFIGURATION` looks like this:
```yaml
EDXAPP_SITE_CONFIGURATION:
- values:
    CONTACT_US_CUSTOM_LINK: /override-contact-us-link
    TEST_VAR: /test
```

**Possible edge scenarios to verify:**
- [ ] Appserver provisioned with default `EDXAPP_SITE_CONFIGURATION`
- [ ] Appserver provisioned with additional `Configuration extra settings`
- [ ] Appserver prodivioned with overridden default  for EDXAPP_SITE_CONFIGURATION (for example: CONTACT_US_CUSTOM_LINK)

**Author notes**
@nizarmah I am sorry for such large instruction, but this is the only way to verify it works. 
Feel free to ask any questions or clarify anything you need for this review. 

Thanks! 
