### PR TITLE
[SE-3470] Adjust periodic build failure email content

### DIFF
--- a/instance/models/mixins/utilities.py
+++ b/instance/models/mixins/utilities.py
@@ -22,6 +22,7 @@ Instance app model mixins - Utilities
 
 # Imports #####################################################################
 
+import ast
 import re
 import logging
 import sys
@@ -72,7 +73,7 @@ class SensitiveDataFilter:
 
     SENSITIVE_VALUE_PATTERNS: list = COMMON_PATTERNS + [
         # This will match is extremely broad, but the safest
-        re.compile(r".*\:.*"),
+        re.compile(r"^(?!/).*\w+\:[\w\#\=\_\-\*\!\+\$\@\&\%\^]+"),
     ]
 
     def __init__(self, data: DataType):
@@ -235,14 +236,25 @@ class EmailMixin:
 
 # Functions #####################################################################
 
-def get_ansible_failure_log_entry(entries) -> Tuple[str, Dict[str, Any]]:
+def _extract_message_from_ansible_log(match) -> Optional[dict]:
     """
-    Get the most relevant failure log entry related to Ansible run and the Ansible
-    task name.
+    Extract message match group from ansible log lines.
     """
-    task_name_pattern = re.compile(r"^TASK\s\[(?P<task>.*)\]")
-    relevant_log_pattern = re.compile(r"^(fatal|critical)\:.*\=\>\s+")
+    if match and match.group('message'):
+        try:
+            return json.loads(match.group('message'))
+        except json.decoder.JSONDecodeError:
+            # the message can be an explicitly printed dict which must be parsed
+            return ast.literal_eval(match.group('message'))
 
+    return None
+
+
+def _extract_most_relevant_log(entries, task_name_pattern, relevant_log_pattern) -> Tuple[str, Dict[str, Any]]:
+    """
+    Make sure we extract most relevant log from the logs to help communities by providing
+    meaningful build logs.
+    """
     task_name: str = ""
     log_entry: Dict[str, Any] = dict()
 
@@ -250,16 +262,64 @@ def get_ansible_failure_log_entry(entries) -> Tuple[str, Dict[str, Any]]:
         if log_entry and task_name:
             break
 
-        text = entry.text.split("|")[-1].strip()
+        text = entry.text.strip()
         task_name_match = task_name_pattern.match(text)
+        relevant_log_match = relevant_log_pattern.match(text)
 
         if task_name_match:
             task_name = task_name_match.group("task")
 
-        if relevant_log_pattern.match(text):
-            log_entry = json.loads(relevant_log_pattern.sub("", text).strip())
+        if relevant_log_match:
+            log_entry = _extract_message_from_ansible_log(relevant_log_match)
 
-    return (task_name, log_entry)
+    return task_name, log_entry
+
+
+def _extract_other_build_logs(entries, log_pattern) -> List[str]:
+    """
+    Make sure we extract other build logs from the provisioning logs, so we can attach more information
+    when we send a failure notification email.
+    """
+    other_ansible_logs: List[str] = list()
+
+    # To get the logs in order, we need to have a separate iteration, which
+    # cannot be combined with the previous one. Fortunately, under normal
+    # circumstances, the previous iteration will finish pretty fast.
+    for entry in entries:
+        text = entry.text.strip()
+        log_match = log_pattern.match(text)
+        extracted_message = _extract_message_from_ansible_log(log_match)
+
+        if not extracted_message:
+            continue
+
+        command = extracted_message.get('cmd')
+        message = extracted_message.get('msg')
+
+        if command:
+            other_ansible_logs.append(command)
+
+        if message:
+            other_ansible_logs.append(message)
+
+        other_ansible_logs.extend(extracted_message.get('stdout_lines', []))
+        other_ansible_logs.extend(extracted_message.get('stderr_lines', []))
+
+    return other_ansible_logs
+
+
+def get_ansible_failure_log_entry(entries) -> Tuple[str, Dict[str, Any], List[str]]:
+    """
+    Get the most relevant failure log entry related to Ansible run and the Ansible
+    task name.
+    """
+    task_name_pattern = re.compile(r".*\|\s+TASK\s\[(?P<task>.*)\].*")
+    relevant_log_pattern = re.compile(r".*\|\s+(\w+)\:.*\=\>\s+(\(item\=)?(?P<message>\{.*\})\)?")
+
+    task_name, log_entry = _extract_most_relevant_log(entries, task_name_pattern, relevant_log_pattern)
+    other_ansible_logs = _extract_other_build_logs(entries, relevant_log_pattern)
+
+    return task_name, log_entry, other_ansible_logs
 
 
 def send_periodic_deployment_success_email(recipients: List[str], instance_name: str) -> None:
@@ -330,13 +390,18 @@ def send_periodic_deployment_failure_email(recipients: List[str], instance) -> N
         latest_deployment_success_date = 'N/A'
 
     with SensitiveDataFilter(yaml.load(appserver.configuration_settings, Loader=yaml.FullLoader)) as filtered_data:
-        filtered_configuration_settings = pformat(filtered_data)
+        filtered_configuration = json.dumps(filtered_data)
 
     # Reverse the log entries to start looking for failure from the latest log entry
-    ansible_task_name, raw_ansible_log_entry = get_ansible_failure_log_entry(appserver.log_entries_queryset)
+    ansible_task_name, raw_ansible_log_entry, other_raw_logs = get_ansible_failure_log_entry(
+        appserver.log_entries_queryset
+    )
 
     with SensitiveDataFilter(raw_ansible_log_entry) as filtered_data:
         relevant_log_entry = pformat(filtered_data)
+
+    with SensitiveDataFilter(other_raw_logs) as filtered_data:
+        other_log_entries = pformat(filtered_data)
 
     logger.warning(
         "Sending notification e-mail to %s after instance %s didn't provision",
@@ -344,19 +409,18 @@ def send_periodic_deployment_failure_email(recipients: List[str], instance) -> N
         instance_name,
     )
 
-    send_mail(
+    email = EmailMultiAlternatives(
         'Deployment failed at instance: {}'.format(instance_name),
         'The periodic deployment of {edx_platform_release} failed. Please see the details below.\n\n'
+        'Ansible task name:\t{ansible_task_name}\n'
+        'Relevant log lines:\n{relevant_log_entry}\n\n'
         'AppServer ID:\t{appserver_id}\n'
         'Latest successful provision date: {latest_successful_provision_date}\n'
         'Configuration source repo:\t{configuration_source_repo_url}\n'
         'Configuration version:\t{configuration_version}\n'
         'OpenEdX platform source repo:\t{edx_platform_repository_url}\n'
         'OpenEdX platform release:\t{edx_platform_release}\n'
-        'OpenEdX platform commit:\t{edx_platform_commit}\n'
-        'Extra configuration settings:\n{extra_settings}\n'
-        'Ansible task name:\t{ansible_task_name}\n'
-        'Relevant log lines:\n{relevant_log_entry}'.format(
+        'OpenEdX platform commit:\t{edx_platform_commit}'.format(
             ansible_task_name=ansible_task_name,
             appserver_id=appserver.id,
             configuration_source_repo_url=appserver.configuration_source_repo_url,
@@ -364,14 +428,18 @@ def send_periodic_deployment_failure_email(recipients: List[str], instance) -> N
             edx_platform_commit=appserver.edx_platform_commit,
             edx_platform_release=appserver.openedx_release,
             edx_platform_repository_url=appserver.edx_platform_repository_url,
-            extra_settings=filtered_configuration_settings,
             latest_successful_provision_date=str(latest_deployment_success_date),
             relevant_log_entry=relevant_log_entry,
         ),
         settings.DEFAULT_FROM_EMAIL,
-        recipients,
-        fail_silently=False,
+        recipients
     )
+
+    # Attach logs and configuration settings as attachments to keep the email readable
+    email.attachments.append(("build_log.txt", other_log_entries, "text/plain"))
+    email.attachments.append(("configuration.json", filtered_configuration, "application/json"))
+
+    email.send()
 
 
 @receiver(appserver_spawned)

--- a/instance/tests/models/test_openedx_instance.py
+++ b/instance/tests/models/test_openedx_instance.py
@@ -21,9 +21,9 @@ OpenEdXInstance model - Tests
 """
 
 # Imports #####################################################################
+import json
 import re
 from datetime import datetime, timedelta
-from pprint import pformat
 from unittest.mock import patch, Mock, PropertyMock
 
 import ddt
@@ -597,31 +597,32 @@ class OpenEdXInstanceTestCase(TestCase):
 
         combined_settings = yaml.load(appserver.configuration_settings, Loader=yaml.FullLoader)
         with SensitiveDataFilter(combined_settings) as filtered_data:
-            filtered_configuration_settings = pformat(filtered_data)
+            filtered_configuration = json.dumps(filtered_data)
 
         self.assertEqual(len(django_mail.outbox), 1)
         self.assertEqual(outbox.subject, f'Deployment failed at instance: {str(instance)}')
         self.assertEqual(outbox.to, failure_emails)
+        self.assertEqual(len(outbox.attachments), 2)
+        self.assertEqual(outbox.attachments[0], ('build_log.txt', '[]', 'text/plain'))
+        self.assertEqual(outbox.attachments[1], ('configuration.json', filtered_configuration, 'application/json'))
         self.assertEqual(
             outbox.body,
             'The periodic deployment of {edx_platform_release} failed. Please see the details below.\n\n'
+            'Ansible task name:\t{ansible_task_name}\n'
+            'Relevant log lines:\n{relevant_log_entry}\n\n'
             'AppServer ID:\t{appserver_id}\n'
             'Latest successful provision date: N/A\n'
             'Configuration source repo:\t{configuration_source_repo_url}\n'
             'Configuration version:\t{configuration_version}\n'
             'OpenEdX platform source repo:\t{edx_platform_repository_url}\n'
             'OpenEdX platform release:\t{edx_platform_release}\n'
-            'OpenEdX platform commit:\t{edx_platform_commit}\n'
-            'Extra configuration settings:\n{extra_settings}\n'
-            'Ansible task name:\t{ansible_task_name}\n'
-            'Relevant log lines:\n{relevant_log_entry}'.format(
+            'OpenEdX platform commit:\t{edx_platform_commit}'.format(
                 appserver_id=appserver.id,
                 configuration_source_repo_url=appserver.configuration_source_repo_url,
                 configuration_version=appserver.configuration_version,
                 edx_platform_commit=appserver.edx_platform_commit,
                 edx_platform_release=appserver.openedx_release,
                 edx_platform_repository_url=appserver.edx_platform_repository_url,
-                extra_settings=filtered_configuration_settings,
                 # Since we cannot mock logging at that place, we cannot mimic ansible failure
                 ansible_task_name="",
                 relevant_log_entry=dict(),


### PR DESCRIPTION
Fix the most relevant log collection and attach all the Ansible produced logs to the email. Also, make sure that the configuration is sent as an attachment instead of a plain text within the email.

**Structure of the email**

```

Subject: Deployment failed at instance: {instance_name}

Body:
The periodic deployment of {edx_platform_release} failed. Please see the details below.
 
Ansible task name: {ansible_task_name}
Relevant log lines:
{relevant_log_entry}
 
AppServer ID:                     {appserver_id}
Latest successful provision date: {latest_successful_provision_date}
Configuration source repo:        {configuration_source_repo_url}
Configuration version:            {configuration_version}
OpenEdX platform source repo:     {edx_platform_repository_url}
OpenEdX platform release:         {edx_platform_release}
OpenEdX platform commit:          {edx_platform_commit}
 
Attachments:
- build_log.txt -> This contains all the Ansible build logs
- configuration.json -> This contains the configuration we created the appserver with
```

**Screenshots**: Always include screenshots if there is any change to the UI. Can be useful for people that are not reviewer but want to know what's going on.

**Sandbox URL**: N/A

**Testing instructions**:

1. Checkout this code on stage environment
2. Create an instance
3. Enable periodic builds on the instance
4. Add your email address to the Periodic build notification emails text field
5. Set 00:05:00 as build interval (5 minutes)
6. Misconfigure it to no be able to provision (for example change a database password or similar to have build logs and not fail immediately)
7. Wait for the email (check your spam folder as well) - It should arrive in 5-10 minutes based on the delay in the queue
8. Check the email has no sensitive data and has the desired (listed above) content.
9. Check the email has a `build_log.txt` attachment and it has content (with no secrets)
10. Check the email has a `configuration.json` attachment and it has content (with no secrets)
11. Fix the configuration
12. Wait for the ack email - It should arrive in 5-10 minutes based on the delay in the queue

**Author notes and concerns**:

1. Testing the flow could take from 5 minutes to 1 hour, depending on how fast the periodic task picked up by the workers.
2. Checking the whole build log is near impossible since it may have several thousand log records

**Reviewers**
- [ ] @Kelketek / @toxinu 