### PR TITLE
[SE-3477] dummy commit to run CI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,4 @@
+# testing CircleCI. Dummy PR
 version: 2.1
 
 orbs:


### PR DESCRIPTION
Please close PR.

The goal is to test that the integration test VMs connect to the integration consul cluster, whose encryption key I just changed  in another PR.