### PR TITLE
[SE-3585] Specifies ecommerce worker version to openedx release

### DIFF
--- a/instance/models/mixins/openedx_config.py
+++ b/instance/models/mixins/openedx_config.py
@@ -222,6 +222,7 @@ class OpenEdXConfigMixin(ConfigMixinBase):
             "ANALYTICS_API_VERSION": self.openedx_release,
             "INSIGHTS_VERSION": self.openedx_release,
             "ECOMMERCE_VERSION": self.openedx_release,
+            "ECOMMERCE_WORKER_VERSION": self.openedx_release,
 
             # Theme
             # Enable comprehensive theming


### PR DESCRIPTION
On October 23, 2020, edX dropped python 2.7 support for the `ecommerce-worker`, [cf commit](https://github.com/edx/ecommerce-worker/commit/20538c829cd3e2068f29e449496c0df3244640cf)

After further investigation, we noticed that the `ecommerce-worker` is tagged similarly to how other releases for other edX repositories are tagged (ie `open-release/juniper.3`)

Ocim sets a default `ECOMMERCE_VERISON`; however, it does not set a default `ECOMMERCE_WORKER_VERSION`. This PR adds `ECOMMERCE_WORKER_VERSION` to the default configuration.

**JIRA tickets**: SE-3585

**Discussions**: [EdX Ecommerce Worker Drops Support for Python 2.7](https://forum.opencraft.com/t/edx-ecommerce-worker-drops-support-for-python-2-7/704?u=nizar)

**Merge deadline**: ASAP

**Testing instructions**:

1. Attempt to provision an app server with ecommerce enabled. It should fail at the `ecomworker : install application requirements` task.
1. Add the `ECOMMERCE_WORKER_VERSION: "{{ ECOMMERCE_VERSION }}"`  to your instance's configuration.
1. Attempt to provision a new app server. The app server should provision successfully.

**Reviewers**
- [x] @mavidser 