### PR TITLE
ci: pin circleci nodejs executors

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -6,7 +6,7 @@ orbs:
 jobs:
   frontend-test:
     docker:
-      - image: circleci/node:lts
+      - image: circleci/node:12
     working_directory: ~/project/frontend
     steps:
       - checkout:
@@ -34,7 +34,7 @@ jobs:
 
   frontend-quality:
     docker:
-      - image: circleci/node:lts
+      - image: circleci/node:12
     working_directory: ~/project/frontend
     steps:
       - checkout:
@@ -62,7 +62,7 @@ jobs:
 
   frontend-build:
     docker:
-      - image: circleci/node:lts
+      - image: circleci/node:12
     working_directory: ~/project/frontend
     steps:
       - checkout:
@@ -82,6 +82,9 @@ jobs:
           paths:
             - node_modules
           key: frontend-deps-{{ .Branch }}-{{ checksum "package-lock.json" }}
+      - run:
+          name: Rebuild node-sass to generate bindings
+          command: npm rebuild node-sass
       - run:
           name: Render environment variables to .env file
           command: |


### PR DESCRIPTION
This PR pins the Circle CI NodeJS executor image for the builds. More information: https://app.circleci.com/pipelines/github/open-craft/opencraft/2458/workflows/16b471ff-14fb-423f-9827-456afdea68d8/jobs/22889

**JIRA tickets**: N/A

**Screenshots**: N/A

**Sandbox URL**: N/A

**Testing instructions**:

N/A

**Author notes and concerns**:

NA

**Reviewers**
- [ ] @Kelketek / @lgp171188 