### PR TITLE
[SE-3619] improve notification emails

### DIFF
--- a/instance/models/mixins/utilities.py
+++ b/instance/models/mixins/utilities.py
@@ -516,7 +516,7 @@ def send_acknowledgement_email_on_deployment_success(sender, **kwargs) -> None:
         # Since the app servers are in reverse order, the element at index 1 will be
         # the previous app server
         previous_appserver = instance.appserver_set.all()[1]
-    except IndexError:  # Not using the strict exception to not cause circular dependencies
+    except IndexError:
         previous_appserver = None
 
     if previous_appserver is None or previous_appserver.status.is_healthy_state:

--- a/instance/models/mixins/utilities.py
+++ b/instance/models/mixins/utilities.py
@@ -293,17 +293,7 @@ def _extract_other_build_logs(entries, log_pattern) -> List[str]:
         if not extracted_message:
             continue
 
-        command = extracted_message.get('cmd')
-        message = extracted_message.get('msg')
-
-        if command:
-            other_ansible_logs.append(command)
-
-        if message:
-            other_ansible_logs.append(message)
-
-        other_ansible_logs.extend(extracted_message.get('stdout_lines', []))
-        other_ansible_logs.extend(extracted_message.get('stderr_lines', []))
+        other_ansible_logs.append(extracted_message)
 
     return other_ansible_logs
 
@@ -401,7 +391,7 @@ def send_periodic_deployment_failure_email(recipients: List[str], instance) -> N
         relevant_log_entry = pformat(filtered_data)
 
     with SensitiveDataFilter(other_raw_logs) as filtered_data:
-        other_log_entries = pformat(filtered_data)
+        other_log_entries = json.dumps(filtered_data)
 
     logger.warning(
         "Sending notification e-mail to %s after instance %s didn't provision",
@@ -436,7 +426,7 @@ def send_periodic_deployment_failure_email(recipients: List[str], instance) -> N
     )
 
     # Attach logs and configuration settings as attachments to keep the email readable
-    email.attachments.append(("build_log.txt", other_log_entries, "text/plain"))
+    email.attachments.append(("build_log.json", other_log_entries, "application/json"))
     email.attachments.append(("configuration.json", filtered_configuration, "application/json"))
 
     email.send()

--- a/instance/models/mixins/utilities.py
+++ b/instance/models/mixins/utilities.py
@@ -33,7 +33,6 @@ from pprint import pformat
 
 import yaml
 from django.conf import settings
-from django.core.exceptions import ObjectDoesNotExist
 from django.core.mail.message import EmailMultiAlternatives
 from django.core.mail import send_mail
 from django.dispatch import receiver
@@ -514,8 +513,10 @@ def send_acknowledgement_email_on_deployment_success(sender, **kwargs) -> None:
         return
 
     try:
-        previous_appserver = appserver.get_previous_by_created()
-    except ObjectDoesNotExist:  # Not using the strict exception to not cause circular dependencies
+        # Since the app servers are in reverse order, the element at index 1 will be
+        # the previous app server
+        previous_appserver = instance.appserver_set.all()[1]
+    except IndexError:  # Not using the strict exception to not cause circular dependencies
         previous_appserver = None
 
     if previous_appserver is None or previous_appserver.status.is_healthy_state:

--- a/instance/tests/models/test_mixin_utilities.py
+++ b/instance/tests/models/test_mixin_utilities.py
@@ -343,6 +343,13 @@ class AnsibleLogExtractTestCase(TestCase):
         """
         self.appserver.logger.info('TASK [task name]')
         self.appserver.logger.info(
+            'failed: [1.2.3.4] (item={"state": "present", "password": "***", "name": "397bf39ead3d3751"}) => '
+            '{"ansible_loop_var": "item", "changed": false, "item": {"name": "397bf39ead3d3751", "password": "***",'
+            '"state": "present"}, "msg": "Failed to import the required Python library (passlib) on '
+            'edxapp-periodic-buil-appserver-1039\'s Python /usr/bin/python3. Please read module documentation and '
+            'install in the appropriate location"}',
+        )
+        self.appserver.logger.info(
             'fatal: [1.2.3.4]: FAILED! => {"changed": true, "stdout_lines": ["out"], "stderr_lines": ["err"]}'
         )
 
@@ -353,4 +360,21 @@ class AnsibleLogExtractTestCase(TestCase):
 
         self.assertEqual(task_name, "")
         self.assertDictEqual(log_entry, dict())
-        self.assertListEqual(other_logs, ["out", "err"])
+        self.assertListEqual(other_logs, [
+            {
+                'ansible_loop_var': 'item',
+                'changed': False,
+                'item': {'name': '397bf39ead3d3751', 'password': '***', 'state': 'present'},
+                'msg': (
+                    'Failed to import the required Python library (passlib) on '
+                    "edxapp-periodic-buil-appserver-1039's Python /usr/bin/python3. "
+                    'Please read module documentation and install in the appropriate '
+                    'location'
+                )
+            },
+            {
+                'changed': True,
+                'stderr_lines': ['err'],
+                'stdout_lines': ['out']
+            }
+        ])

--- a/instance/tests/models/test_openedx_instance.py
+++ b/instance/tests/models/test_openedx_instance.py
@@ -603,7 +603,7 @@ class OpenEdXInstanceTestCase(TestCase):
         self.assertEqual(outbox.subject, f'Deployment failed at instance: {str(instance)}')
         self.assertEqual(outbox.to, failure_emails)
         self.assertEqual(len(outbox.attachments), 2)
-        self.assertEqual(outbox.attachments[0], ('build_log.txt', '[]', 'text/plain'))
+        self.assertEqual(outbox.attachments[0], ('build_log.json', '[]', 'application/json'))
         self.assertEqual(outbox.attachments[1], ('configuration.json', filtered_configuration, 'application/json'))
         self.assertEqual(
             outbox.body,


### PR DESCRIPTION
This PR makes sure that we send more verbose logs to be able to provide more context.
Also, I found an additional issue with getting the previous app server, which is fixed by this PR too.

**Screenshots**: NA

**Sandbox URL**: N/A

**Testing instructions**:

1. Checkout this code on stage environment
2. Create an instance
3. Enable periodic builds on the instance
4. Add your email address to the Periodic build notification emails text field
5. Set 00:05:00 as build interval (5 minutes)
6. Misconfigure it to no be able to provision (for example change a database password or similar to have build logs and not fail immediately)
7. Wait for the email (check your spam folder as well) - It should arrive in 5-10 minutes based on the delay in the queue
8. Check the email has no sensitive data and has the desired (listed above) content.
9. Check the email has a `build_log.json` attachment and it has content (with no secrets)
10. Check the email has a `configuration.json` attachment and it has content (with no secrets)
11. Fix the configuration
12. Wait for the ack email - It should arrive in 5-10 minutes based on the delay in the queue

**Author notes and concerns**:

1. I'll need to look for other improvements as well by checking the previously sent emails.

**Reviewers**
- [ ] @mavidser 