### PR TITLE
Prevent new deployments until first P&T instance is provisioned

### DIFF
--- a/instance/models/openedx_deployment.py
+++ b/instance/models/openedx_deployment.py
@@ -67,6 +67,7 @@ class OpenEdXDeployment(Deployment):
     # Field which denotes if the deployment was cancelled by the user
     cancelled = models.BooleanField(default=False)
 
+     # pylint: disable=too-many-return-statements
     def status(self):
         """
         Current state of deployment.
@@ -122,6 +123,10 @@ class OpenEdXDeployment(Deployment):
         # There are some provisioning servers, so overall we are provisioning even if
         # there are some unhealthy servers.
         if appservers_provisioning > 0:
+            if not self.instance.deployment_set.exclude(id=self.id).exists():
+                # This is the VERY first time we've ever been set up, which is special and should not be treated as
+                # a simple provision.
+                return DeploymentState.preparing
             return DeploymentState.provisioning
 
         # At this point no AppSevers are provisioning, and there aren't enough healthy servers.


### PR DESCRIPTION
This fixes a bug where deployments where the first deployments allowed to be cancelled. This PR also adds a is_successfully_deployed flag which is used to prevent user deployments if the first deployment never succeeded.

**JIRA tickets**: [SE-3517](https://tasks.opencraft.com/browse/SE-3517)

**Testing instructions**:

1. Register as a new P&T user on OCIM
2. Verify the email to start provisioning
3. Verify that you are not allowed to make new changes while the instance is being provisioned (neither before the appserver was created, nor after the appserver was created as there's a few mins of gap between the two depending on the queue size).
4. Terminate the first appserver being created - and make sure that the UI still doesn't allow the user to deploy changes (we wat a staff member to fix the first instance first).

**Reviewers**
- [ ] @mtyaka 