### PR TITLE
SE-3629 Store MKTG_URL_LINK_MAP in EDXAPP_MKTG_URL_LINK_MAP

### DIFF
--- a/instance/models/mixins/openedx_config.py
+++ b/instance/models/mixins/openedx_config.py
@@ -84,7 +84,7 @@ class OpenEdXConfigMixin(ConfigMixinBase):
                     "CONTACT": "/contact",
                 },
             },
-            "EDXAPP_MKTG_URL_LINK_MAP":{
+            "EDXAPP_MKTG_URL_LINK_MAP": {
                 "FAQ": "help",
                 "PRESS": "press",
                 "SITEMAP.XML": "sitemap_xml",

--- a/instance/models/mixins/openedx_config.py
+++ b/instance/models/mixins/openedx_config.py
@@ -83,19 +83,17 @@ class OpenEdXConfigMixin(ConfigMixinBase):
                     # use different contact page
                     "CONTACT": "/contact",
                 },
-                # default values
-                "MKTG_URL_LINK_MAP": {
-                    "FAQ": "help",
-                    "PRESS": "press",
-                    "SITEMAP.XML": "sitemap_xml",
-                    "COURSES": "courses",
-                    "ROOT": "root",
-                    "WHAT_IS_VERIFIED_CERT": "verified-certificate",
-                    # "BLOG": "blog",  not supported yet
-                    **self.instance.get_mktg_url_link(),
-                },
             },
-
+            "EDXAPP_MKTG_URL_LINK_MAP":{
+                "FAQ": "help",
+                "PRESS": "press",
+                "SITEMAP.XML": "sitemap_xml",
+                "COURSES": "courses",
+                "ROOT": "root",
+                "WHAT_IS_VERIFIED_CERT": "verified-certificate",
+                # "BLOG": "blog",  not supported yet
+                **self.instance.get_mktg_url_link(),
+            },
             "EDXAPP_LMS_NGINX_PORT": 80,
             "EDXAPP_LMS_SSL_NGINX_PORT": 443,
             "EDXAPP_LMS_BASE_SCHEME": 'https',

--- a/registration/tests/test_api.py
+++ b/registration/tests/test_api.py
@@ -20,7 +20,6 @@
 Tests for the registration API
 """
 import json
-import yaml
 from typing import Optional, Union
 from unittest.mock import patch
 

--- a/registration/tests/test_api.py
+++ b/registration/tests/test_api.py
@@ -1162,10 +1162,10 @@ class OpenEdXInstanceConfigAPITestCase(APITestCase):
         custom_pages = ['ABOUT', 'CONTACT', 'DONATE', 'TOS', 'HONOR', 'PRIVACY']
 
         for page in custom_pages + base_custom_pages:
-            self.assertTrue(page in configuration_settings['EDXAPP_LMS_ENV_EXTRA']['MKTG_URL_LINK_MAP'])
+            self.assertTrue(page in configuration_settings['EDXAPP_MKTG_URL_LINK_MAP'])
 
         # Test that BLOG static page is disabled
-        self.assertTrue('BLOG' not in configuration_settings['EDXAPP_LMS_ENV_EXTRA']['MKTG_URL_LINK_MAP'])
+        self.assertTrue('BLOG' not in configuration_settings['EDXAPP_MKTG_URL_LINK_MAP'])
 
     def test_instance_appserver_configuration_reflect_on_disabled_pages(self):
         """
@@ -1190,12 +1190,12 @@ class OpenEdXInstanceConfigAPITestCase(APITestCase):
         configuration_settings = yaml.load(appserver.configuration_settings, Loader=yaml.SafeLoader)
 
         # This page was disabled
-        self.assertTrue('ABOUT' not in configuration_settings['EDXAPP_LMS_ENV_EXTRA']['MKTG_URL_LINK_MAP'])
+        self.assertTrue('ABOUT' not in configuration_settings['EDXAPP_MKTG_URL_LINK_MAP'])
 
         base_custom_pages = ['FAQ', 'PRESS', 'SITEMAP.XML', 'COURSES', 'ROOT', 'WHAT_IS_VERIFIED_CERT']
         custom_pages = ['CONTACT', 'DONATE', 'TOS', 'HONOR', 'PRIVACY']
         for page in custom_pages + base_custom_pages:
-            self.assertTrue(page in configuration_settings['EDXAPP_LMS_ENV_EXTRA']['MKTG_URL_LINK_MAP'])
+            self.assertTrue(page in configuration_settings['EDXAPP_MKTG_URL_LINK_MAP'])
 
     def test_check_config_urls(self):
         """


### PR DESCRIPTION
This merge request is about resolving an issue with MKTG_URL_LINK_MAP override.


**Testing instructions**  
- Create a new instance
- Create new appserver
- Verify that key `EDXAPP_MKTG_URL_LINK_MAP` in `Combined ansible vars:` exists
- This key should contain all default pages
- Set yaml to the `configuration_extra_settings`
```yaml
EDXAPP_MKTG_URL_LINK_MAP:
  HONOR: !!null
  BLOG: !!null
  DONATE: !!null
```
- Create new appserver
- Check that key `EDXAPP_MKTG_URL_LINK_MAP` in `Combined ansible vars:` was updated in regards to `configuration_extra_settings`

**Author's notes and concerns**  
- These changes will work for already existed instances

**Reviewers**  
- [ ] @nizarmah 
