### PR TITLE
Update Celery configuration to keep using RabbitMQ as the backend

### DIFF
--- a/instance/models/mixins/openedx_config.py
+++ b/instance/models/mixins/openedx_config.py
@@ -317,6 +317,8 @@ class OpenEdXConfigMixin(ConfigMixinBase):
 
             # RabbitMQ disabled locally
             "SANDBOX_ENABLE_RABBITMQ": False,
+            # Redis disabled locally
+            "SANDBOX_ENABLE_REDIS": False,
 
             # Ecommerce
             "SANDBOX_ENABLE_ECOMMERCE": False,  # set to true to enable ecommerce

--- a/instance/models/mixins/openedx_database.py
+++ b/instance/models/mixins/openedx_database.py
@@ -438,6 +438,11 @@ class OpenEdXDatabaseMixin(MySQLInstanceMixin, MongoDBInstanceMixin, RabbitMQIns
         """
         Return dictionary of RabbitMQ Settings
         """
+        rabbit_hostname = "{}:{}".format(
+            self.rabbitmq_server.instance_host,
+            self.rabbitmq_server.instance_port
+        )
+
         return {
             "XQUEUE_RABBITMQ_USER": self.rabbitmq_provider_user.username,
             "XQUEUE_RABBITMQ_PASS": self.rabbitmq_provider_user.password,
@@ -454,13 +459,12 @@ class OpenEdXDatabaseMixin(MySQLInstanceMixin, MongoDBInstanceMixin, RabbitMQIns
                 },
             },
 
+            "EDXAPP_RABBIT_HOSTNAME": rabbit_hostname,
             "EDXAPP_CELERY_USER": self.rabbitmq_provider_user.username,
+            "EDXAPP_CELERY_BROKER_TRANSPORT": "amqp",
+            "EDXAPP_CELERY_BROKER_HOSTNAME": rabbit_hostname,
             "EDXAPP_CELERY_PASSWORD": self.rabbitmq_provider_user.password,
             "EDXAPP_CELERY_BROKER_VHOST": self.rabbitmq_vhost,
-            "EDXAPP_RABBIT_HOSTNAME": "{}:{}".format(
-                self.rabbitmq_server.instance_host,
-                self.rabbitmq_server.instance_port
-            ),
             "EDXAPP_CELERY_BROKER_USE_SSL": True
         }
 

--- a/instance/tests/models/test_openedx_database_mixins.py
+++ b/instance/tests/models/test_openedx_database_mixins.py
@@ -804,6 +804,31 @@ class RabbitMQInstanceTestCase(TestCase):
         self.instance.deprovision_rabbitmq(ignore_errors=True)
         self.assertFalse(self.instance.rabbitmq_provisioned)
 
+    def test_ansible_settings_rabbitmq(self, mock_consul):
+        """
+        Test that rabbitmq related ansible variables are set correctly.
+        """
+        instance = OpenEdXInstanceFactory()
+        appserver = make_test_appserver(instance)
+        ansible_vars = appserver.configuration_settings
+        rabbit_hostname = '{}:{}'.format(
+            instance.rabbitmq_server.instance_host,
+            instance.rabbitmq_server.instance_port,
+        )
+        self.assertIn('EDXAPP_RABBIT_HOSTNAME: {}'.format(rabbit_hostname), ansible_vars)
+        self.assertIn('EDXAPP_CELERY_USER: {}'.format(instance.rabbitmq_provider_user.username), ansible_vars)
+        self.assertIn('EDXAPP_CELERY_BROKER_TRANSPORT: amqp', ansible_vars)
+        self.assertIn('EDXAPP_CELERY_BROKER_HOSTNAME: {}'.format(rabbit_hostname), ansible_vars)
+        self.assertIn('EDXAPP_CELERY_PASSWORD: {}'.format(instance.rabbitmq_provider_user.password), ansible_vars)
+        self.assertIn('EDXAPP_CELERY_BROKER_VHOST: {}'.format(instance.rabbitmq_vhost), ansible_vars)
+        self.assertIn('EDXAPP_CELERY_BROKER_USE_SSL: true', ansible_vars)
+        self.assertIn('XQUEUE_RABBITMQ_USER: {}'.format(instance.rabbitmq_provider_user.username), ansible_vars)
+        self.assertIn('XQUEUE_RABBITMQ_PASS: {}'.format(instance.rabbitmq_provider_user.password), ansible_vars)
+        self.assertIn('XQUEUE_RABBITMQ_VHOST: {}'.format(instance.rabbitmq_vhost), ansible_vars)
+        self.assertIn('XQUEUE_RABBITMQ_HOSTNAME: {}'.format(instance.rabbitmq_server.instance_host), ansible_vars)
+        self.assertIn('XQUEUE_RABBITMQ_PORT: {}'.format(instance.rabbitmq_server.instance_port), ansible_vars)
+        self.assertIn('XQUEUE_RABBITMQ_TLS: true', ansible_vars)
+
 
 @patch(
     'instance.tests.models.factories.openedx_instance.OpenEdXInstance._write_metadata_to_consul',

--- a/instance/tests/models/test_openedx_instance.py
+++ b/instance/tests/models/test_openedx_instance.py
@@ -297,6 +297,7 @@ class OpenEdXInstanceTestCase(TestCase):
         appserver = instance.appserver_set.get(pk=appserver_id)
         configuration_vars = yaml.load(appserver.configuration_settings, Loader=yaml.SafeLoader)
         self.assertIs(configuration_vars['SANDBOX_ENABLE_RABBITMQ'], False)
+        self.assertIs(configuration_vars['SANDBOX_ENABLE_REDIS'], False)
         self.assertIs(configuration_vars['SANDBOX_ENABLE_DISCOVERY'], False)
         self.assertIs(configuration_vars['SANDBOX_ENABLE_ECOMMERCE'], False)
         self.assertIs(configuration_vars['SANDBOX_ENABLE_ANALYTICS_API'], False)


### PR DESCRIPTION
This updates instance settings so that instances continue to work correctly using RabbitMQ as the Celery backend. This change is required since https://github.com/edx/configuration/pull/6147 switched to local Redis for native install.

We will switch to Redis in Ocim when we implement support for a Redis backend with ACLs, but for now this makes it possible to keep using RabbitMQ.

**Test instructions**:

I spawned two servers on Ocim stage:
- Juniper: https://stage.manage.opencraft.com/instance/6540/
- master: https://stage.manage.opencraft.com/instance/6530/

Check the instances to make sure they work correctly and the configuration looks good. You can use the default `staff@example.com` account.

Note: Celery tasks don't seem to be working on the master sandbox, but I think that's related to the problems on edx-platform master where tasks don't get registered properly (see https://github.com/edx/edx-platform/pull/25479#issuecomment-736073800).

**Reviewers**:

- [x] @0x29a 