### PR TITLE
Update cryptography dependency

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -9,7 +9,7 @@ channels_redis==2.4.0
 CherryPy<18.2
 colour==0.1.5
 cookies<2.3
-cryptography>=3.2
+cryptography==3.2.1
 dictdiffer<0.9
 Django<2.3,>=2.2
 # using the latest django-angular (2.2 or later) requires a heavy rewrite of the registration form, so we use the old 1.0.0 version patched to work under Django 2

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -9,6 +9,7 @@ channels_redis==2.4.0
 CherryPy<18.2
 colour==0.1.5
 cookies<2.3
+cryptography>=3.2
 dictdiffer<0.9
 Django<2.3,>=2.2
 # using the latest django-angular (2.2 or later) requires a heavy rewrite of the registration form, so we use the old 1.0.0 version patched to work under Django 2

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -32,7 +32,7 @@ constantly==15.1.0        # via twisted
 cookies==2.2.1            # via -r requirements/base.in
 coreapi==2.3.3            # via drf-yasg
 coreschema==0.0.4         # via coreapi, drf-yasg
-cryptography==2.9.2       # via autobahn, dns-lexicon, openstacksdk, pyopenssl, requests, service-identity
+cryptography==3.2.1       # via -r requirements/base.in, autobahn, dns-lexicon, openstacksdk, pyopenssl, requests, service-identity
 cssutils==1.0.2           # via pynliner
 daphne==2.5.0             # via channels
 debtcollector==2.0.1      # via oslo.config, oslo.serialization, oslo.utils, python-keystoneclient

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -1,6 +1,6 @@
 -r test.in
 
-cryptography>=3.2
+cryptography==3.2.1
 django-debug-toolbar==2.2
 ipdb==0.12
 ipython==7.5.0

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -1,5 +1,6 @@
 -r test.in
 
+cryptography>=3.2
 django-debug-toolbar==2.2
 ipdb==0.12
 ipython==7.5.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -7,7 +7,6 @@
 -e git+https://github.com/open-craft/django-angular.git@v1-with-django2-support#egg=django_angular  # via -r requirements/base.in
 aioredis==1.3.1           # via channels-redis
 appdirs==1.4.4            # via openstacksdk, virtualenv
-appnope==0.1.0            # via ipython
 asgiref==3.2.7            # via channels, channels-redis, daphne
 astroid==2.1.0            # via pylint, pylint-celery, requirements-detector
 async-timeout==3.0.1      # via aioredis
@@ -36,7 +35,7 @@ cookies==2.2.1            # via -r requirements/base.in
 coreapi==2.3.3            # via drf-yasg
 coreschema==0.0.4         # via coreapi, drf-yasg
 coverage==4.5.4           # via -r requirements/test.in
-cryptography==2.9.2       # via autobahn, dns-lexicon, openstacksdk, pyopenssl, requests, service-identity
+cryptography==3.2.1       # via -r requirements/base.in, -r requirements/dev.in, -r requirements/test.in, autobahn, dns-lexicon, openstacksdk, pyopenssl, requests, service-identity
 cssutils==1.0.2           # via pynliner
 daphne==2.5.0             # via channels
 ddt==1.4.1                # via -r requirements/test.in
@@ -84,7 +83,8 @@ honcho==1.0.1             # via -r requirements/base.in
 huey==2.1.0               # via -r requirements/base.in
 hyperlink==19.0.0         # via twisted
 idna==2.9                 # via requests, tldextract, twisted
-importlib-metadata==1.6.0  # via jsonschema, virtualenv
+importlib-metadata==1.6.0  # via importlib-resources, jsonschema, virtualenv
+importlib-resources==1.5.0  # via virtualenv
 incremental==17.5.0       # via twisted
 inflection==0.4.0         # via drf-yasg
 ipdb==0.12                # via -r requirements/dev.in
@@ -194,10 +194,11 @@ stevedore==1.32.0         # via cliff, keystoneauth1, osc-lib, oslo.config, pyth
 tempora==3.0.0            # via portend
 testfixtures==6.10.3      # via -r requirements/test.in
 text-unidecode==1.3       # via faker
-tldextract==2.2.2         # via dns-lexicon
+tldextract==2.2.3         # via -r requirements/base.in, dns-lexicon
 traitlets==4.3.3          # via ipython
 twisted[tls]==20.3.0      # via daphne
 txaio==20.4.1             # via autobahn
+typed-ast==1.4.1          # via astroid
 uritemplate==3.0.1        # via coreapi, drf-yasg
 urllib3==1.25.3           # via -r requirements/base.in, botocore, requests
 virtualenv==20.0.20       # via -r requirements/base.in
@@ -206,7 +207,7 @@ wcwidth==0.1.9            # via cmd2, prompt-toolkit
 werkzeug==0.15.4          # via -r requirements/base.in
 wrapt==1.12.1             # via astroid, debtcollector, python-glanceclient
 zc.lockfile==2.0          # via cherrypy
-zipp==3.1.0               # via importlib-metadata
+zipp==3.1.0               # via importlib-metadata, importlib-resources
 zope.interface==5.1.0     # via twisted
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -1,6 +1,7 @@
 -r base.in
 
 coverage<4.6
+cryptography>=3.2
 ddt
 factory-boy<2.13
 Faker

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -1,7 +1,7 @@
 -r base.in
 
 coverage<4.6
-cryptography>=3.2
+cryptography==3.2.1
 ddt
 factory-boy<2.13
 Faker

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -34,7 +34,7 @@ cookies==2.2.1            # via -r requirements/base.in
 coreapi==2.3.3            # via drf-yasg
 coreschema==0.0.4         # via coreapi, drf-yasg
 coverage==4.5.4           # via -r requirements/test.in
-cryptography==2.9.2       # via autobahn, dns-lexicon, openstacksdk, pyopenssl, requests, service-identity
+cryptography==3.2.1       # via -r requirements/base.in, -r requirements/test.in, autobahn, dns-lexicon, openstacksdk, pyopenssl, requests, service-identity
 cssutils==1.0.2           # via pynliner
 daphne==2.5.0             # via channels
 ddt==1.4.1                # via -r requirements/test.in
@@ -81,7 +81,8 @@ honcho==1.0.1             # via -r requirements/base.in
 huey==2.1.0               # via -r requirements/base.in
 hyperlink==19.0.0         # via twisted
 idna==2.9                 # via requests, tldextract, twisted
-importlib-metadata==1.6.0  # via jsonschema, virtualenv
+importlib-metadata==1.6.0  # via importlib-resources, jsonschema, virtualenv
+importlib-resources==1.5.0  # via virtualenv
 incremental==17.5.0       # via twisted
 inflection==0.4.0         # via drf-yasg
 iso8601==0.1.12           # via keystoneauth1, openstacksdk, oslo.utils, python-novaclient
@@ -181,9 +182,10 @@ stevedore==1.32.0         # via cliff, keystoneauth1, osc-lib, oslo.config, pyth
 tempora==3.0.0            # via portend
 testfixtures==6.10.3      # via -r requirements/test.in
 text-unidecode==1.3       # via faker
-tldextract==2.2.2         # via dns-lexicon
+tldextract==2.2.3         # via -r requirements/base.in, dns-lexicon
 twisted[tls]==20.3.0      # via daphne
 txaio==20.4.1             # via autobahn
+typed-ast==1.4.1          # via astroid
 uritemplate==3.0.1        # via coreapi, drf-yasg
 urllib3==1.25.3           # via -r requirements/base.in, botocore, requests
 virtualenv==20.0.20       # via -r requirements/base.in
@@ -192,7 +194,7 @@ wcwidth==0.1.9            # via cmd2
 werkzeug==0.15.4          # via -r requirements/base.in
 wrapt==1.12.1             # via astroid, debtcollector, python-glanceclient
 zc.lockfile==2.0          # via cherrypy
-zipp==3.1.0               # via importlib-metadata
+zipp==3.1.0               # via importlib-metadata, importlib-resources
 zope.interface==5.1.0     # via twisted
 
 # The following packages are considered to be unsafe in a requirements file:


### PR DESCRIPTION
Address security flaw by updating cryptography dependency in base.in, dev.in, and test.in then running pip-compile.
 
- [x] I tested this: Tested working locally
- [x] I read through the code
~~I checked for accessibility issues~~
~~Includes documentation~~