### PR TITLE
[FAL-23] Enable ORGANIZATIONS_APP feature flag by default.

### DIFF
--- a/instance/models/mixins/openedx_config.py
+++ b/instance/models/mixins/openedx_config.py
@@ -254,6 +254,7 @@ class OpenEdXConfigMixin(ConfigMixinBase):
                 "ENABLE_THIRD_PARTY_AUTH": True,
                 "ENABLE_XBLOCK_VIEW_ENDPOINT": True,
                 "ENABLE_SYSADMIN_DASHBOARD": True,
+                "ORGANIZATIONS_APP": True,
                 "PREVIEW_LMS_BASE": self.instance.lms_preview_domain,
                 "REQUIRE_COURSE_EMAIL_AUTH": False,
                 "USE_MICROSITES": False,


### PR DESCRIPTION
It is required to be able to set up custom certificate templates.

**Test instructions**:

1. Spawn a new appserver.
2. Verify that the `ORGANIZATIONS_APP` flag is enabled in `EDXAPP_FEATURES`.

You can check [the appserver](https://stage.manage.opencraft.com/instance/6700/edx-appserver/3005/) I created on stage after deploying this update.