### PR TITLE
BB-3501 Add permissions to rabbitmq vhost for admin

### DIFF
--- a/instance/models/mixins/rabbitmq.py
+++ b/instance/models/mixins/rabbitmq.py
@@ -182,11 +182,12 @@ class RabbitMQInstanceMixin(models.Model):
                     'write': '.*',
                     'read': '.*'
                 })
-            self._rabbitmq_request('put', 'permissions', self.rabbitmq_vhost, self.rabbitmq_server.admin_username, data={
-                'configure': '.*',
-                'write': '.*',
-                'read': '.*'
-            })
+            self._rabbitmq_request(
+                'put', 'permissions', self.rabbitmq_vhost, self.rabbitmq_server.admin_username, data={
+                    'configure': '.*',
+                    'write': '.*',
+                    'read': '.*'
+                })
         self.rabbitmq_provisioned = True
         self.save()
 

--- a/instance/models/mixins/rabbitmq.py
+++ b/instance/models/mixins/rabbitmq.py
@@ -182,6 +182,11 @@ class RabbitMQInstanceMixin(models.Model):
                     'write': '.*',
                     'read': '.*'
                 })
+            self._rabbitmq_request('put', 'permissions', self.rabbitmq_vhost, self.rabbitmq_server.admin_username, data={
+                'configure': '.*',
+                'write': '.*',
+                'read': '.*'
+            })
         self.rabbitmq_provisioned = True
         self.save()
 

--- a/instance/tests/models/test_openedx_database_mixins.py
+++ b/instance/tests/models/test_openedx_database_mixins.py
@@ -720,7 +720,7 @@ class RabbitMQInstanceTestCase(TestCase):
         vhosts_calls = ['vhosts/{}'.format(rabbitmq_vhost)]
         users_calls = ['users/{}'.format(user) for user in rabbitmq_users]
         permissions_calls = ['permissions/{}/{}'.format(rabbitmq_vhost, user) for user in rabbitmq_users]
-        permisisons_calls += ['permissions/{}/{}'.format(rabbitmq_vhost, 'admin')]
+        permissions_calls += ['permissions/{}/{}'.format(rabbitmq_vhost, 'admin')]
 
         provision_calls = [
             '{}/api/{}'.format(self.instance.rabbitmq_server.api_url, url)

--- a/instance/tests/models/test_openedx_database_mixins.py
+++ b/instance/tests/models/test_openedx_database_mixins.py
@@ -714,12 +714,13 @@ class RabbitMQInstanceTestCase(TestCase):
         So, this test should pass if and only if all of the specifically mocked URLs are
         called during both provision and deprovision.
         """
-        rabbitmq_users = [self.instance.rabbitmq_provider_user, self.instance.rabbitmq_consumer_user, 'admin']
+        rabbitmq_users = [self.instance.rabbitmq_provider_user, self.instance.rabbitmq_consumer_user]
         rabbitmq_vhost = urllib.parse.quote(self.instance.rabbitmq_vhost, safe='')
 
         vhosts_calls = ['vhosts/{}'.format(rabbitmq_vhost)]
         users_calls = ['users/{}'.format(user) for user in rabbitmq_users]
         permissions_calls = ['permissions/{}/{}'.format(rabbitmq_vhost, user) for user in rabbitmq_users]
+        permisisons_calls += ['permissions/{}/{}'.format(rabbitmq_vhost, 'admin')]
 
         provision_calls = [
             '{}/api/{}'.format(self.instance.rabbitmq_server.api_url, url)

--- a/instance/tests/models/test_openedx_database_mixins.py
+++ b/instance/tests/models/test_openedx_database_mixins.py
@@ -714,7 +714,7 @@ class RabbitMQInstanceTestCase(TestCase):
         So, this test should pass if and only if all of the specifically mocked URLs are
         called during both provision and deprovision.
         """
-        rabbitmq_users = [self.instance.rabbitmq_provider_user, self.instance.rabbitmq_consumer_user]
+        rabbitmq_users = [self.instance.rabbitmq_provider_user, self.instance.rabbitmq_consumer_user, 'admin']
         rabbitmq_vhost = urllib.parse.quote(self.instance.rabbitmq_vhost, safe='')
 
         vhosts_calls = ['vhosts/{}'.format(rabbitmq_vhost)]


### PR DESCRIPTION
This PR changes the RabbitMQ provisioning for instances by adding all permissions to 'admin' on every vhost created.

**JIRA tickets**: BB-3501

**Testing instructions**:

1. Check out this branch in OCIM Stage.
2. Spin a new instance and start provisioning a new AppServer.
3. Go to the Stage RabbitMQ management console (or SSH) and check the 'admin' user has permissions to access the vhost created for that instance.
