### PR TITLE
Add .readthedocs.yml for configuring Read the docs build

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,8 @@
+version: 2
+formats: all
+python:
+  version: 3.6
+  install:
+    - requirements: documentation/requirements.txt
+mkdocs:
+  configuration: mkdocs.yml

--- a/documentation/requirements.in
+++ b/documentation/requirements.in
@@ -1,2 +1,2 @@
-mkdocs==1.0.4
-pygments==2.4.2
+mkdocs==1.1.2
+pygments==2.7.3

--- a/documentation/requirements.txt
+++ b/documentation/requirements.txt
@@ -4,16 +4,47 @@
 #
 #    pip-compile
 #
-click==7.0                # via mkdocs
-jinja2==2.10.1            # via mkdocs
-livereload==2.6.1         # via mkdocs
-markdown==3.1.1           # via mkdocs
-markupsafe==1.1.1         # via jinja2
-mkdocs==1.0.4
-pygments==2.4.2
-pyyaml==5.1.2             # via mkdocs
-six==1.12.0               # via livereload
-tornado==6.0.3            # via livereload, mkdocs
-
-# The following packages are considered to be unsafe in a requirements file:
-# setuptools==41.2.0        # via markdown
+click==7.0
+    # via
+    #   mkdocs
+    #   nltk
+future==0.18.2
+    # via lunr
+importlib-metadata==3.3.0
+    # via markdown
+jinja2==2.10.1
+    # via mkdocs
+joblib==1.0.0
+    # via nltk
+livereload==2.6.1
+    # via mkdocs
+lunr[languages]==0.5.8
+    # via mkdocs
+markdown==3.3.3
+    # via mkdocs
+markupsafe==1.1.1
+    # via jinja2
+mkdocs==1.1.2
+    # via -r requirements.in
+nltk==3.5
+    # via lunr
+pygments==2.7.3
+    # via -r requirements.in
+pyyaml==5.1.2
+    # via mkdocs
+regex==2020.11.13
+    # via nltk
+six==1.12.0
+    # via
+    #   livereload
+    #   lunr
+tornado==6.0.3
+    # via
+    #   livereload
+    #   mkdocs
+tqdm==4.55.1
+    # via nltk
+typing-extensions==3.7.4.3
+    # via importlib-metadata
+zipp==3.4.0
+    # via importlib-metadata


### PR DESCRIPTION
This PR fixes the failing Read the docs build for Ocim documentation (hosted at https://ocim.opencraft.com) by adding a `.readthedocs.yml` configuration file which explicitly configures the build.

Without this PR, RTD was trying to install the requirements from the top-level requirements file and failing because the MySQL client library required a MySQL client package to be installed. This is now fixed by configuring RTD to install only the requirements file under the `documentation` directory,

**Testing instructions**:
1. Check and verify that https://ocim.opencraft.com/en/guruprasad-bb-3528-fix-readthedocs-builds/ has all the documentation present in the `documentation/` directory of this repository.
2. Compare with the documentation at https://ocim.opencraft.com/ which has some of the recent documentation changes missing due to the build failures. For example, a new section about the `reset_db` management command was added to the `master` branch a while ago but doesn't show up under https://ocim.opencraft.com but shows up in the build branch for this PR.