### PR TITLE
[BB-3516] Change link for Support Request button in Ocim console

### DIFF
--- a/frontend/src/global/constants.ts
+++ b/frontend/src/global/constants.ts
@@ -5,6 +5,7 @@ export const NOTIFICATIONS_LIMIT = process.env.REACT_APP_NOTIFICATIONS_LIMIT
 export const OCIM_API_BASE =
   process.env.REACT_APP_OCIM_API_BASE || 'http://localhost:5000';
 
+export const SUPPORT_LINK = process.env.REACT_APP_SUPPORT_LINK || '/#';
 export const CONTACT_US_LINK = process.env.REACT_APP_CONTACT_US_LINK || '/#';
 export const CONTACT_US_EMAIL =
   process.env.REACT_APP_CONTACT_US_EMAIL || 'contact@opencraft.com';

--- a/frontend/src/ui/components/App/__snapshots__/App.spec.tsx.snap
+++ b/frontend/src/ui/components/App/__snapshots__/App.spec.tsx.snap
@@ -79,7 +79,7 @@ exports[`renders without crashing 1`] = `
     >
       <a
         className="footer-link"
-        href="https://opencraft.com/help"
+        href="/#"
       >
         Support
       </a>

--- a/frontend/src/ui/components/Footer/Footer.tsx
+++ b/frontend/src/ui/components/Footer/Footer.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import {
+  SUPPORT_LINK,
   CONTACT_US_LINK,
   PRIVACY_POLICY_LINK,
   OPENCRAFT_WEBSITE_LINK
@@ -22,7 +23,7 @@ export const Footer: React.FC = () => (
       </a>
     </Col>
     <Col lg="auto" sm={{ span: 12 }} className="text-center mx-2 my-2">
-      <a className="footer-link" href="https://opencraft.com/help">
+      <a className="footer-link" href={SUPPORT_LINK}>
         Support
       </a>
     </Col>

--- a/frontend/src/ui/components/Footer/__snapshots__/Footer.spec.tsx.snap
+++ b/frontend/src/ui/components/Footer/__snapshots__/Footer.spec.tsx.snap
@@ -22,7 +22,7 @@ exports[`renders without crashing 1`] = `
   >
     <a
       className="footer-link"
-      href="https://opencraft.com/help"
+      href="/#"
     >
       Support
     </a>


### PR DESCRIPTION
Currently both the Contact Us link on the frontend home page and the Support Request link in the frontend console point to the same destination. We separate the two so that the Support Request link can instead go to OpenCraft's Contact Us form instead.

**JIRA tickets**: BB-3516

**Merge deadline**: None

**Testing instructions**:

1. Checkout this PR
2. Set the environment variable `REACT_APP_SUPPORT_LINK` to 'https://opencraft.com/contact-us/'
3. Login to OCIM frontend and check that clicking Support Request now takes you to 'https://opencraft.com/contact-us/'
4. Make sure the Contact Us button on the homepage is unaffected and does not take you to 'https://opencraft.com/contact-us/'

**Reviewers**
- [ ] @farhaanbukhsh 