### PR TITLE
[SE-3953] Updates NewRelic policy to check for failure instead

### DIFF
--- a/instance/newrelic.py
+++ b/instance/newrelic.py
@@ -187,7 +187,7 @@ def add_alert_nrql_condition(policy_id, monitor_url, name):
                 'value_function': 'sum',
                 'terms': [{
                     'duration': settings.NEWRELIC_NRQL_ALERT_CONDITION_DURATION,
-                    'threshold': '2',
+                    'threshold': settings.NEWRELIC_NRQL_ALERT_CONDITION_THRESHOLD,
                     'operator': 'above',
                     'priority': 'critical',
                     'time_function': 'all',

--- a/instance/newrelic.py
+++ b/instance/newrelic.py
@@ -175,7 +175,7 @@ def add_alert_nrql_condition(policy_id, monitor_url, name):
     """
     url = '{}/policies/{}.json'.format(ALERTS_NRQL_CONDITIONS_API_URL, policy_id)
     logger.info('POST %s', url)
-    query = "SELECT count(*) FROM SyntheticCheck WHERE monitorName = '{}' AND result = 'SUCCESS'".format(monitor_url)
+    query = "SELECT count(*) FROM SyntheticCheck WHERE monitorName = '{}' AND result = 'FAILED'".format(monitor_url)
     r = requests.post(
         url,
         headers=_request_headers(),
@@ -187,8 +187,8 @@ def add_alert_nrql_condition(policy_id, monitor_url, name):
                 'value_function': 'sum',
                 'terms': [{
                     'duration': settings.NEWRELIC_NRQL_ALERT_CONDITION_DURATION,
-                    'threshold': '1',
-                    'operator': 'below',
+                    'threshold': '2',
+                    'operator': 'above',
                     'priority': 'critical',
                     'time_function': 'all',
                 }],
@@ -201,9 +201,9 @@ def add_alert_nrql_condition(policy_id, monitor_url, name):
                     'fill_value': '0'
                 },
                 'expiration': {
-                    'expiration_duration': '600',
-                    'open_violation_on_expiration': True,
-                    'close_violations_on_expiration': False,
+                    'expiration_duration': settings.NEWRELIC_NRQL_ALERT_SIGNAL_EXPIRATION,
+                    'open_violation_on_expiration': False,
+                    'close_violations_on_expiration': True,
                 }
             }
         }

--- a/instance/tests/test_newrelic.py
+++ b/instance/tests/test_newrelic.py
@@ -222,8 +222,9 @@ class NewRelicTestCase(TestCase):
 
     @responses.activate
     @override_settings(
-        NEWRELIC_NRQL_ALERT_CONDITION_DURATION='11',
-        NEWRELIC_NRQL_ALERT_SIGNAL_EXPIRATION='660'
+        NEWRELIC_NRQL_ALERT_CONDITION_THRESHOLD='2',
+        NEWRELIC_NRQL_ALERT_CONDITION_DURATION='16',
+        NEWRELIC_NRQL_ALERT_SIGNAL_EXPIRATION='960',
     )
     def test_add_alert_nrql_condition(self):
         """
@@ -259,7 +260,7 @@ class NewRelicTestCase(TestCase):
                 'enabled': True,
                 'value_function': 'sum',
                 'terms': [{
-                    'duration': '11',
+                    'duration': '16',
                     'threshold': '2',
                     'operator': 'above',
                     'priority': 'critical',
@@ -274,7 +275,7 @@ class NewRelicTestCase(TestCase):
                     'fill_value': '0'
                 },
                 'expiration': {
-                    'expiration_duration': '660',
+                    'expiration_duration': '960',
                     'open_violation_on_expiration': False,
                     'close_violations_on_expiration': True,
                 }

--- a/instance/tests/test_newrelic.py
+++ b/instance/tests/test_newrelic.py
@@ -221,7 +221,10 @@ class NewRelicTestCase(TestCase):
         self.assertEqual(request_body, None)
 
     @responses.activate
-    @override_settings(NEWRELIC_NRQL_ALERT_CONDITION_DURATION='11')
+    @override_settings(
+        NEWRELIC_NRQL_ALERT_CONDITION_DURATION='11',
+        NEWRELIC_NRQL_ALERT_SIGNAL_EXPIRATION='660'
+    )
     def test_add_alert_nrql_condition(self):
         """
         Check that the add_alert_nrql_condition function adds an alert condition for the given URL to
@@ -246,7 +249,7 @@ class NewRelicTestCase(TestCase):
         request_json = json.loads(responses.calls[0].request.body.decode())
         request_headers = responses.calls[0].request.headers
         self.assertEqual(request_headers['x-api-key'], 'admin-api-key')
-        query = "SELECT count(*) FROM SyntheticCheck WHERE monitorName = '{}' AND result = 'SUCCESS'".format(
+        query = "SELECT count(*) FROM SyntheticCheck WHERE monitorName = '{}' AND result = 'FAILED'".format(
             monitor_url
         )
         self.assertEqual(request_json, {
@@ -257,8 +260,8 @@ class NewRelicTestCase(TestCase):
                 'value_function': 'sum',
                 'terms': [{
                     'duration': '11',
-                    'threshold': '1',
-                    'operator': 'below',
+                    'threshold': '2',
+                    'operator': 'above',
                     'priority': 'critical',
                     'time_function': 'all',
                 }],
@@ -271,9 +274,9 @@ class NewRelicTestCase(TestCase):
                     'fill_value': '0'
                 },
                 'expiration': {
-                    'expiration_duration': '600',
-                    'open_violation_on_expiration': True,
-                    'close_violations_on_expiration': False,
+                    'expiration_duration': '660',
+                    'open_violation_on_expiration': False,
+                    'close_violations_on_expiration': True,
                 }
             }
         })

--- a/opencraft/settings.py
+++ b/opencraft/settings.py
@@ -778,12 +778,15 @@ NEWRELIC_ADMIN_USER_API_KEY = env('NEWRELIC_ADMIN_USER_API_KEY', default=None)
 # The basic auth password needed to access the node exporter.
 NODE_EXPORTER_PASSWORD = env('NODE_EXPORTER_PASSWORD', default=None)
 
-# Thresholds for NRQL alert conditions (minutes)
-NEWRELIC_NRQL_ALERT_CONDITION_DURATION = env('NEWRELIC_NRQL_ALERT_CONDITION_DURATION', default='16')
+# Threhold for NRQL alert condition
+NEWRELIC_NRQL_ALERT_CONDITION_THRESHOLD = env('NEWRELIC_NRQL_ALERT_CONDITION_THRESHOLD', default='1')
+
+# Duration for NRQL alert conditions (minutes)
+NEWRELIC_NRQL_ALERT_CONDITION_DURATION = env('NEWRELIC_NRQL_ALERT_CONDITION_DURATION', default='11')
 
 # Signal Expiration for NRQL loss of signal alert conditions (seconds)
 # Default is set to `NEWRELIC_NRQL_ALERT_CONDITION_DURATION` default
-NEWRELIC_NRQL_ALERT_SIGNAL_EXPIRATION = env('NEWRELIC_NRQL_ALERT_SIGNAL_EXPIRATION', default='960')
+NEWRELIC_NRQL_ALERT_SIGNAL_EXPIRATION = env('NEWRELIC_NRQL_ALERT_SIGNAL_EXPIRATION', default='660')
 
 # Load balancing ##############################################################
 

--- a/opencraft/settings.py
+++ b/opencraft/settings.py
@@ -778,8 +778,12 @@ NEWRELIC_ADMIN_USER_API_KEY = env('NEWRELIC_ADMIN_USER_API_KEY', default=None)
 # The basic auth password needed to access the node exporter.
 NODE_EXPORTER_PASSWORD = env('NODE_EXPORTER_PASSWORD', default=None)
 
-# Thresholds for NRQL alert conditions
+# Thresholds for NRQL alert conditions (minutes)
 NEWRELIC_NRQL_ALERT_CONDITION_DURATION = env('NEWRELIC_NRQL_ALERT_CONDITION_DURATION', default='16')
+
+# Signal Expiration for NRQL loss of signal alert conditions (seconds)
+# Default is set to `NEWRELIC_NRQL_ALERT_CONDITION_DURATION` default
+NEWRELIC_NRQL_ALERT_SIGNAL_EXPIRATION = env('NEWRELIC_NRQL_ALERT_SIGNAL_EXPIRATION', default='960')
 
 # Load balancing ##############################################################
 


### PR DESCRIPTION
This check checks for failure instead of success.

This check also makes sure that ~3~ 2 consecutive failures happened before creating an alert/violation.

Once ~3~ 2 alerts happen in the matter of ~16~ 11 minutes, a violation will be opened. In order to guarantee the alert is closed, we use the 'loss of signal' or 'signal expiration'. If we don't have any signal for a duration of ~16~ 11 mins, ie no failed request for ~16~ 11 mins, it means that all issues were resolved, so close the violation.

**JIRA tickets**: SE-3953

**Screenshots**: 

* Opening Alert:
![image](https://user-images.githubusercontent.com/5631091/104562092-ed1acf00-5658-11eb-9849-50fae7ed4eb2.png)

* Closing Alert:
![image](https://user-images.githubusercontent.com/5631091/104562021-d4aab480-5658-11eb-95d7-cffe905a75f6.png)

**Sandbox Instance**: [Sandbox Instance](https://manage.opencraft.com/instance/22310/)

**Testing instructions**:

1. Open [NewRelic Synthetic Summary](https://one.newrelic.com/launcher/nr1-core.explorer?pane=eyJuZXJkbGV0SWQiOiJzeW50aGV0aWNzLW5lcmRsZXRzLm1vbml0b3Itb3ZlcnZpZXciLCJpc092ZXJ2aWV3Ijp0cnVlLCJyZWZlcnJlcnMiOnsibGF1bmNoZXJJZCI6InN5bnRoZXRpY3MtbmVyZGxldHMuaG9tZSIsIm5lcmRsZXRJZCI6InN5bnRoZXRpY3MtbmVyZGxldHMubW9uaXRvci1saXN0In0sImVudGl0eUlkIjoiTVRNME5qazFOWHhUV1U1VVNIeE5UMDVKVkU5U2ZHWXdORGs1Wm1KaExXSTVPR1F0TkRGa05pMWlaakUxTFRjeFlUWTFZV0V5Wm1Ga1lRIn0=&sidebars[0]=eyJuZXJkbGV0SWQiOiJucjEtY29yZS5hY3Rpb25zIiwiZW50aXR5SWQiOiJNVE0wTmprMU5YeFRXVTVVU0h4TlQwNUpWRTlTZkdZd05EazVabUpoTFdJNU9HUXROREZrTmkxaVpqRTFMVGN4WVRZMVlXRXlabUZrWVEiLCJzZWxlY3RlZE5lcmRsZXQiOnsibmVyZGxldElkIjoic3ludGhldGljcy1uZXJkbGV0cy5tb25pdG9yLW92ZXJ2aWV3IiwiaXNPdmVydmlldyI6dHJ1ZX19&platform[accountId]=1346955&platform[filters]=IihuYW1lIGxpa2UgJ3ByMjU2OTUuc2FuZGJveC5vcGVuY3JhZnQuaG9zdGluZycgb3IgaWQgPSAncHIyNTY5NS5zYW5kYm94Lm9wZW5jcmFmdC5ob3N0aW5nJyBvciBkb21haW5JZCA9ICdwcjI1Njk1LnNhbmRib3gub3BlbmNyYWZ0Lmhvc3RpbmcnKSI=&platform[timeRange][duration]=1800000&platform[$isFallbackTimeRange]=true) for the sandbox instance's extended heartbeat check in a new tab.
2. Open [NewRelic Policy](https://one.newrelic.com/launcher/nrai.launcher?pane=eyJuZXJkbGV0SWQiOiJhbGVydGluZy11aS1jbGFzc2ljLnBvbGljaWVzIiwibmF2IjoiUG9saWNpZXMiLCJwb2xpY3lJZCI6MTE1MDk2N30=&sidebars[0]=eyJuZXJkbGV0SWQiOiJucmFpLm5hdmlnYXRpb24tYmFyIiwibmF2IjoiUG9saWNpZXMifQ==&platform[accountId]=1346955) for the sandbox instance's extended heartbeat check in a new tab.
3. SSH into the sandbox instance.
`ssh 149.202.172.84`
4. Set the LMS env settings yaml file to the error file.
`sudo cp /edx/etc/lms-error.yml /edx/etc/lms.yml`
5. Restart the LMS
`/edx/bin/supervisorctl restart lms`
6. Wait ~16~ 11 mins, and an incident should be opened for the sandbox instance.
7. SSH into the sandbox instance, again.
`ssh 149.202.172.84`
8. Set the LMS env settings yaml file to the fix file.
`sudo cp /edx/etc/lms-fix.yml /edx/etc/lms.yml`
9. Restart the LMS, again.
`/edx/bin/supervisorctl restart lms`
10. Wait ~16~ 11 mins, and the incident should be closed for the sandbox instance.

**Author notes and concerns**:

1. NewRelic solution architect explains how to automatically close Failure checking alerts in this [forum thread](https://discuss.newrelic.com/t/synthetic-check-nrql-alerts-not-getting-closed/121690).
 
**Reviewers**
- [x] @arbrandes 
- [ ] @mtyaka 
- [ ] @gabor-boros 
