### PR TITLE
Revert "[FAL-23] Enable ORGANIZATIONS_APP feature flag by default."

### DIFF
--- a/instance/models/mixins/openedx_config.py
+++ b/instance/models/mixins/openedx_config.py
@@ -256,7 +256,6 @@ class OpenEdXConfigMixin(ConfigMixinBase):
                 "ENABLE_THIRD_PARTY_AUTH": True,
                 "ENABLE_XBLOCK_VIEW_ENDPOINT": True,
                 "ENABLE_SYSADMIN_DASHBOARD": True,
-                "ORGANIZATIONS_APP": True,
                 "PREVIEW_LMS_BASE": self.instance.lms_preview_domain,
                 "REQUIRE_COURSE_EMAIL_AUTH": False,
                 "USE_MICROSITES": False,


### PR DESCRIPTION
Enabling the organizations app means that users have to go to django admin and create organizations before they can start creating new courses in the Studio. We don't want users to have to fiddle with django admin before being able to use the Studio.

This reverts commit 9bd5fe47177d87af54889e0b3b63e52df585a8fe.