### PR TITLE
BB-3517 Change build success/fail email subject

### DIFF
--- a/instance/models/mixins/utilities.py
+++ b/instance/models/mixins/utilities.py
@@ -311,13 +311,14 @@ def get_ansible_failure_log_entry(entries) -> Tuple[str, Dict[str, Any], List[st
     return task_name, log_entry, other_ansible_logs
 
 
-def send_periodic_deployment_success_email(recipients: List[str], instance_name: str) -> None:
+def send_periodic_deployment_success_email(recipients: List[str], instance) -> None:
     """
     Send notification email about successful periodic deployments.
 
     This email sending should be called, when the previous deployment failed, but the
     latest passed.
     """
+    instance_name = str(instance)
     logger.warning(
         "Sending acknowledgement e-mail to %s after instance %s didn provision",
         recipients,
@@ -325,7 +326,7 @@ def send_periodic_deployment_success_email(recipients: List[str], instance_name:
     )
 
     send_mail(
-        'Deployment back to normal at instance: {}'.format(instance_name),
+        '{} CI: Passed'.format(instance.name),
         'The deployment of a new appserver was successful. You can consider any failure notification '
         'related to {} as resolved. No further action needed.'.format(instance_name),
         settings.DEFAULT_FROM_EMAIL,
@@ -346,8 +347,8 @@ def send_urgent_deployment_failure_email(recipients: List[str], instance_name: s
 
     send_mail(
         'Deployment failed at instance: {}'.format(instance_name),
-        'The deployment of a new appserver failed and needs manual intervention. '
-        'You can find the logs in the web interface.',
+        'The deployment of a new appserver "{}" failed and needs manual intervention. '
+        'You can find the logs in the web interface.'.format(instance_name),
         settings.DEFAULT_FROM_EMAIL,
         recipients,
         fail_silently=False,
@@ -399,7 +400,7 @@ def send_periodic_deployment_failure_email(recipients: List[str], instance) -> N
     )
 
     email = EmailMultiAlternatives(
-        'Deployment failed at instance: {}'.format(instance_name),
+        '{} CI: Failed'.format(instance.name),
         'The periodic deployment of {edx_platform_release} failed. Please see the details below.\n\n'
         'Ansible task name:\t{ansible_task_name}\n'
         'Relevant log lines:\n{relevant_log_entry}\n\n'
@@ -524,5 +525,5 @@ def send_acknowledgement_email_on_deployment_success(sender, **kwargs) -> None:
 
     send_periodic_deployment_success_email(
         periodic_build_failure_emails,
-        str(instance)
+        instance
     )

--- a/instance/tests/models/test_openedx_instance.py
+++ b/instance/tests/models/test_openedx_instance.py
@@ -517,8 +517,8 @@ class OpenEdXInstanceTestCase(TestCase):
         self.assertEqual(outbox.to, failure_emails)
         self.assertEqual(
             outbox.body,
-            'The deployment of a new appserver failed and needs manual intervention. '
-            'You can find the logs in the web interface.',
+            f'The deployment of a new appserver "{str(instance)}" failed and needs manual intervention. '
+            f'You can find the logs in the web interface.',
         )
         self.assertLogs(
             "instance.models.mixins.utilities",
@@ -602,7 +602,7 @@ class OpenEdXInstanceTestCase(TestCase):
             filtered_configuration = json.dumps(filtered_data)
 
         self.assertEqual(len(django_mail.outbox), 1)
-        self.assertEqual(outbox.subject, f'Deployment failed at instance: {str(instance)}')
+        self.assertEqual(outbox.subject, f'{instance.name} CI: Failed')
         self.assertEqual(outbox.to, failure_emails)
         self.assertEqual(len(outbox.attachments), 2)
         self.assertEqual(outbox.attachments[0], ('build_log.json', '[]', 'application/json'))
@@ -671,7 +671,7 @@ class OpenEdXInstanceTestCase(TestCase):
         # Given these deployment types, at least one email should be sended
         outbox = django_mail.outbox[0]
         self.assertEqual(len(django_mail.outbox), 1)
-        self.assertEqual(outbox.subject, f'Deployment back to normal at instance: {str(instance)}')
+        self.assertEqual(outbox.subject, f'{instance.name} CI: Passed')
         self.assertEqual(outbox.to, failure_emails)
         self.assertEqual(
             outbox.body,


### PR DESCRIPTION
Changes the build success/fail email subject as requested by Ned [here](https://discuss.openedx.org/t/how-do-we-build-continuous-integration-for-the-supported-installation/3065/30?u=0x29a)

**JIRA Tickets**: BB-3517

**Discussions**: https://discuss.openedx.org/t/how-do-we-build-continuous-integration-for-the-supported-installation/3065/30?u=0x29a

**Merge deadline**: None

**Testing Instructions**:
1. Checkout to this PR
2. ssh to the vagrant box
3. run `make test.one instance.tests.models.test_openedx_instance.OpenEdXInstanceTestCase` and check all the tests pass
4. In file instance/models/mixins/utilities.py check that the email subjects are according to [this comment](https://discuss.openedx.org/t/how-do-we-build-continuous-integration-for-the-supported-installation/3065/30?u=0x29a)

**Reviewers**:
- [ ] @farhaanbukhsh 
- [ ] @0x29a 