### PR TITLE
[BB-3498] Implement user menu and rework page header

### DIFF
--- a/frontend/src/console/components/ConsolePage/ConsolePage.tsx
+++ b/frontend/src/console/components/ConsolePage/ConsolePage.tsx
@@ -3,7 +3,6 @@ import { CustomizationSideMenu, RedeploymentToolbar } from 'console/components';
 import { EmailActivationAlertMessage, ErrorPage } from 'ui/components';
 import { OCIM_API_BASE } from 'global/constants';
 import { Row, Col, Container } from 'react-bootstrap';
-import { WrappedMessage } from 'utils/intl';
 import { InstancesModel } from 'console/models';
 import { RootState } from 'global/state';
 import { connect } from 'react-redux';
@@ -76,38 +75,6 @@ export class ConsolePageComponent extends React.PureComponent<Props> {
     }
   }
 
-  private renderHeader() {
-    if (this.props.loading || this.props.activeInstance.data === null) {
-      return (
-        <div className="title-container">
-          <h1>
-            <i className="fas fa-sync-alt fa-spin" />
-          </h1>
-        </div>
-      );
-    }
-
-    const instanceData = this.props.activeInstance.data;
-    const instanceLink = instanceData.lmsUrl;
-    const studioLink = instanceData.studioUrl;
-
-    return (
-      <div className="title-container">
-        <h1>
-          <a className="header-link" href={instanceLink}>
-            {instanceData.instanceName}
-            <i className="instance-link fas fa-link fa-xs" />
-          </a>
-        </h1>
-        <h2>
-          <a className="header-link" href={studioLink}>
-            <WrappedMessage messages={messages} id="editCourses" />
-          </a>
-        </h2>
-      </div>
-    );
-  }
-
   public render() {
     const content = () => {
       let innerContent = this.props.children;
@@ -166,8 +133,6 @@ export class ConsolePageComponent extends React.PureComponent<Props> {
 
     return (
       <div className="console-page">
-        {this.renderHeader()}
-
         {!isEmailVerified ? (
           <EmailActivationAlertMessage />
         ) : (

--- a/frontend/src/console/components/ConsolePage/__snapshots__/ConsolePage.spec.tsx.snap
+++ b/frontend/src/console/components/ConsolePage/__snapshots__/ConsolePage.spec.tsx.snap
@@ -5,15 +5,6 @@ exports[`Console Page Correctly renders loading page 1`] = `
   className="console-page"
 >
   <div
-    className="title-container"
-  >
-    <h1>
-      <i
-        className="fas fa-sync-alt fa-spin"
-      />
-    </h1>
-  </div>
-  <div
     className="d-flex justify-content-center align-middle redeployment-toolbar"
   >
     <div
@@ -284,29 +275,6 @@ exports[`Console Page Correctly renders page with data 1`] = `
   className="console-page"
 >
   <div
-    className="title-container"
-  >
-    <h1>
-      <a
-        className="header-link"
-        href="test-url"
-      >
-        test
-        <i
-          className="instance-link fas fa-link fa-xs"
-        />
-      </a>
-    </h1>
-    <h2>
-      <a
-        className="header-link"
-        href="test-url"
-      >
-        Edit courses (Studio)
-      </a>
-    </h2>
-  </div>
-  <div
     className="d-flex justify-content-center align-middle redeployment-toolbar"
   >
     <div
@@ -568,29 +536,6 @@ exports[`Console Page Correctly renders page with email not verified alert 1`] =
 <div
   className="console-page"
 >
-  <div
-    className="title-container"
-  >
-    <h1>
-      <a
-        className="header-link"
-        href="test-url"
-      >
-        test
-        <i
-          className="instance-link fas fa-link fa-xs"
-        />
-      </a>
-    </h1>
-    <h2>
-      <a
-        className="header-link"
-        href="test-url"
-      >
-        Edit courses (Studio)
-      </a>
-    </h2>
-  </div>
   <div
     className="d-flex justify-content-center align-middle email-activation-alert"
   >

--- a/frontend/src/console/components/ConsolePage/displayMessages.ts
+++ b/frontend/src/console/components/ConsolePage/displayMessages.ts
@@ -1,8 +1,4 @@
 const messages = {
-  editCourses: {
-    defaultMessage: 'Edit courses (Studio)',
-    description: 'Label to Studio link.'
-  },
   notAllowedForStaff: {
     defaultMessage:
       'This page is not accessible by staff users yet. Use <link>this link</link> instead.',

--- a/frontend/src/console/components/Hero/__snapshots__/Hero.spec.tsx.snap
+++ b/frontend/src/console/components/Hero/__snapshots__/Hero.spec.tsx.snap
@@ -5,27 +5,6 @@ exports[`Hero customization page renders the hero customization page when instan
   className="console-page"
 >
   <div
-    className="title-container"
-  >
-    <h1>
-      <a
-        className="header-link"
-      >
-        test
-        <i
-          className="instance-link fas fa-link fa-xs"
-        />
-      </a>
-    </h1>
-    <h2>
-      <a
-        className="header-link"
-      >
-        Edit courses (Studio)
-      </a>
-    </h2>
-  </div>
-  <div
     className="d-flex justify-content-center align-middle email-activation-alert"
   >
     <i
@@ -277,27 +256,6 @@ exports[`Hero customization page renders the hero customization page when instan
 <div
   className="console-page"
 >
-  <div
-    className="title-container"
-  >
-    <h1>
-      <a
-        className="header-link"
-      >
-        test
-        <i
-          className="instance-link fas fa-link fa-xs"
-        />
-      </a>
-    </h1>
-    <h2>
-      <a
-        className="header-link"
-      >
-        Edit courses (Studio)
-      </a>
-    </h2>
-  </div>
   <div
     className="d-flex justify-content-center align-middle email-activation-alert"
   >
@@ -551,27 +509,6 @@ exports[`Hero customization page renders the hero customization page when the in
   className="console-page"
 >
   <div
-    className="title-container"
-  >
-    <h1>
-      <a
-        className="header-link"
-      >
-        test
-        <i
-          className="instance-link fas fa-link fa-xs"
-        />
-      </a>
-    </h1>
-    <h2>
-      <a
-        className="header-link"
-      >
-        Edit courses (Studio)
-      </a>
-    </h2>
-  </div>
-  <div
     className="d-flex justify-content-center align-middle email-activation-alert"
   >
     <i
@@ -824,27 +761,6 @@ exports[`Hero customization page renders the hero customization page when the in
   className="console-page"
 >
   <div
-    className="title-container"
-  >
-    <h1>
-      <a
-        className="header-link"
-      >
-        test
-        <i
-          className="instance-link fas fa-link fa-xs"
-        />
-      </a>
-    </h1>
-    <h2>
-      <a
-        className="header-link"
-      >
-        Edit courses (Studio)
-      </a>
-    </h2>
-  </div>
-  <div
     className="d-flex justify-content-center align-middle email-activation-alert"
   >
     <i
@@ -1096,15 +1012,6 @@ exports[`Hero customization page renders without crashing 1`] = `
 <div
   className="console-page"
 >
-  <div
-    className="title-container"
-  >
-    <h1>
-      <i
-        className="fas fa-sync-alt fa-spin"
-      />
-    </h1>
-  </div>
   <div
     className="d-flex justify-content-center align-middle redeployment-toolbar"
   >

--- a/frontend/src/console/components/InstanceSettings/__snapshots__/InstanceSettings.spec.tsx.snap
+++ b/frontend/src/console/components/InstanceSettings/__snapshots__/InstanceSettings.spec.tsx.snap
@@ -5,15 +5,6 @@ exports[`renders without crashing 1`] = `
   className="console-page"
 >
   <div
-    className="title-container"
-  >
-    <h1>
-      <i
-        className="fas fa-sync-alt fa-spin"
-      />
-    </h1>
-  </div>
-  <div
     className="d-flex justify-content-center align-middle redeployment-toolbar"
   >
     <div

--- a/frontend/src/console/components/Logos/__snapshots__/Logos.spec.tsx.snap
+++ b/frontend/src/console/components/Logos/__snapshots__/Logos.spec.tsx.snap
@@ -5,15 +5,6 @@ exports[`renders without crashing 1`] = `
   className="console-page"
 >
   <div
-    className="title-container"
-  >
-    <h1>
-      <i
-        className="fas fa-sync-alt fa-spin"
-      />
-    </h1>
-  </div>
-  <div
     className="d-flex justify-content-center align-middle redeployment-toolbar"
   >
     <div

--- a/frontend/src/console/components/NoticeBoard/__snapshots__/NoticeBoard.spec.tsx.snap
+++ b/frontend/src/console/components/NoticeBoard/__snapshots__/NoticeBoard.spec.tsx.snap
@@ -5,29 +5,6 @@ exports[`NoticeBoard tests Renders all notification types without crashing 1`] =
   className="console-page"
 >
   <div
-    className="title-container"
-  >
-    <h1>
-      <a
-        className="header-link"
-        href="test-url"
-      >
-        test
-        <i
-          className="instance-link fas fa-link fa-xs"
-        />
-      </a>
-    </h1>
-    <h2>
-      <a
-        className="header-link"
-        href="test-url"
-      >
-        Edit courses (Studio)
-      </a>
-    </h2>
-  </div>
-  <div
     className="d-flex justify-content-center align-middle redeployment-toolbar"
   >
     <div
@@ -1412,29 +1389,6 @@ exports[`NoticeBoard tests Renders message about non-existent instance if email 
 <div
   className="console-page"
 >
-  <div
-    className="title-container"
-  >
-    <h1>
-      <a
-        className="header-link"
-        href="test-url"
-      >
-        test
-        <i
-          className="instance-link fas fa-link fa-xs"
-        />
-      </a>
-    </h1>
-    <h2>
-      <a
-        className="header-link"
-        href="test-url"
-      >
-        Edit courses (Studio)
-      </a>
-    </h2>
-  </div>
   <div
     className="d-flex justify-content-center align-middle email-activation-alert"
   >

--- a/frontend/src/console/components/ThemeButtons/__snapshots__/ThemeButtons.spec.tsx.snap
+++ b/frontend/src/console/components/ThemeButtons/__snapshots__/ThemeButtons.spec.tsx.snap
@@ -5,15 +5,6 @@ exports[`renders without crashing 1`] = `
   className="console-page"
 >
   <div
-    className="title-container"
-  >
-    <h1>
-      <i
-        className="fas fa-sync-alt fa-spin"
-      />
-    </h1>
-  </div>
-  <div
     className="d-flex justify-content-center align-middle redeployment-toolbar"
   >
     <div

--- a/frontend/src/console/components/ThemeFooter/__snapshots__/ThemeFooter.spec.tsx.snap
+++ b/frontend/src/console/components/ThemeFooter/__snapshots__/ThemeFooter.spec.tsx.snap
@@ -5,15 +5,6 @@ exports[`renders without crashing 1`] = `
   className="console-page"
 >
   <div
-    className="title-container"
-  >
-    <h1>
-      <i
-        className="fas fa-sync-alt fa-spin"
-      />
-    </h1>
-  </div>
-  <div
     className="d-flex justify-content-center align-middle redeployment-toolbar"
   >
     <div

--- a/frontend/src/console/components/ThemeNavigation/__snapshots__/ThemeNavigation.spec.tsx.snap
+++ b/frontend/src/console/components/ThemeNavigation/__snapshots__/ThemeNavigation.spec.tsx.snap
@@ -5,15 +5,6 @@ exports[`renders without crashing 1`] = `
   className="console-page"
 >
   <div
-    className="title-container"
-  >
-    <h1>
-      <i
-        className="fas fa-sync-alt fa-spin"
-      />
-    </h1>
-  </div>
-  <div
     className="d-flex justify-content-center align-middle redeployment-toolbar"
   >
     <div

--- a/frontend/src/console/components/ThemePreviewAndColors/__snapshots__/ThemePreviewAndColors.spec.tsx.snap
+++ b/frontend/src/console/components/ThemePreviewAndColors/__snapshots__/ThemePreviewAndColors.spec.tsx.snap
@@ -5,27 +5,6 @@ exports[`Theme preview and colors page Render theme settings page when instance 
   className="console-page"
 >
   <div
-    className="title-container"
-  >
-    <h1>
-      <a
-        className="header-link"
-      >
-        test
-        <i
-          className="instance-link fas fa-link fa-xs"
-        />
-      </a>
-    </h1>
-    <h2>
-      <a
-        className="header-link"
-      >
-        Edit courses (Studio)
-      </a>
-    </h2>
-  </div>
-  <div
     className="d-flex justify-content-center align-middle email-activation-alert"
   >
     <i
@@ -262,27 +241,6 @@ exports[`Theme preview and colors page Render theme settings page with theme set
 <div
   className="console-page"
 >
-  <div
-    className="title-container"
-  >
-    <h1>
-      <a
-        className="header-link"
-      >
-        test
-        <i
-          className="instance-link fas fa-link fa-xs"
-        />
-      </a>
-    </h1>
-    <h2>
-      <a
-        className="header-link"
-      >
-        Edit courses (Studio)
-      </a>
-    </h2>
-  </div>
   <div
     className="d-flex justify-content-center align-middle email-activation-alert"
   >
@@ -1046,27 +1004,6 @@ exports[`Theme preview and colors page Render theme settings page with theme set
   className="console-page"
 >
   <div
-    className="title-container"
-  >
-    <h1>
-      <a
-        className="header-link"
-      >
-        test
-        <i
-          className="instance-link fas fa-link fa-xs"
-        />
-      </a>
-    </h1>
-    <h2>
-      <a
-        className="header-link"
-      >
-        Edit courses (Studio)
-      </a>
-    </h2>
-  </div>
-  <div
     className="d-flex justify-content-center align-middle email-activation-alert"
   >
     <i
@@ -1828,15 +1765,6 @@ exports[`Theme preview and colors page renders without crashing 1`] = `
 <div
   className="console-page"
 >
-  <div
-    className="title-container"
-  >
-    <h1>
-      <i
-        className="fas fa-sync-alt fa-spin"
-      />
-    </h1>
-  </div>
   <div
     className="d-flex justify-content-center align-middle redeployment-toolbar"
   >

--- a/frontend/src/ui/components/App/__snapshots__/App.spec.tsx.snap
+++ b/frontend/src/ui/components/App/__snapshots__/App.spec.tsx.snap
@@ -4,18 +4,18 @@ exports[`renders without crashing 1`] = `
 <div
   className="app-container container-fluid"
 >
-  <div
-    className="container"
+  <nav
+    className="navbar navbar-expand-md navbar-dark"
   >
-    <nav
-      className="navbar navbar-expand-md navbar-dark bg-transparent"
+    <div
+      className="nav-container"
     >
       <span
-        className="logo-container mx-auto navbar-brand"
+        className="logo-container mr-auto order-0 navbar-brand"
       >
         <a
           aria-current="page"
-          className="nav-link active"
+          className="navbar-brand-link active"
           href="/"
           onClick={[Function]}
           style={Object {}}
@@ -32,7 +32,7 @@ exports[`renders without crashing 1`] = `
       <button
         aria-controls="basic-navbar-nav"
         aria-label="Toggle navigation"
-        className="navbar-toggler collapsed"
+        className="order-1 navbar-toggler collapsed"
         onClick={[Function]}
         type="button"
       >
@@ -42,7 +42,7 @@ exports[`renders without crashing 1`] = `
       </button>
       <div
         aria-expanded={null}
-        className="navbar-collapse collapse"
+        className="order-3 order-md-2 navbar-collapse collapse"
         id="basic-navbar-nav"
       >
         <div
@@ -50,8 +50,12 @@ exports[`renders without crashing 1`] = `
           onKeyDown={[Function]}
         />
       </div>
-    </nav>
-  </div>
+      <div
+        className="accounts-dropdown-nav order-2 order-md-3 navbar-nav"
+        onKeyDown={[Function]}
+      />
+    </div>
+  </nav>
   <div
     className="app-main row"
   />

--- a/frontend/src/ui/components/CustomStatusPill/CustomStatusPill.tsx
+++ b/frontend/src/ui/components/CustomStatusPill/CustomStatusPill.tsx
@@ -1,11 +1,8 @@
 import * as React from 'react';
 import { WrappedMessage } from 'utils/intl';
 import { Tooltip, OverlayTrigger, Badge, Nav } from 'react-bootstrap';
-import {
-  OpenEdXInstanceDeploymentStatusStatusEnum as DeploymentStatus,
-  OpenEdXInstanceDeploymentStatusDeploymentTypeEnum as DeploymentType
-} from 'ocim-client';
-
+import { OpenEdXInstanceDeploymentStatusStatusEnum as DeploymentStatus } from 'ocim-client';
+import { buildStatusContext } from './util';
 import messages from './displayMessages';
 import './styles.scss';
 
@@ -22,46 +19,10 @@ export const CustomStatusPill: React.FC<Props> = ({
   deploymentType,
   cancelRedeployment
 }: Props) => {
-  let dotColor = 'grey';
-  let deploymentStatusText = 'unavailable';
-  let tooltipText = 'unavailableTooltip';
-
-  switch (redeploymentStatus) {
-    case DeploymentStatus.Healthy:
-      dotColor = '#1abb64';
-      deploymentStatusText = 'updatedDeployment';
-      tooltipText = 'updatedDeploymentTooltip';
-      break;
-    case DeploymentStatus.Provisioning:
-      dotColor = '#ff9b04';
-      // If there's a deployment provisioning, but it's the
-      // first on (from registration), show preparing instance
-      // message.
-      if (deploymentType === DeploymentType.Registration) {
-        deploymentStatusText = 'preparingInstance';
-        tooltipText = 'preparingInstanceTooltip';
-      }
-      // If not, then this is a normal deployment, so show the usual
-      // running deployment message.
-      else {
-        deploymentStatusText = 'runningDeployment';
-        tooltipText = 'runningDeploymentTooltip';
-      }
-      break;
-    case DeploymentStatus.Preparing:
-      dotColor = '#ff9b04';
-      deploymentStatusText = 'preparingInstance';
-      tooltipText = 'preparingInstanceTooltip';
-      break;
-    case DeploymentStatus.ChangesPending:
-      dotColor = '#1abb64';
-      deploymentStatusText = 'pendingChanges';
-      tooltipText = 'pendingChangesTooltip';
-      break;
-    default:
-      // Default values already set up when instancing variables
-      break;
-  }
+  const { tooltipText, dotColor, deploymentStatusText } = buildStatusContext(
+    redeploymentStatus,
+    deploymentType
+  );
 
   const tooltip = (
     <Tooltip id="redeployment-status">

--- a/frontend/src/ui/components/CustomStatusPill/DeploymentIndicator.spec.tsx
+++ b/frontend/src/ui/components/CustomStatusPill/DeploymentIndicator.spec.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import { setupComponentForTesting } from "utils/testing";
+import { DeploymentIndicator } from './DeploymentIndicator';
+
+it('renders without crashing', () => {
+    const tree = setupComponentForTesting(<DeploymentIndicator />).toJSON();
+    expect(tree).toMatchSnapshot();
+});

--- a/frontend/src/ui/components/CustomStatusPill/DeploymentIndicator.tsx
+++ b/frontend/src/ui/components/CustomStatusPill/DeploymentIndicator.tsx
@@ -1,0 +1,17 @@
+import * as React from 'react';
+import { buildStatusContext } from './util';
+
+interface Props {
+  redeploymentStatus?: string | null;
+  deploymentType?: string | null;
+}
+
+export const DeploymentIndicator: React.FC<Props> = (props: Props) => {
+  const { redeploymentStatus, deploymentType } = props;
+  const { dotColor } = buildStatusContext(redeploymentStatus, deploymentType);
+  const style = {
+    color: dotColor,
+    fontSize: '12px'
+  };
+  return <i className="fa fa-circle" style={style} />;
+};

--- a/frontend/src/ui/components/CustomStatusPill/__snapshots__/DeploymentIndicator.spec.tsx.snap
+++ b/frontend/src/ui/components/CustomStatusPill/__snapshots__/DeploymentIndicator.spec.tsx.snap
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders without crashing 1`] = `
+<i
+  className="fa fa-circle"
+  style={
+    Object {
+      "color": "grey",
+      "fontSize": "12px",
+    }
+  }
+/>
+`;

--- a/frontend/src/ui/components/CustomStatusPill/index.ts
+++ b/frontend/src/ui/components/CustomStatusPill/index.ts
@@ -1,1 +1,2 @@
 export * from './CustomStatusPill';
+export * from './DeploymentIndicator';

--- a/frontend/src/ui/components/CustomStatusPill/util.ts
+++ b/frontend/src/ui/components/CustomStatusPill/util.ts
@@ -1,0 +1,68 @@
+import {
+  OpenEdXInstanceDeploymentStatusStatusEnum as DeploymentStatus,
+  OpenEdXInstanceDeploymentStatusDeploymentTypeEnum as DeploymentType
+} from 'ocim-client';
+
+interface StatusContext {
+  tooltipText: string;
+  dotColor: string;
+  deploymentStatusText: string;
+}
+
+/**
+ * An utility function to conditionally return color, tooltip and
+ * status text keys based on deployment status and type.
+ *
+ * @param redeploymentStatus
+ * @param deploymentType
+ * @returns StatusContext
+ */
+export function buildStatusContext(
+  redeploymentStatus?: string | null,
+  deploymentType?: string | null
+): StatusContext {
+  const result: StatusContext = {
+    dotColor: 'grey',
+    deploymentStatusText: 'unavailable',
+    tooltipText: 'unavailableTooltip'
+  };
+
+  switch (redeploymentStatus) {
+    case DeploymentStatus.Healthy:
+      result.dotColor = '#1abb64';
+      result.deploymentStatusText = 'updatedDeployment';
+      result.tooltipText = 'updatedDeploymentTooltip';
+      break;
+    case DeploymentStatus.Provisioning:
+      result.dotColor = '#ff9b04';
+      // If there's a deployment provisioning, but it's the
+      // first on (from registration), show preparing instance
+      // message.
+      if (deploymentType === DeploymentType.Registration) {
+        result.deploymentStatusText = 'preparingInstance';
+        result.tooltipText = 'preparingInstanceTooltip';
+      }
+
+      // If not, then this is a normal deployment, so show the usual
+      // running deployment message.
+      else {
+        result.deploymentStatusText = 'runningDeployment';
+        result.tooltipText = 'runningDeploymentTooltip';
+      }
+      break;
+    case DeploymentStatus.Preparing:
+      result.dotColor = '#ff9b04';
+      result.deploymentStatusText = 'preparingInstance';
+      result.tooltipText = 'preparingInstanceTooltip';
+      break;
+    case DeploymentStatus.ChangesPending:
+      result.dotColor = '#1abb64';
+      result.deploymentStatusText = 'pendingChanges';
+      result.tooltipText = 'pendingChangesTooltip';
+      break;
+    default:
+      // Default values already set up when instancing variables
+      break;
+  }
+  return result;
+}

--- a/frontend/src/ui/components/Header/Header.tsx
+++ b/frontend/src/ui/components/Header/Header.tsx
@@ -1,25 +1,55 @@
 import * as React from 'react';
-import { Container, Nav, Navbar } from 'react-bootstrap';
-import { CONTACT_US_LINK, FAQ_PAGE_LINK, ROUTES } from 'global/constants';
+import { Nav, Navbar, NavDropdown } from 'react-bootstrap';
+import { FAQ_PAGE_LINK, ROUTES } from 'global/constants';
 import { NavLink, Route } from 'react-router-dom';
+import { InstancesModel } from 'console/models';
+import { RootState } from 'global/state';
+import { connect } from 'react-redux';
 import logo from 'assets/icons.svg';
+import { WrappedMessage } from 'utils/intl';
+import { DeploymentIndicator } from '../CustomStatusPill';
+import messages from './displayMessages';
 import './styles.scss';
 
-export const Header: React.FC = () => {
+interface StateProps extends InstancesModel {}
+
+interface Props extends StateProps {
+  children: React.ReactNode;
+}
+
+export const HeaderComponent: React.FC<Props> = (props: Props) => {
   // Only show login link when on registration page and only show registration
   // link when on login page
+
+  let lmsUrl = null;
+  let deploymentPill = null;
+
+  if (!props.loading && props.activeInstance.data !== null) {
+    // if active instance data is available, get lms link
+    lmsUrl = props.activeInstance.data.lmsUrl;
+
+    // build the deployment status indicator
+    const { deployment } = props.activeInstance;
+    deploymentPill = (
+      <DeploymentIndicator
+        deploymentType={deployment?.deploymentType}
+        redeploymentStatus={deployment?.status}
+      />
+    );
+  }
+
   return (
-    <Container>
-      <Navbar bg="transparent" expand="md" variant="dark">
-        <Navbar.Brand className="logo-container mx-auto">
-          <NavLink className="nav-link" to="/">
+    <Navbar expand="md" variant="dark">
+      <div className="nav-container">
+        <Navbar.Brand className="logo-container mr-auto order-0">
+          <NavLink className="navbar-brand-link" to="/">
             <svg className="site-logo">
               <use xlinkHref={`${logo}#opencraft_logo`} />
             </svg>
           </NavLink>
         </Navbar.Brand>
-        <Navbar.Toggle aria-controls="basic-navbar-nav" />
-        <Navbar.Collapse id="basic-navbar-nav">
+        <Navbar.Toggle aria-controls="basic-navbar-nav" className="order-1" />
+        <Navbar.Collapse id="basic-navbar-nav" className="order-3 order-md-2">
           <Nav className="ml-auto">
             <Route path={ROUTES.Registration.HOME}>
               <Nav.Link
@@ -27,34 +57,96 @@ export const Header: React.FC = () => {
                 target="_blank"
                 href={FAQ_PAGE_LINK}
               >
-                FAQ
+                <WrappedMessage messages={messages} id="faq" />
               </Nav.Link>
               <NavLink className="nav-link" to={ROUTES.Auth.LOGIN}>
-                Login
+                <WrappedMessage messages={messages} id="login" />
               </NavLink>
             </Route>
             <Route path={ROUTES.Auth.LOGIN}>
               <NavLink className="nav-link" to={ROUTES.Registration.HOME}>
-                Create your account
+                <WrappedMessage messages={messages} id="registration" />
               </NavLink>
             </Route>
             <Route path={ROUTES.Console.HOME}>
-              <NavLink className="nav-link" to={ROUTES.Console.HOME}>
-                Customize
+              <NavLink
+                className="nav-link"
+                to={ROUTES.Console.HOME}
+                isActive={(match, location) => {
+                  // Mark this link as `active` for all customization pages.
+                  return location.pathname.startsWith(ROUTES.Console.HOME);
+                }}
+              >
+                <WrappedMessage messages={messages} id="customize" />
               </NavLink>
-              <Nav.Link onClick={() => window.open(CONTACT_US_LINK, '_blank')}>
-                Support Request
-              </Nav.Link>
-              <NavLink className="nav-link" to={ROUTES.Console.NOTICE_BOARD}>
-                Status & Notifications
-              </NavLink>
-              <NavLink className="nav-link" to={ROUTES.Auth.LOGOUT}>
-                Log out
-              </NavLink>
+
+              {lmsUrl && (
+                <a
+                  href={lmsUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="nav-link nav-lms-link"
+                >
+                  {deploymentPill}
+                  <span>
+                    <WrappedMessage messages={messages} id="visitLMS" />
+                  </span>
+                  <i className="fa fa-external-link-alt externalLinkIcon" />
+                </a>
+              )}
             </Route>
           </Nav>
         </Navbar.Collapse>
-      </Navbar>
-    </Container>
+        <Nav className="accounts-dropdown-nav order-2 order-md-3">
+          <Route path={ROUTES.Console.HOME}>
+            <NavDropdown
+              title={<i className="fa fa-user-circle account-dropdown-icon" />}
+              alignRight
+              id="accounts-dropdown"
+            >
+              <NavLink
+                exact
+                to=""
+                className="dropdown-item disabled"
+                onClick={e => {
+                  e.preventDefault();
+                }}
+              >
+                <WrappedMessage messages={messages} id="account" />
+              </NavLink>
+              <NavLink
+                className="dropdown-item"
+                to={ROUTES.Console.INSTANCE_SETTINGS_GENERAL}
+              >
+                <WrappedMessage messages={messages} id="siteSettings" />
+              </NavLink>
+              <NavLink
+                exact
+                to=""
+                className="dropdown-item disabled"
+                onClick={e => {
+                  e.preventDefault();
+                }}
+              >
+                <WrappedMessage messages={messages} id="domain" />
+              </NavLink>
+              <NavLink
+                className="dropdown-item"
+                to={ROUTES.Console.NOTICE_BOARD}
+              >
+                <WrappedMessage messages={messages} id="noticeBoard" />
+              </NavLink>
+              <NavLink className="dropdown-item" to={ROUTES.Auth.LOGOUT}>
+                <WrappedMessage messages={messages} id="logout" />
+              </NavLink>
+            </NavDropdown>
+          </Route>
+        </Nav>
+      </div>
+    </Navbar>
   );
 };
+
+export const Header = connect<StateProps, {}, {}, Props, RootState>(
+  (state: RootState) => state.console
+)(HeaderComponent);

--- a/frontend/src/ui/components/Header/__snapshots__/Header.spec.tsx.snap
+++ b/frontend/src/ui/components/Header/__snapshots__/Header.spec.tsx.snap
@@ -1,18 +1,18 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`renders without crashing 1`] = `
-<div
-  className="container"
+<nav
+  className="navbar navbar-expand-md navbar-dark"
 >
-  <nav
-    className="navbar navbar-expand-md navbar-dark bg-transparent"
+  <div
+    className="nav-container"
   >
     <span
-      className="logo-container mx-auto navbar-brand"
+      className="logo-container mr-auto order-0 navbar-brand"
     >
       <a
         aria-current="page"
-        className="nav-link active"
+        className="navbar-brand-link active"
         href="/"
         onClick={[Function]}
         style={Object {}}
@@ -29,7 +29,7 @@ exports[`renders without crashing 1`] = `
     <button
       aria-controls="basic-navbar-nav"
       aria-label="Toggle navigation"
-      className="navbar-toggler collapsed"
+      className="order-1 navbar-toggler collapsed"
       onClick={[Function]}
       type="button"
     >
@@ -39,7 +39,7 @@ exports[`renders without crashing 1`] = `
     </button>
     <div
       aria-expanded={null}
-      className="navbar-collapse collapse"
+      className="order-3 order-md-2 navbar-collapse collapse"
       id="basic-navbar-nav"
     >
       <div
@@ -47,6 +47,10 @@ exports[`renders without crashing 1`] = `
         onKeyDown={[Function]}
       />
     </div>
-  </nav>
-</div>
+    <div
+      className="accounts-dropdown-nav order-2 order-md-3 navbar-nav"
+      onKeyDown={[Function]}
+    />
+  </div>
+</nav>
 `;

--- a/frontend/src/ui/components/Header/displayMessages.ts
+++ b/frontend/src/ui/components/Header/displayMessages.ts
@@ -1,0 +1,44 @@
+const messages = {
+  faq: {
+    defaultMessage: 'FAQ',
+    description: 'Navbar link for FAQ page'
+  },
+  login: {
+    defaultMessage: 'Login',
+    description: 'Navbar link for Login page'
+  },
+  registration: {
+    defaultMessage: 'Create your account',
+    description: 'Navbar link for Registration page'
+  },
+  customize: {
+    defaultMessage: 'Customize',
+    description: 'Navbar link for Customization / Console page'
+  },
+  visitLMS: {
+    defaultMessage: 'My site (LMS)',
+    description: 'Navbar link for LMS'
+  },
+  siteSettings: {
+    defaultMessage: 'Site Settings',
+    description: 'Navbar link for Site Settings page'
+  },
+  account: {
+    defaultMessage: 'Account',
+    description: 'Navbar link for User Account page'
+  },
+  domain: {
+    defaultMessage: 'Domain',
+    description: 'Navbar link for Domain management page'
+  },
+  noticeBoard: {
+    defaultMessage: 'Status & Notifications',
+    description: 'Navbar link for Noticeboard page'
+  },
+  logout: {
+    defaultMessage: 'Logout',
+    description: 'Navbar link for Logout'
+  }
+};
+
+export default messages;

--- a/frontend/src/ui/components/Header/styles.scss
+++ b/frontend/src/ui/components/Header/styles.scss
@@ -7,31 +7,121 @@
 
   .site-logo {
     fill: #fff;
-    width: 152px;
-    height: 82px;
-    padding-top: 15px;
+    width: 100px;
+    height: 50px;
   }
 }
 
 /* change the link color */
 .navbar-dark {
+  padding: 0;
+  margin-left: -15px;
+  margin-right: -15px;
+  background-color: $primary-1;
+
   .navbar-toggler {
     border: none;
+  }
+
+  .navbar-brand {
+    padding: 20px;
+  }
+
+  .nav-container {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+    max-width: 1100px;
+    align-items: center;
+    justify-content: space-between;
+    width: 100%;
+    margin-left: auto;
+    margin-right: auto;
   }
 
   .navbar-nav .nav-link {
     font-family: $chivo-font;
     font-size: 20px;
-    letter-spacing: 0.72px;
+    letter-spacing: 0.6px;
     color: white;
     border-bottom: 3px solid transparent;
     padding-left: none;
     padding-right: none;
     margin: auto 7px;
 
-    &:hover, &:focus {
+    &:hover, &.active {
       color: white;
       border-bottom: 3px solid white;
     }
+
+    &:focus {
+      color: white;
+    }
+
+  }
+
+  .accounts-dropdown-nav{
+
+    .dropdown-toggle {
+      border-bottom: 0;
+      display: flex;
+
+      &:hover {
+        border-bottom: 0;
+      }
+    }
+
+    .account-dropdown-icon {
+      color: $primary-2;
+      font-size: 28px;
+    }
+
+    .dropdown-menu {
+      position: absolute;
+      box-shadow: 0 0 15px 0 rgba(0, 0, 0, 0.3);
+      padding: 0px;
+      right: 20px;
+      border: none;
+
+      a {
+        font-size: 16px;
+        color: $secondary-1;
+        padding: 10px 30px;
+        font-family: $chivo-font;
+
+        &:hover, &.active {
+          background-color: rgba(109, 156, 174, 0.2);
+        }
+
+        &.disabled {
+          color: #6c757d;
+        }
+      }
+    }
+
+    #accounts-dropdown::after {
+      display: none;
+    }
+  }
+
+  .nav-lms-link {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+
+    span {
+      margin: 0px 10px;
+    }
+
+    .externalLinkIcon {
+      font-size: 14px;
+    }
+  }
+}
+
+@media (min-width: 768px) {
+  .navbar-expand-md .navbar-nav .nav-link {
+    padding: 0;
+    margin: auto 25px;
   }
 }


### PR DESCRIPTION
This PR improves the Console UI header by re-organizing menu items for better usability.

**JIRA tickets**: https://tasks.opencraft.com/browse/BB-3498

**Discussions**: None

**Dependencies**: None

**Screenshots**: 
![Screenshot from 2021-01-22 23-45-14](https://user-images.githubusercontent.com/1010244/105526400-8f4b4e80-5d0c-11eb-9fcb-0f7f4808f245.png)

![Screenshot from 2021-01-22 23-45-39](https://user-images.githubusercontent.com/1010244/105526409-92463f00-5d0c-11eb-9e3f-fd5f79ad3ddf.png)


**Sandbox URL**: N/A

**Merge deadline**: None

**Testing instructions**:

1. Checkout this PR
2. Run Ocim - if vagrant stack, login to VirtualBox via - ``vagrant ssh`` and run ``make run.dev``
3. Run frontend from frontend folder - ``npm install && npm start``
4. Log in to the Ocim console.
5. On Desktop - the header should contain the ``Customize``, ``My site(LMS)`` link, and an accounts dropdown menu with a user icon.
6. ``My site(LMS)`` shows a link icon on the right.
7. ``My site(LMS)`` shows a deployment status indicator on left.
8. On Mobile / Smaller screens - A hamburger menu icon shows and ``Customize``, ``My site(LMS)`` link are collapsed under it.
9. Accounts dropdown should show on the right side of the Hamburger menu icon.

**Author notes and concerns**:

1. Deployment indicator and Custom Status pill use the same colors in their corresponding circles to show different deployment statuses.

**Reviewers**
- [ ] @Agrendalath 
