### PR TITLE
FAL-78 Fix the MKTG_URL_LINK_MAP override 

### DIFF
--- a/instance/models/mixins/openedx_config.py
+++ b/instance/models/mixins/openedx_config.py
@@ -83,19 +83,7 @@ class OpenEdXConfigMixin(ConfigMixinBase):
                     # use different contact page
                     "CONTACT": "/contact",
                 },
-                # default values
-                "MKTG_URL_LINK_MAP": {
-                    "FAQ": "help",
-                    "PRESS": "press",
-                    "SITEMAP.XML": "sitemap_xml",
-                    "COURSES": "courses",
-                    "ROOT": "root",
-                    "WHAT_IS_VERIFIED_CERT": "verified-certificate",
-                    # "BLOG": "blog",  not supported yet
-                    **self.instance.get_mktg_url_link(),
-                },
             },
-
             "EDXAPP_LMS_NGINX_PORT": 80,
             "EDXAPP_LMS_SSL_NGINX_PORT": 443,
             "EDXAPP_LMS_BASE_SCHEME": 'https',

--- a/instance/models/mixins/openedx_static_content_overrides.py
+++ b/instance/models/mixins/openedx_static_content_overrides.py
@@ -21,6 +21,7 @@ Instance app model mixins -  custom pages
 """
 
 # Imports #####################################################################
+import yaml
 
 from django.contrib.postgres.fields import JSONField
 from django.db import models
@@ -55,20 +56,13 @@ class OpenEdXStaticContentOverridesMixin(models.Model):
         help_text="Configure `MKTG_URL_LINK_MAP` to display/hide static pages",
     )
 
-    def get_mktg_url_link(self):
+    def marketing_links(self):
         """
-        Build MKTG_URL_LINK_MAP config.
-        Allow to display/hide static content pages
+        Prepare `EDXAPP_MKTG_URL_LINK_MAP`.
+
+        Support disabling of static pages on UI.
         """
-        mktg_url_link_map_config = {
-            "ABOUT": "about",
-            "CONTACT": "contact",
-            "DONATE": "donate",
-            "TOS": "tos",
-            "HONOR": "honor",
-            "PRIVACY": "privacy",
-        }
-        # It all pages were disabled - it will be empty dict, not None
-        if self.static_content_display is None:
-            return mktg_url_link_map_config
-        return self.static_content_display
+        result = {}
+        if self.static_content_display:
+            result = {key.upper(): value for key, value in self.static_content_display.items()}
+        return yaml.dump({"EDXAPP_MKTG_URL_LINK_MAP": result}, default_flow_style=False)

--- a/instance/models/openedx_appserver.py
+++ b/instance/models/openedx_appserver.py
@@ -279,12 +279,20 @@ class OpenEdXAppServer(AppServer, OpenEdXAppConfiguration, AnsibleAppServerMixin
         'configuration_storage_settings',
         'configuration_theme_settings',
         'configuration_secret_keys',
+        'configuration_marketing_links',
         # The extra settings should stay at the end of this list to allow manual overrides of all settings.
         'configuration_extra_settings',
     ]
 
     class Meta(AppServer.Meta):
         verbose_name = 'Open edX App Server'
+
+    @property
+    def configuration_marketing_links(self):
+        """
+        Get `EDXAPP_MKTG_URL_LINK_MAP` values.
+        """
+        return self.instance.marketing_links()
 
     def make_active(self, active=True):
         """

--- a/registration/api/v2/serializers.py
+++ b/registration/api/v2/serializers.py
@@ -292,7 +292,7 @@ class DisplayStaticContentPagesSerializer(DataSerializer):
     privacy = serializers.BooleanField()
 
     def to_representation(self, instance):
-        return instance.instance.get_mktg_url_link()
+        return instance.static_content_display
 
 
 class OpenEdXInstanceConfigSerializer(serializers.ModelSerializer):

--- a/registration/models.py
+++ b/registration/models.py
@@ -509,26 +509,17 @@ class BetaTestApplication(ValidateModelMixin, TimeStampedModel):
             "privacy": True,
         }
 
-    def get_mktg_url_link(self):
+    def get_disabled_mktg_links(self):
         """
-        Build MKTG_URL_LINK_MAP config.
-        Allow to display/hide static content pages
+        Get disabled MKTG links.
         """
-        mktg_url_link_map_config = {
-            "ABOUT": "about",
-            "CONTACT": "contact",
-            "DONATE": "donate",
-            "TOS": "tos",
-            "HONOR": "honor",
-            "PRIVACY": "privacy",
-        }
-
+        result = []
         if self.configuration_display_static_pages:
             for page_name, enabled in self.configuration_display_static_pages.items():
                 if not enabled:
-                    del mktg_url_link_map_config[page_name.upper()]
-
-        return mktg_url_link_map_config
+                    result.append(page_name)
+            return {page_name: None for page_name in result}
+        return {}
 
     def commit_changes_to_instance(
             self,
@@ -553,7 +544,7 @@ class BetaTestApplication(ValidateModelMixin, TimeStampedModel):
 
         instance.theme_config = self.draft_theme_config
         instance.static_content_overrides = self.draft_static_content_overrides
-        instance.static_content_display = self.get_mktg_url_link()
+        instance.static_content_display = self.get_disabled_mktg_links()
         instance.name = self.instance_name
         instance.privacy_policy_url = self.privacy_policy_url
         instance.email = self.public_contact_email

--- a/registration/tests/test_api.py
+++ b/registration/tests/test_api.py
@@ -1093,18 +1093,21 @@ class OpenEdXInstanceConfigAPITestCase(APITestCase):
             format='json'
         )
         self.assertEqual(response.status_code, 200)
-        expected_mktg_url_link_map = {
-            'CONTACT': 'contact',
-            'DONATE': 'donate',
-            'HONOR': 'honor',
-            'PRIVACY': 'privacy',
-            'TOS': 'tos',
-        }
         self.instance_config.refresh_from_db()
         # Check that static page about is disabled after API request
         self.assertEqual(self.instance_config.configuration_display_static_pages, {'about': False})
         # Check that about page doesn't exists for MKTG_URL_LINK_MAP config
-        self.assertEqual(self.instance_config.get_mktg_url_link(), expected_mktg_url_link_map)
+        self.instance_config.commit_changes_to_instance()
+        self.instance_config.refresh_from_db()
+        marketing_links = yaml.load(
+            self.instance_config.instance.marketing_links(),
+            Loader=yaml.SafeLoader
+        )
+
+        self.assertEqual(
+            marketing_links['EDXAPP_MKTG_URL_LINK_MAP'],
+            {'ABOUT': None}
+        )
 
     def test_disabling_all_static_pages(self):
         """
@@ -1119,7 +1122,6 @@ class OpenEdXInstanceConfigAPITestCase(APITestCase):
             {"page_name": "tos", "enabled": False},
             {"page_name": "honor", "enabled": False},
             {"page_name": "privacy", "enabled": False},
-            {"page_name": "tos", "enabled": False},
         ]
 
         for payload in static_pages_payload:
@@ -1132,8 +1134,24 @@ class OpenEdXInstanceConfigAPITestCase(APITestCase):
                 format='json'
             )
         self.instance_config.refresh_from_db()
+        self.instance_config.commit_changes_to_instance()
+
+        marketing_links = yaml.load(
+            self.instance_config.instance.marketing_links(),
+            Loader=yaml.SafeLoader
+        )
         # Check that all static pages are disabled after API request
-        self.assertEqual(self.instance_config.get_mktg_url_link(), {})
+        self.assertEqual(
+            marketing_links['EDXAPP_MKTG_URL_LINK_MAP'],
+            {
+                'ABOUT': None,
+                'CONTACT': None,
+                'DONATE': None,
+                'HONOR': None,
+                'PRIVACY': None,
+                'TOS': None,
+            }
+        )
 
     def test_disabling_static_pages_existing_instances(self):
         """
@@ -1144,39 +1162,7 @@ class OpenEdXInstanceConfigAPITestCase(APITestCase):
         # Check that static page about is disabled after API request
         self.assertEqual(self.instance_config.configuration_display_static_pages, None)
         # Check that about page doesn't exists for MKTG_URL_LINK_MAP config
-        self.assertEqual(
-            self.instance_config.get_mktg_url_link(),
-            {
-                "ABOUT": "about",
-                "CONTACT": "contact",
-                "DONATE": "donate",
-                "TOS": "tos",
-                "HONOR": "honor",
-                "PRIVACY": "privacy",
-            }
-        )
-
-    def test_instance_appserver_configuration_disabled_static_pages(self):
-        """
-        Test appserver ansible configuration variabled
-        """
-        self.client.force_login(self.user_with_instance)
-        self._setup_user_instance()
-        self.instance_config.commit_changes_to_instance()
-
-        appserver = self.instance_config.instance._create_owned_appserver()
-        configuration_settings = yaml.load(appserver.configuration_settings, Loader=yaml.SafeLoader)
-
-        # This is the required custom pages
-        base_custom_pages = ['FAQ', 'PRESS', 'SITEMAP.XML', 'COURSES', 'ROOT', 'WHAT_IS_VERIFIED_CERT']
-        # It is possible to enable/disable custom pages
-        custom_pages = ['ABOUT', 'CONTACT', 'DONATE', 'TOS', 'HONOR', 'PRIVACY']
-
-        for page in custom_pages + base_custom_pages:
-            self.assertTrue(page in configuration_settings['EDXAPP_LMS_ENV_EXTRA']['MKTG_URL_LINK_MAP'])
-
-        # Test that BLOG static page is disabled
-        self.assertTrue('BLOG' not in configuration_settings['EDXAPP_LMS_ENV_EXTRA']['MKTG_URL_LINK_MAP'])
+        self.assertEqual(self.instance_config.get_disabled_mktg_links(), {})
 
     def test_instance_appserver_configuration_reflect_on_disabled_pages(self):
         """
@@ -1201,12 +1187,8 @@ class OpenEdXInstanceConfigAPITestCase(APITestCase):
         configuration_settings = yaml.load(appserver.configuration_settings, Loader=yaml.SafeLoader)
 
         # This page was disabled
-        self.assertTrue('ABOUT' not in configuration_settings['EDXAPP_LMS_ENV_EXTRA']['MKTG_URL_LINK_MAP'])
-
-        base_custom_pages = ['FAQ', 'PRESS', 'SITEMAP.XML', 'COURSES', 'ROOT', 'WHAT_IS_VERIFIED_CERT']
-        custom_pages = ['CONTACT', 'DONATE', 'TOS', 'HONOR', 'PRIVACY']
-        for page in custom_pages + base_custom_pages:
-            self.assertTrue(page in configuration_settings['EDXAPP_LMS_ENV_EXTRA']['MKTG_URL_LINK_MAP'])
+        self.assertTrue('ABOUT' in configuration_settings['EDXAPP_MKTG_URL_LINK_MAP'])
+        self.assertFalse(configuration_settings['EDXAPP_MKTG_URL_LINK_MAP']['ABOUT'])
 
     def test_check_config_urls(self):
         """


### PR DESCRIPTION
This PR is about resolving conflicts for the **MKTG_URL_LINK_MAP** configuration.

### Description

The issue with the previous implementation happens for juniper.3 release. 
- https://github.com/open-craft/edx-platform/blob/opencraft-release/juniper.3/common/djangoapps/edxmako/shortcuts.py#L93

For testing master branch was used. 
- https://github.com/edx/edx-platform/blob/master/common/djangoapps/edxmako/shortcuts.py#L96

This PR was tested on both environments and work fine for master and juniper.3 .
 

**Testing instruction:**
- Follow testing instruction in the ticket details 

**Authors notes:**
- Included API client updates 
- Instead of injecting the full list into MKTG_URL_LINK_MAP - this code will add only disabled pages