### PR TITLE
[BB-3594] Header Login button is aware of auth token

### DIFF
--- a/frontend/src/ui/components/App/__snapshots__/App.spec.tsx.snap
+++ b/frontend/src/ui/components/App/__snapshots__/App.spec.tsx.snap
@@ -14,11 +14,10 @@ exports[`renders without crashing 1`] = `
         className="logo-container mr-auto order-0 navbar-brand"
       >
         <a
-          aria-current="page"
-          className="navbar-brand-link active"
-          href="/"
+          aria-current={null}
+          className="navbar-brand-link"
+          href="/console"
           onClick={[Function]}
-          style={Object {}}
         >
           <svg
             className="site-logo"

--- a/frontend/src/ui/components/Header/Header.tsx
+++ b/frontend/src/ui/components/Header/Header.tsx
@@ -15,6 +15,7 @@ interface StateProps extends InstancesModel {}
 
 interface Props extends StateProps {
   children: React.ReactNode;
+  access: string;
 }
 
 export const HeaderComponent: React.FC<Props> = (props: Props) => {
@@ -42,7 +43,7 @@ export const HeaderComponent: React.FC<Props> = (props: Props) => {
     <Navbar expand="md" variant="dark">
       <div className="nav-container">
         <Navbar.Brand className="logo-container mr-auto order-0">
-          <NavLink className="navbar-brand-link" to="/">
+          <NavLink className="navbar-brand-link" to={ROUTES.Console.HOME}>
             <svg className="site-logo">
               <use xlinkHref={`${logo}#opencraft_logo`} />
             </svg>
@@ -59,9 +60,15 @@ export const HeaderComponent: React.FC<Props> = (props: Props) => {
               >
                 <WrappedMessage messages={messages} id="faq" />
               </Nav.Link>
-              <NavLink className="nav-link" to={ROUTES.Auth.LOGIN}>
-                <WrappedMessage messages={messages} id="login" />
-              </NavLink>
+              {props.access !== '' ? (
+                <NavLink className="nav-link" to={ROUTES.Console.HOME}>
+                  <WrappedMessage messages={messages} id="goToConsole" />
+                </NavLink>
+              ) : (
+                <NavLink className="nav-link" to={ROUTES.Auth.LOGIN}>
+                  <WrappedMessage messages={messages} id="login" />
+                </NavLink>
+              )}
             </Route>
             <Route path={ROUTES.Auth.LOGIN}>
               <NavLink className="nav-link" to={ROUTES.Registration.HOME}>
@@ -148,5 +155,8 @@ export const HeaderComponent: React.FC<Props> = (props: Props) => {
 };
 
 export const Header = connect<StateProps, {}, {}, Props, RootState>(
-  (state: RootState) => state.console
+  (state: RootState) => ({
+    ...state.loginState,
+    ...state.console
+  })
 )(HeaderComponent);

--- a/frontend/src/ui/components/Header/__snapshots__/Header.spec.tsx.snap
+++ b/frontend/src/ui/components/Header/__snapshots__/Header.spec.tsx.snap
@@ -11,11 +11,10 @@ exports[`renders without crashing 1`] = `
       className="logo-container mr-auto order-0 navbar-brand"
     >
       <a
-        aria-current="page"
-        className="navbar-brand-link active"
-        href="/"
+        aria-current={null}
+        className="navbar-brand-link"
+        href="/console"
         onClick={[Function]}
-        style={Object {}}
       >
         <svg
           className="site-logo"

--- a/frontend/src/ui/components/Header/displayMessages.ts
+++ b/frontend/src/ui/components/Header/displayMessages.ts
@@ -38,6 +38,10 @@ const messages = {
   logout: {
     defaultMessage: 'Logout',
     description: 'Navbar link for Logout'
+  },
+  goToConsole: {
+    defaultMessage: 'Go to console',
+    description: 'Console is available when logged in'
   }
 };
 


### PR DESCRIPTION
We're fulfilling the following user story:

> "As a OCIM developer, I want to make the page be aware of logged in status of user so that I can help the user to go to console"

In the Congratulations page, the user is actually logged in, but the page header shows the Login button. Make it aware that the user is logged in and change the text to “go to console”.

**JIRA tickets**: [BB-3594](https://tasks.opencraft.com/browse/BB-3594)

**Screenshots**: See Jira ticket

**Merge deadline**: "None" 

**Testing instructions**:

1. Pull this branch to your local OCIM environment.
2. Make the suggested change below on `src/registration/components/CongratulationsPage/CongratulationsPage.tsx`, line 37, and test logging in, out and changing the suggested `true` to `false`: 
 ```
    {true && (
          <RedirectToCorrectStep
            currentPageStep={4}
            currentRegistrationStep={this.props.currentRegistrationStep}
          />
    )}
```
Then head to `registration/congrats`.

**Author notes and concerns**:

1. Currently, the user can only log out from inside the console, it should be possible to log out from outside the console, too. Maybe adding another NavLink below FAQ.

**Reviewers**
- [ ] @farhaanbukhsh 