### PR TITLE
Revert "Fix Koa integration tests (#682)"

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -122,7 +122,6 @@ jobs:
           DEBUG: 'true'
           DEFAULT_FORK: 'open-craft/edx-platform'
           LOAD_BALANCER_FRAGMENT_NAME_PREFIX: 'integration-'
-          SIMPLE_THEME_SKELETON_THEME_VERSION: 'samuel/remove-v2'
       - image: redis
       - image: mongo:3.2-jessie
       - image: "circleci/mysql:5"

--- a/instance/tests/integration/factories/instance.py
+++ b/instance/tests/integration/factories/instance.py
@@ -79,8 +79,8 @@ class OpenEdXInstanceFactory(DjangoModelFactory):
     # or a release candidate tag will work.  We point both the edx-platform and the configuration
     # versions to the branch "integration" in our own forks.  These branches are based on the
     # corresponding openedx_release versions from upstream, but can contain custom modifications.
-    openedx_release = 'open-release/koa.master'
+    openedx_release = 'open-release/juniper.3'
     configuration_source_repo_url = 'https://github.com/open-craft/configuration.git'
-    configuration_version = 'integration-koa'
+    configuration_version = 'integration-juniper'
     edx_platform_repository_url = 'https://github.com/open-craft/edx-platform.git'
-    edx_platform_commit = 'opencraft-release/koa.1'
+    edx_platform_commit = 'opencraft-release/juniper.3'

--- a/playbooks/collect_activity/collect_activity.yml
+++ b/playbooks/collect_activity/collect_activity.yml
@@ -22,7 +22,7 @@
     - name: Run collect_activity script
       shell: >
         . /edx/app/edxapp/edxapp_env &&
-        python /tmp/collect_activity.py
+        /edx/bin/python.edxapp /tmp/collect_activity.py
         --config-section {{ config_section | default(inventory_hostname) }}
         --out {{ remote_output_filename }}
         {{ extra_script_arguments }}

--- a/playbooks/collect_activity/stats.py
+++ b/playbooks/collect_activity/stats.py
@@ -1,4 +1,4 @@
-#!/edx/app/edxapp/venvs/edxapp/bin/python
+#!/edx/bin/python.edxapp
 # pylint: skip-file
 
 from __future__ import print_function


### PR DESCRIPTION
This reverts commit https://github.com/open-craft/opencraft/commit/853f9953ca2abe8c7be3726663f26b19ad6377ca. This is causing integration tests to fail as the default release of OCIM is still Juniper.