### PR TITLE
[BB-3387] Use forum common branch for Juniper

### DIFF
--- a/instance/models/mixins/openedx_config.py
+++ b/instance/models/mixins/openedx_config.py
@@ -483,9 +483,9 @@ class OpenEdXConfigMixin(ConfigMixinBase):
             template["forum_source_repo"] = "https://github.com/open-craft/cs_comments_service.git"
             template["forum_version"] = "opencraft-release/ironwood.2"
         if self._is_openedx_release_in(['juniper']):
-            template["forum_source_repo"] = "https://github.com/edx/cs_comments_service.git"
-            template["forum_version"] = "open-release/juniper.master"
-            template["FORUM_VERSION"] = "open-release/juniper.master"
+            template["forum_source_repo"] = "https://github.com/open-craft/cs_comments_service.git"
+            template["forum_version"] = "opencraft-release/juniper.3"
+            template["FORUM_VERSION"] = "opencraft-release/juniper.3"
 
         return template
 


### PR DESCRIPTION
Description
------------

This PR changes the forum repository and branch used to deploy new instances.

It replaces the upstream `open-release/juniper.master` with our own `opencraft-release/juniper.3` repo/branch.

Testing
--------

1. Check out this branch on a Stage or Dev environment.
1. Create an [instance](https://bb3387-forum-juniper-3.stage.opencraft.hosting/).
1. Spawn a new AppServer for the new instance.
1. Wait for provisioning to check out the forum code and check the correct repo/branch have been used.