### PR TITLE
[FAL-873] Prettify ansible output

### DIFF
--- a/instance/ansible.py
+++ b/instance/ansible.py
@@ -33,9 +33,16 @@ from django.conf import settings
 
 from instance.utils import poll_streams, create_temp_dir
 
+
 # Logging #####################################################################
 
 logger = logging.getLogger(__name__)
+
+
+# Custom ansible plugins ######################################################
+
+ANSIBLE_CALLBACKS_DIR = os.path.join(os.path.dirname(__file__), 'ansible_callbacks')
+ANSIBLE_STDOUT_CALLBACK = 'prettify'
 
 
 # Functions ###################################################################
@@ -154,6 +161,10 @@ def run_playbook(requirements_path, inventory_str, vars_str, playbook_path, play
         # Disable SSH host key checking by Ansible – since IP addresses are constantly reused,
         # changing host keys are expected.
         env['ANSIBLE_HOST_KEY_CHECKING'] = 'false'
+
+        # Use a custom output callback to make ansible logs more readable.
+        env['ANSIBLE_CALLBACK_PLUGINS'] = ANSIBLE_CALLBACKS_DIR
+        env['ANSIBLE_STDOUT_CALLBACK'] = ANSIBLE_STDOUT_CALLBACK
 
         yield subprocess.Popen(
             cmd,

--- a/instance/ansible_callbacks/prettify.py
+++ b/instance/ansible_callbacks/prettify.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+#
+# OpenCraft -- tools to aid developing and hosting free software projects
+# Copyright (C) 2015-2019 OpenCraft <contact@opencraft.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+# We need absolute_import to prevent ansible's json callback module from
+# shadowing the python built-in json module.
+from __future__ import absolute_import
+import json
+from ansible.plugins.callback.default import CallbackModule as DefaultCallback
+
+class CallbackModule(DefaultCallback):
+    """
+    Ansible callback module which tweaks the default ansible output to make it more reable.
+    """
+
+    CALLBACK_VERSION = 2.0
+    CALLBACK_TYPE = 'stdout'
+    CALLBACK_NAME = 'prettify'
+
+    def _get_item_label(self, result):
+        """
+        Overrides the DefaultCallback's `_get_item_label` method to returned a readable
+        json representation of the item instead of a raw python dump.
+        """
+        item = super(CallbackModule, self)._get_item_label(result)
+        return json.dumps(item, indent=2, ensure_ascii=False)
+
+    def _dump_results(self, result, indent=2, sort_keys=False, keep_invocation=False):
+        """
+        Overrides the DefaultCallback's `_dump_results` to indent the json output by default.
+        """
+        return super(CallbackModule, self)._dump_results(
+            result,
+            indent=indent,
+            sort_keys=sort_keys,
+            keep_invocation=keep_invocation
+        )

--- a/instance/ansible_callbacks/prettify.py
+++ b/instance/ansible_callbacks/prettify.py
@@ -34,19 +34,8 @@ class CallbackModule(DefaultCallback):
 
     def _get_item_label(self, result):
         """
-        Overrides the DefaultCallback's `_get_item_label` method to returned a readable
-        json representation of the item instead of a raw python dump.
+        Overrides the DefaultCallback's `_get_item_label` method to return
+        a json representation of the item instead of a raw python dump.
         """
         item = super(CallbackModule, self)._get_item_label(result)
-        return json.dumps(item, indent=2, ensure_ascii=False)
-
-    def _dump_results(self, result, indent=2, sort_keys=False, keep_invocation=False):
-        """
-        Overrides the DefaultCallback's `_dump_results` to indent the json output by default.
-        """
-        return super(CallbackModule, self)._dump_results(
-            result,
-            indent=indent,
-            sort_keys=sort_keys,
-            keep_invocation=keep_invocation
-        )
+        return json.dumps(item, ensure_ascii=False)

--- a/instance/static/html/instance/appserver.html
+++ b/instance/static/html/instance/appserver.html
@@ -205,7 +205,7 @@
            ng-repeat="line in appserverLogs.log_error_entries track by $index">
         <span class="timestamp">{{ line.created | date:'yyyy-MM-dd HH:mm:ssZ' }}</span>
         <span class="log-level">{{ line.level }}</span>
-        <pre>{{ line.text | stripLogMeta }}</pre>
+        <pre>{{ line.text | stripLogMeta | prettifyJSON }}</pre>
       </div>
     </div>
     <div class="instance-log-section" ng-if="appserverLogs != null">
@@ -214,7 +214,7 @@
            ng-repeat="line in appserverLogs.log_entries track by $index">
         <span class="timestamp">{{ line.created | date:'yyyy-MM-dd HH:mm:ssZ' }}</span>
         <span class="log-level">{{ line.level }}</span>
-        <pre>{{ line.text | stripLogMeta }}</pre>
+        <pre>{{ line.text | stripLogMeta | prettifyJSON }}</pre>
       </div>
     </div>
   </accordion-group>

--- a/instance/static/js/src/openedx_appserver.js
+++ b/instance/static/js/src/openedx_appserver.js
@@ -139,7 +139,36 @@ app.controller("OpenEdXAppServerDetails", ['$scope', '$state', '$stateParams', '
 // "instance.models.appserver | instance=60 (Instance),app_server=12 (AppServer 1) | "
 app.filter('stripLogMeta', function() {
     return function(input) {
-      return input.split(' | ').slice(2).join(' | ');
+        return input.split(' | ').slice(2).join(' | ');
+    };
+});
+
+// This custom filter pretty prints JSON structures from ansible output log.
+app.filter('prettifyJSON', function() {
+    return function(input) {
+        var result = input;
+        var trimmed = input.trim();
+        // Checks for common ansible output patterns that may contain JSON data.
+        var patterns = [
+            / => ({[\s\S]*})$/,            // task result as an object
+            / => \(item=({[\s\S]*})\)$/,   // item result as an object
+            / => \(item=(\[[\s\S]*\])\)$/  // item result as an array
+        ];
+        for (var i = 0; i < patterns.length; i++) {
+            var match = trimmed.match(patterns[i]);
+            if (match) {
+                try {
+                    var json = JSON.parse(match[1]);
+                    var pretty_printed = JSON.stringify(json, null, 4);
+                    // Replace the matched portion with pretty-printed JSON.
+                    result = result.replace(match[1], pretty_printed);
+                    break;
+                } catch (err) {
+                    // ignore
+                }
+            }
+        }
+        return result;
     };
 });
 

--- a/instance/static/js/src/openedx_appserver.js
+++ b/instance/static/js/src/openedx_appserver.js
@@ -159,6 +159,15 @@ app.filter('prettifyJSON', function() {
             if (match) {
                 try {
                     var json = JSON.parse(match[1]);
+                    // stdout and stdout_lines contain the same data, except that stdout_lines is nicely
+                    // broken by newlines while stdout is much less readable. Remove stdout if both are present.
+                    if (json.hasOwnProperty('stdout') && json.hasOwnProperty('stdout_lines')) {
+                        delete json.stdout;
+                    }
+                    // Do the same for stderr/stderr_lines
+                    if (json.hasOwnProperty('stderr') && json.hasOwnProperty('stderr_lines')) {
+                        delete json.stderr;
+                    }
                     var pretty_printed = JSON.stringify(json, null, 4);
                     // Replace the matched portion with pretty-printed JSON.
                     result = result.replace(match[1], pretty_printed);

--- a/instance/static/scss/instance.scss
+++ b/instance/static/scss/instance.scss
@@ -148,7 +148,7 @@ ul.side-nav li.active {
         }
         &.error,
         &.critical {
-            background-color: #ffd8d8;
+            color: #ff0000;
         }
     }
 

--- a/instance/tests/integration/ansible/requirements.txt
+++ b/instance/tests/integration/ansible/requirements.txt
@@ -1,1 +1,1 @@
-ansible==2.8.15
+ansible==2.8.17

--- a/instance/tests/integration/ansible/requirements.txt
+++ b/instance/tests/integration/ansible/requirements.txt
@@ -1,1 +1,1 @@
-git+https://github.com/edx/ansible.git@stable-1.9-plus-edx#egg=ansible==1.9.1-edx.2
+ansible==2.8.15

--- a/instance/tests/js/instance_app_spec.js
+++ b/instance/tests/js/instance_app_spec.js
@@ -501,6 +501,38 @@ describe('Instance app', function () {
             });
         });
     });
+
+    describe('prettifyJSON filter', function() {
+        var prettifyJSON;
+
+        beforeEach(inject(function($filter) {
+            prettifyJSON = $filter('prettifyJSON');
+        }));
+
+        it('prettifies JSON snippets from ansible output', function() {
+            expect(prettifyJSON('ok => not json')).toEqual('ok => not json');
+            expect(prettifyJSON('ok => {not: json either}')).toEqual('ok => {not: json either}');
+            expect(prettifyJSON('ok => {"result": "some json result", "value": 42}')).toEqual([
+              'ok => {',
+              '    "result": "some json result",',
+              '    "value": 42',
+              '}'
+            ].join('\n'));
+            expect(prettifyJSON('error => (item={"result": "item result"})')).toEqual([
+              'error => (item={',
+              '    "result": "item result"',
+              '})'
+            ].join('\n'));
+            expect(prettifyJSON('out => (item=["result", "is", "an", "array"])')).toEqual([
+              'out => (item=[',
+              '    "result",',
+              '    "is",',
+              '    "an",',
+              '    "array"',
+              '])'
+            ].join('\n'));
+        });
+    });
 });
 
 })();

--- a/instance/tests/js/instance_app_spec.js
+++ b/instance/tests/js/instance_app_spec.js
@@ -532,6 +532,23 @@ describe('Instance app', function () {
               '])'
             ].join('\n'));
         });
+
+        it('removes stdout/stderr entries from JSON snippets', function() {
+            expect(prettifyJSON('ok => {"stdout": "", "stdout_lines": [], "value": 42}')).toEqual([
+              'ok => {',
+              '    "stdout_lines": [],',
+              '    "value": 42',
+              '}'
+            ].join('\n'));
+            expect(prettifyJSON('ok => {"stderr": "Error!\\nAbort!", "stderr_lines": ["Error!","Abort!"]}')).toEqual([
+              'ok => {',
+              '    "stderr_lines": [',
+              '        "Error!",',
+              '        "Abort!"',
+              '    ]',
+              '}'
+            ].join('\n'));
+        });
     });
 });
 

--- a/instance/tests/test_ansible.py
+++ b/instance/tests/test_ansible.py
@@ -137,6 +137,9 @@ class AnsibleTestCase(TestCase):
             call_kwargs = mock_popen.mock_calls[0][2]
             self.assertIn('env', call_kwargs)
             self.assertEqual(call_kwargs['env']['TMPDIR'], '/tmp/tempdir')
+            self.assertEqual(call_kwargs['env']['ANSIBLE_STDOUT_CALLBACK'], 'prettify')
+            callbacks_dir = os.path.dirname(__file__).replace('/instance/tests', '/instance/ansible_callbacks')
+            self.assertEqual(call_kwargs['env']['ANSIBLE_CALLBACK_PLUGINS'], callbacks_dir)
 
     def test_render_command(self):
         """


### PR DESCRIPTION
**Description**

This tweaks ansible output to make it valid JSON in more cases than the defaults.
It then uses some JS on the frontend to identify and pretty-print JSON fragments in ansible output.

**Screenshot**

<img width="926" alt="Screenshot 2021-03-17 at 09 36 06" src="https://user-images.githubusercontent.com/32585/111438179-3b555880-8704-11eb-9161-b73ade87a6d7.png">

**Testing**

This was deployed to stage, so you can check the logs of appservers that were spawned when the code was active on stage. You can use these two:

- https://stage.manage.opencraft.com/instance/7420/edx-appserver/3170/
- https://stage.manage.opencraft.com/instance/7400/edx-appserver/3171/

**Reviewers**

- [ ] @tartansandal 