### PR TITLE
[BB-3701] Bugfix: Colliding className from Logo and CustomStatusPill components

### DIFF
--- a/frontend/src/console/components/Logos/Logos.tsx
+++ b/frontend/src/console/components/Logos/Logos.tsx
@@ -71,7 +71,7 @@ export class LogosComponent extends React.PureComponent<Props, State> {
               <Col md={3} className="image-container">
                 <div>
                   {instance.data && instance.data.favicon && (
-                    <img src={instance.data.favicon} alt="favicon" />
+                    <img src={instance.data.favicon} alt="Favicon" />
                   )}
                 </div>
               </Col>

--- a/frontend/src/console/components/Logos/styles.scss
+++ b/frontend/src/console/components/Logos/styles.scss
@@ -21,6 +21,7 @@
     img {
       max-width: 100%;
       max-height: 100%;
+      font-size: 0px;
     }
   }
 }

--- a/frontend/src/ui/components/ImageUploadField/ImageUploadField.tsx
+++ b/frontend/src/ui/components/ImageUploadField/ImageUploadField.tsx
@@ -51,7 +51,7 @@ export const ImageUploadField: React.FC<ImageUploadFieldProps> = (
 
   if (props.parentMessages && props.tooltipTextId) {
     tooltip = (
-      <Tooltip className="tooltip" id={props.tooltipTextId}>
+      <Tooltip className="image-upload-tooltip" id={props.tooltipTextId}>
         <p>
           <WrappedMessage
             messages={props.parentMessages}

--- a/frontend/src/ui/components/ImageUploadField/styles.scss
+++ b/frontend/src/ui/components/ImageUploadField/styles.scss
@@ -99,7 +99,7 @@
     }
 }
 
-.tooltip {
+.image-upload-tooltip {
     padding-left: 130px;
     .tooltip-inner{
         background-color: $secondary-1;


### PR DESCRIPTION
Because class names collided on different PRs, we see a bug in the Tooltips styles:

![image](https://user-images.githubusercontent.com/33784039/110020450-f0007a80-7cff-11eb-9e9b-654025e4bd12.png)


We're fixing it to:
![image](https://user-images.githubusercontent.com/33784039/110020473-f68ef200-7cff-11eb-96be-8afa7682ef99.png)
