### PR TITLE
Updates installation page in response to Issue 729

### DIFF
--- a/documentation/installation.md
+++ b/documentation/installation.md
@@ -54,7 +54,7 @@ repository – most notably Ansible:
 
 Now you can run:
 
-    vagrant up
+    vagrant --provision up
 
 This will provision a virtual machine running Ubuntu 16.04, set up local
 Postgres, MySQL, MongoDB and Redis, and install the dependencies.


### PR DESCRIPTION
Changes 'vagrant up' to 'vagrant --provision up'

https://github.com/open-craft/opencraft/issues/729