### PR TITLE
Check subdomain name validity for instance factories.

### DIFF
--- a/instance/factories.py
+++ b/instance/factories.py
@@ -23,6 +23,7 @@ Instance app - Factory functions for creating instances
 # Imports #####################################################################
 
 import logging
+import re
 import yaml
 
 from django.conf import settings
@@ -66,6 +67,17 @@ def _check_environment():
     return True
 
 
+def is_valid_domain_name(sub_domain):
+    """
+    Validate subdomain names passed to instance factory functions,
+    using the same regex as the BetaTestApplication.subdomain field validator.
+    """
+
+    regex = r'^[a-z0-9]([a-z0-9\-]+[a-z0-9])?$'
+
+    return re.match(regex, sub_domain)
+
+
 def instance_factory(**kwargs):
     """
     Factory function for creating instances.
@@ -86,6 +98,7 @@ def instance_factory(**kwargs):
     """
     # Ensure caller provided required arguments
     assert "sub_domain" in kwargs
+    assert is_valid_domain_name(kwargs.get('sub_domain'))
 
     # Create instance
     instance = OpenEdXInstance.objects.create(**kwargs)
@@ -116,6 +129,7 @@ def production_instance_factory(**kwargs):
 
     # Ensure caller provided required arguments
     assert "sub_domain" in kwargs
+    assert is_valid_domain_name(kwargs.get('sub_domain'))
 
     # Check environment and report potential problems
     environment_ready = _check_environment()

--- a/instance/tests/test_factories.py
+++ b/instance/tests/test_factories.py
@@ -102,6 +102,16 @@ class FactoriesTestCase(TestCase):
         custom_instance = OpenEdXInstance.objects.get(pk=custom_instance.pk)
         self._assert_field_values(custom_instance, sub_domain, **self.PRODUCTION_DEFAULTS)
 
+        # Create instance with underscore in domain name
+        sub_domain = "bad_domain_name"
+        with self.assertRaises(AssertionError):
+            instance_factory(sub_domain=sub_domain)
+
+        # Create instance with not all lowercase domain name
+        sub_domain = "Bad-Domain"
+        with self.assertRaises(AssertionError):
+            instance_factory(sub_domain=sub_domain)
+
         # Calling factory without specifying "sub_domain" should result in an error
         with self.assertRaises(AssertionError):
             instance_factory()


### PR DESCRIPTION
Add extra asserts for when calling the instance factory methods
from the Django shell and there's no previous validation step involved.
This prevents domain names that are duplicates and only differ in case,
or domains with invalid characters in them which will cause problems
later in provisioning.