### PR TITLE
[BB-3787] [NewConsole] Move color component to sidebar

### DIFF
--- a/frontend/src/console/components/CoursesManage/__snapshots__/CoursesManage.spec.tsx.snap
+++ b/frontend/src/console/components/CoursesManage/__snapshots__/CoursesManage.spec.tsx.snap
@@ -58,7 +58,7 @@ exports[`renders without crashing 1`] = `
         className="container-fluid"
       >
         <div
-          className="justify-content-center row"
+          className="justify-content-center console-page-inner-content row"
         >
           <div
             className="col-md-3"
@@ -96,7 +96,7 @@ exports[`renders without crashing 1`] = `
                         href="/console/theming/preview-and-colors"
                         onClick={[Function]}
                       >
-                        Preview & colors
+                        Colors
                       </a>
                       <a
                         aria-current={null}

--- a/frontend/src/console/components/CustomizationSideMenu/displayMessages.ts
+++ b/frontend/src/console/components/CustomizationSideMenu/displayMessages.ts
@@ -3,6 +3,10 @@ const messages = {
     defaultMessage: 'Theme',
     description: 'The name of the theme menu in the sidebar accordion.'
   },
+  linkColors: {
+    defaultMessage: 'Colors',
+    description: 'Edit Colors'
+  },
   linkPreviewColors: {
     defaultMessage: 'Preview & colors',
     description: 'Menu name.'

--- a/frontend/src/console/components/ThemeColors/styles.scss
+++ b/frontend/src/console/components/ThemeColors/styles.scss
@@ -1,7 +1,6 @@
 @import '~styles/theme';
 
 .side-buttons {
-  padding: 0 15px 0 0;
 
   .row {
     display: flex;

--- a/frontend/src/newConsole/components/ColorsComponent/ColorsComponent.spec.tsx
+++ b/frontend/src/newConsole/components/ColorsComponent/ColorsComponent.spec.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { setupComponentForTesting } from "utils/testing";
+import { Colors } from './ColorsComponent';
+
+it('renders without crashing', () => {
+  const tree = setupComponentForTesting(
+    <Colors />,
+      {
+        console: {
+          loading: false,
+          activeInstance: {
+            data: {
+              id: 1,
+              instanceName: "test",
+              subdomain: "test",
+              draftThemeConfig: {
+                version: 1,
+                mainColor: "#444444",
+                linkColor: "#FFAAFF"
+              },
+              draftStaticContentOverrides: {
+                homepageOverlayHtml: "Test overlay",
+              }
+            },
+            loading: ['draftThemeConfig'],
+            deployment: null,
+          },
+          instances: [{
+            id: 1,
+            instanceName: "test",
+            subdomain: "test",
+          }],
+          history: {
+            goBack: () => {}
+          }
+        }
+      }
+    ).toJSON();
+    expect(tree).toMatchSnapshot();
+});

--- a/frontend/src/newConsole/components/ColorsComponent/ColorsComponent.tsx
+++ b/frontend/src/newConsole/components/ColorsComponent/ColorsComponent.tsx
@@ -1,0 +1,45 @@
+import { InstancesModel } from 'console/models';
+import * as React from 'react';
+import { ConsolePage } from 'newConsole/components';
+import { ThemeColors } from 'console/components';
+import { connect } from 'react-redux';
+import { RootState } from 'global/state';
+import { updateThemeFieldValue } from 'console/actions';
+import { WrappedMessage } from 'utils/intl';
+import messages from './displayMessages';
+import './styles.scss';
+
+interface State {}
+interface ActionProps {
+  updateThemeFieldValue: Function;
+}
+interface StateProps extends InstancesModel {}
+interface Props extends StateProps {
+  history: {
+    goBack: Function;
+  };
+}
+
+class ColorsComponent extends React.PureComponent<Props, State> {
+  public render() {
+    return (
+      <ConsolePage
+        contentLoading={this.props.loading}
+        goBack={this.props.history.goBack}
+        showSideBarEditComponent
+      >
+        <h1 className="edit-heading">
+          <WrappedMessage messages={messages} id="colors" />
+        </h1>
+        <ThemeColors />
+      </ConsolePage>
+    );
+  }
+}
+
+export const Colors = connect<StateProps, ActionProps, {}, Props, RootState>(
+  (state: RootState) => state.console,
+  {
+    updateThemeFieldValue
+  }
+)(ColorsComponent);

--- a/frontend/src/newConsole/components/ColorsComponent/__snapshots__/ColorsComponent.spec.tsx.snap
+++ b/frontend/src/newConsole/components/ColorsComponent/__snapshots__/ColorsComponent.spec.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Theme footer sidebar tests renders without crashing 1`] = `
+exports[`renders without crashing 1`] = `
 <div
   className="console-page"
 >
@@ -43,154 +43,114 @@ exports[`Theme footer sidebar tests renders without crashing 1`] = `
                 Back
               </span>
             </button>
+            <h1
+              className="edit-heading"
+            >
+              Colors
+            </h1>
             <div
-              className="footer-settings"
+              className="row"
             >
               <div
-                className="customization-form"
+                className="side-buttons col"
               >
                 <div
-                  className="row"
+                  className="color-input form-group"
                 >
-                  <div
-                    className="col"
+                  <label
+                    className="form-label"
                   >
-                    <h2>
-                      Footer
-                    </h2>
-                  </div>
-                </div>
-                <div
-                  className="row"
-                >
+                    Main Color
+                  </label>
                   <div
-                    className="col"
+                    className="row"
                   >
+                    <input
+                      className="input-field-color form-control"
+                      disabled={true}
+                      name="mainColor"
+                      onClick={[Function]}
+                      readOnly={true}
+                      value="#444444"
+                    />
                     <div
-                      className="color-input form-group"
+                      className="input-field-preview"
+                      style={
+                        Object {
+                          "backgroundColor": "#444444",
+                        }
+                      }
+                    />
+                    <div
+                      className="info-icon"
+                      onBlur={[Function]}
+                      onFocus={[Function]}
+                      onMouseOut={[Function]}
+                      onMouseOver={[Function]}
                     >
-                      <label
-                        className="form-label"
-                      >
-                        Footer background color
-                      </label>
-                      <div
-                        className="row"
-                      >
-                        <input
-                          className="input-field-color form-control"
-                          disabled={false}
-                          name="footerBg"
-                          onClick={[Function]}
-                          readOnly={true}
-                          value="Not set"
-                        />
-                        <div
-                          className="input-field-preview"
-                          style={
-                            Object {
-                              "backgroundColor": undefined,
-                            }
-                          }
-                        />
-                        <button
-                          className="reset-value padded"
-                          onClick={[Function]}
-                          type="button"
-                        >
-                          Reset
-                        </button>
-                      </div>
+                      <i
+                        className="fas fa-info-circle"
+                      />
                     </div>
                   </div>
+                  <p>
+                    <button
+                      className="reset-value"
+                      onClick={[Function]}
+                      type="button"
+                    >
+                      Reset
+                    </button>
+                  </p>
                 </div>
                 <div
-                  className="row"
+                  className="color-input form-group"
                 >
-                  <div
-                    className="col"
+                  <label
+                    className="form-label"
                   >
+                    Link Color
+                  </label>
+                  <div
+                    className="row"
+                  >
+                    <input
+                      className="input-field-color form-control"
+                      disabled={true}
+                      name="linkColor"
+                      onClick={[Function]}
+                      readOnly={true}
+                      value="#FFAAFF"
+                    />
                     <div
-                      className="color-input form-group"
+                      className="input-field-preview"
+                      style={
+                        Object {
+                          "backgroundColor": "#FFAAFF",
+                        }
+                      }
+                    />
+                    <div
+                      className="info-icon"
+                      onBlur={[Function]}
+                      onFocus={[Function]}
+                      onMouseOut={[Function]}
+                      onMouseOver={[Function]}
                     >
-                      <label
-                        className="form-label"
-                      >
-                        Footer text color
-                      </label>
-                      <div
-                        className="row"
-                      >
-                        <input
-                          className="input-field-color form-control"
-                          disabled={false}
-                          name="footerColor"
-                          onClick={[Function]}
-                          readOnly={true}
-                          value="Not set"
-                        />
-                        <div
-                          className="input-field-preview"
-                          style={
-                            Object {
-                              "backgroundColor": undefined,
-                            }
-                          }
-                        />
-                        <button
-                          className="reset-value padded"
-                          onClick={[Function]}
-                          type="button"
-                        >
-                          Reset
-                        </button>
-                      </div>
+                      <i
+                        className="fas fa-info-circle"
+                      />
                     </div>
                   </div>
-                </div>
-                <div
-                  className="row"
-                >
-                  <div
-                    className="col"
-                  >
-                    <div
-                      className="color-input form-group"
+                  <p>
+                    <button
+                      className="reset-value"
+                      onClick={[Function]}
+                      type="button"
                     >
-                      <label
-                        className="form-label"
-                      >
-                        Footer link color
-                      </label>
-                      <div
-                        className="row"
-                      >
-                        <input
-                          className="input-field-color form-control"
-                          disabled={false}
-                          name="footerLinkColor"
-                          onClick={[Function]}
-                          readOnly={true}
-                          value="Not set"
-                        />
-                        <div
-                          className="input-field-preview"
-                          style={
-                            Object {
-                              "backgroundColor": undefined,
-                            }
-                          }
-                        />
-                        <button
-                          className="reset-value padded"
-                          onClick={[Function]}
-                          type="button"
-                        >
-                          Reset
-                        </button>
-                      </div>
-                    </div>
-                  </div>
+                      Reset
+                    </button>
+                  </p>
                 </div>
               </div>
             </div>
@@ -323,8 +283,8 @@ exports[`Theme footer sidebar tests renders without crashing 1`] = `
                       onMouseLeave={[Function]}
                       style={
                         Object {
-                          "borderBottomColor": undefined,
-                          "color": undefined,
+                          "borderBottomColor": "#FFAAFF",
+                          "color": "#FFAAFF",
                         }
                       }
                       type="button"
@@ -475,7 +435,7 @@ exports[`Theme footer sidebar tests renders without crashing 1`] = `
                               className="fa fa-chevron-right"
                               style={
                                 Object {
-                                  "color": undefined,
+                                  "color": "#FFAAFF",
                                 }
                               }
                             />
@@ -495,7 +455,7 @@ exports[`Theme footer sidebar tests renders without crashing 1`] = `
                                 style={
                                   Object {
                                     "borderBottomColor": undefined,
-                                    "color": undefined,
+                                    "color": "#FFAAFF",
                                   }
                                 }
                                 type="button"
@@ -518,7 +478,7 @@ exports[`Theme footer sidebar tests renders without crashing 1`] = `
                               className="fa fa-chevron-right"
                               style={
                                 Object {
-                                  "color": undefined,
+                                  "color": "#FFAAFF",
                                 }
                               }
                             />
@@ -538,7 +498,7 @@ exports[`Theme footer sidebar tests renders without crashing 1`] = `
                                 style={
                                   Object {
                                     "borderBottomColor": undefined,
-                                    "color": undefined,
+                                    "color": "#FFAAFF",
                                   }
                                 }
                                 type="button"
@@ -552,7 +512,7 @@ exports[`Theme footer sidebar tests renders without crashing 1`] = `
                                 style={
                                   Object {
                                     "borderBottomColor": undefined,
-                                    "color": undefined,
+                                    "color": "#FFAAFF",
                                   }
                                 }
                                 type="button"
@@ -578,7 +538,7 @@ exports[`Theme footer sidebar tests renders without crashing 1`] = `
                               className="fa fa-chevron-right"
                               style={
                                 Object {
-                                  "color": undefined,
+                                  "color": "#FFAAFF",
                                 }
                               }
                             />
@@ -598,7 +558,7 @@ exports[`Theme footer sidebar tests renders without crashing 1`] = `
                                 style={
                                   Object {
                                     "borderBottomColor": undefined,
-                                    "color": undefined,
+                                    "color": "#FFAAFF",
                                   }
                                 }
                                 type="button"
@@ -612,7 +572,7 @@ exports[`Theme footer sidebar tests renders without crashing 1`] = `
                                 style={
                                   Object {
                                     "borderBottomColor": undefined,
-                                    "color": undefined,
+                                    "color": "#FFAAFF",
                                   }
                                 }
                                 type="button"
@@ -626,7 +586,7 @@ exports[`Theme footer sidebar tests renders without crashing 1`] = `
                                 style={
                                   Object {
                                     "borderBottomColor": undefined,
-                                    "color": undefined,
+                                    "color": "#FFAAFF",
                                   }
                                 }
                                 type="button"
@@ -649,7 +609,7 @@ exports[`Theme footer sidebar tests renders without crashing 1`] = `
                               className="fa fa-chevron-right"
                               style={
                                 Object {
-                                  "color": undefined,
+                                  "color": "#FFAAFF",
                                 }
                               }
                             />
@@ -669,7 +629,7 @@ exports[`Theme footer sidebar tests renders without crashing 1`] = `
                                 style={
                                   Object {
                                     "borderBottomColor": undefined,
-                                    "color": undefined,
+                                    "color": "#FFAAFF",
                                   }
                                 }
                                 type="button"
@@ -683,7 +643,7 @@ exports[`Theme footer sidebar tests renders without crashing 1`] = `
                                 style={
                                   Object {
                                     "borderBottomColor": undefined,
-                                    "color": undefined,
+                                    "color": "#FFAAFF",
                                   }
                                 }
                                 type="button"
@@ -697,7 +657,7 @@ exports[`Theme footer sidebar tests renders without crashing 1`] = `
                                 style={
                                   Object {
                                     "borderBottomColor": undefined,
-                                    "color": undefined,
+                                    "color": "#FFAAFF",
                                   }
                                 }
                                 type="button"
@@ -720,7 +680,7 @@ exports[`Theme footer sidebar tests renders without crashing 1`] = `
                               className="fa fa-chevron-right"
                               style={
                                 Object {
-                                  "color": undefined,
+                                  "color": "#FFAAFF",
                                 }
                               }
                             />
@@ -740,7 +700,7 @@ exports[`Theme footer sidebar tests renders without crashing 1`] = `
                                 style={
                                   Object {
                                     "borderBottomColor": undefined,
-                                    "color": undefined,
+                                    "color": "#FFAAFF",
                                   }
                                 }
                                 type="button"
@@ -774,7 +734,7 @@ exports[`Theme footer sidebar tests renders without crashing 1`] = `
                               style={
                                 Object {
                                   "borderBottomColor": undefined,
-                                  "color": undefined,
+                                  "color": "#FFAAFF",
                                 }
                               }
                               type="button"
@@ -804,7 +764,7 @@ exports[`Theme footer sidebar tests renders without crashing 1`] = `
                               style={
                                 Object {
                                   "borderBottomColor": undefined,
-                                  "color": undefined,
+                                  "color": "#FFAAFF",
                                 }
                               }
                               type="button"
@@ -937,7 +897,7 @@ exports[`Theme footer sidebar tests renders without crashing 1`] = `
                           }
                         }
                       >
-                        © undefined. 
+                        © test. 
                         All rights reserved except where noted. edX, Open edX and their respective logos are registered trademarks of edX Inc.
                       </div>
                     </div>

--- a/frontend/src/newConsole/components/ColorsComponent/displayMessages.ts
+++ b/frontend/src/newConsole/components/ColorsComponent/displayMessages.ts
@@ -1,0 +1,8 @@
+const messages = {
+  colors: {
+    defaultMessage: 'Colors',
+    description: 'Title text for colors edit page'
+  }
+};
+
+export default messages;

--- a/frontend/src/newConsole/components/ColorsComponent/index.ts
+++ b/frontend/src/newConsole/components/ColorsComponent/index.ts
@@ -1,0 +1,1 @@
+export * from './ColorsComponent';

--- a/frontend/src/newConsole/components/ConsoleHome/__snapshots__/ConsoleHome.spec.tsx.snap
+++ b/frontend/src/newConsole/components/ConsoleHome/__snapshots__/ConsoleHome.spec.tsx.snap
@@ -58,7 +58,7 @@ exports[`renders without crashing 1`] = `
         className="container-fluid"
       >
         <div
-          className="justify-content-center row"
+          className="justify-content-center console-page-inner-content row"
         >
           <div
             className="col-md-3"
@@ -96,7 +96,7 @@ exports[`renders without crashing 1`] = `
                         href="/console/theming/preview-and-colors"
                         onClick={[Function]}
                       >
-                        Preview & colors
+                        Colors
                       </a>
                       <a
                         aria-current={null}

--- a/frontend/src/newConsole/components/PreviewBox/style.scss
+++ b/frontend/src/newConsole/components/PreviewBox/style.scss
@@ -2,6 +2,7 @@
     height: 100%;
     box-shadow: 0 0 15px 0 rgba(0, 0, 0, 0.3);
     width: 95%;
+    max-height: 650px;
 
     .custom-footer {
         margin-bottom: 0;

--- a/frontend/src/newConsole/components/ThemeNavigationPage/__snapshots__/ThemeNavigationPage.spec.tsx.snap
+++ b/frontend/src/newConsole/components/ThemeNavigationPage/__snapshots__/ThemeNavigationPage.spec.tsx.snap
@@ -22,7 +22,7 @@ exports[`renders without crashing 1`] = `
         className="container-fluid"
       >
         <div
-          className="justify-content-center row"
+          className="justify-content-center console-page-inner-content row"
         >
           <div
             className="col-md-3"

--- a/frontend/src/newConsole/components/index.ts
+++ b/frontend/src/newConsole/components/index.ts
@@ -6,3 +6,4 @@ export * from './CourseOutlinePreview';
 export * from './ConsoleHome';
 export * from './newFooter';
 export * from './ThemeNavigationPage';
+export * from './ColorsComponent';

--- a/frontend/src/newConsole/components/newConsolePage/ConsolePage.tsx
+++ b/frontend/src/newConsole/components/newConsolePage/ConsolePage.tsx
@@ -119,7 +119,7 @@ export class ConsolePageComponent extends React.PureComponent<Props> {
 
       if (this.props.showSidebar && !this.props.showSideBarEditComponent) {
         innerContent = (
-          <Row className="justify-content-center">
+          <Row className="justify-content-center console-page-inner-content">
             <Col md="3">
               <CustomizationSideMenu />
             </Col>
@@ -130,7 +130,7 @@ export class ConsolePageComponent extends React.PureComponent<Props> {
 
       if (this.props.showSidebar && this.props.showSideBarEditComponent) {
         innerContent = (
-          <Row className="justify-content-center">
+          <Row className="justify-content-center console-page-inner-content">
             <Col md="3">
               {renderBackButton(this.props.goBack!)}
               {innerContent}

--- a/frontend/src/newConsole/components/newConsolePage/__snapshots__/ConsolePage.spec.tsx.snap
+++ b/frontend/src/newConsole/components/newConsolePage/__snapshots__/ConsolePage.spec.tsx.snap
@@ -58,7 +58,7 @@ exports[`Console Page Console Page with Edit component Correctly renders loading
         className="container-fluid"
       >
         <div
-          className="justify-content-center row"
+          className="justify-content-center console-page-inner-content row"
         >
           <div
             className="col-md-3"
@@ -163,7 +163,7 @@ exports[`Console Page Correctly renders loading page 1`] = `
         className="container-fluid"
       >
         <div
-          className="justify-content-center row"
+          className="justify-content-center console-page-inner-content row"
         >
           <div
             className="col-md-3"
@@ -201,7 +201,7 @@ exports[`Console Page Correctly renders loading page 1`] = `
                         href="/console/theming/preview-and-colors"
                         onClick={[Function]}
                       >
-                        Preview & colors
+                        Colors
                       </a>
                       <a
                         aria-current={null}
@@ -476,7 +476,7 @@ exports[`Console Page Correctly renders page with data 1`] = `
         className="container-fluid"
       >
         <div
-          className="justify-content-center row"
+          className="justify-content-center console-page-inner-content row"
         >
           <div
             className="col-md-3"
@@ -514,7 +514,7 @@ exports[`Console Page Correctly renders page with data 1`] = `
                         href="/console/theming/preview-and-colors"
                         onClick={[Function]}
                       >
-                        Preview & colors
+                        Colors
                       </a>
                       <a
                         aria-current={null}
@@ -745,7 +745,7 @@ exports[`Console Page Correctly renders page with email not verified alert 1`] =
         className="container-fluid"
       >
         <div
-          className="justify-content-center row"
+          className="justify-content-center console-page-inner-content row"
         >
           <div
             className="col-md-3"
@@ -783,7 +783,7 @@ exports[`Console Page Correctly renders page with email not verified alert 1`] =
                         href="/console/theming/preview-and-colors"
                         onClick={[Function]}
                       >
-                        Preview & colors
+                        Colors
                       </a>
                       <a
                         aria-current={null}

--- a/frontend/src/newConsole/components/newConsolePage/styles.scss
+++ b/frontend/src/newConsole/components/newConsolePage/styles.scss
@@ -3,15 +3,26 @@
 
 
 .console-page {
+  flex-direction: column;
+  height: 100% ;
   .new-console-page-container {
     padding: 3rem 1rem;
     margin: 0 -15px;
     flex: 1;
 
+    .new-console-page-content {
+      height: 100%;
+
+      .console-page-inner-content {
+        height: 100%;
+      }
+    }
+
     .console-page-content {
       margin: 0 auto;
       max-width: 1100px;
       justify-content: center;
+      flex-grow: 1;
 
       .customization-form {
         background-color: #f0f5f7;
@@ -35,6 +46,16 @@
       }
     }
   }
+
+  .edit-heading {
+    text-align: left;
+    color: #0f1f24;
+    font-family: $playfair-font;
+    font-weight: bold;
+    font-size: 28px;
+    margin-top: 37px;
+    margin-bottom: 31.5px;
+}
 }
 
 .back-button {

--- a/frontend/src/newConsole/components/newCustomizationSideMenu/CustomizationSideMenu.tsx
+++ b/frontend/src/newConsole/components/newCustomizationSideMenu/CustomizationSideMenu.tsx
@@ -50,7 +50,7 @@ export const CustomizationSideMenu: React.FC = () => {
           <Card.Body>
             <Nav className="flex-column">
               <NavLink exact to={ROUTES.Console.THEME_PREVIEW_AND_COLORS}>
-                <WrappedMessage messages={messages} id="linkPreviewColors" />
+                <WrappedMessage messages={messages} id="linkColors" />
               </NavLink>
               <NavLink exact to={ROUTES.Console.LOGOS}>
                 <WrappedMessage messages={messages} id="linkLogos" />

--- a/frontend/src/newConsole/components/newCustomizationSideMenu/__snapshots__/CustomizationSideMenu.spec.tsx.snap
+++ b/frontend/src/newConsole/components/newCustomizationSideMenu/__snapshots__/CustomizationSideMenu.spec.tsx.snap
@@ -34,7 +34,7 @@ exports[`Custom Side Menu Page Renders with correct accordion expanded, and with
             href="/console/theming/preview-and-colors"
             onClick={[Function]}
           >
-            Preview & colors
+            Colors
           </a>
           <a
             aria-current={null}

--- a/frontend/src/routes/console.tsx
+++ b/frontend/src/routes/console.tsx
@@ -7,7 +7,6 @@ import {
   Logos,
   NoticeBoard,
   ThemeButtons,
-  ThemePreviewAndColors,
   CustomPages,
   CoursesManage
 } from 'console/components';
@@ -17,7 +16,7 @@ import {
   ThemeNavigationPage
 } from 'newConsole/components';
 import { PrivateRoute } from 'auth/components';
-
+import { Colors } from 'newConsole/components/ColorsComponent';
 import { ROUTES } from '../global/constants';
 
 export const ConsoleRoutes = () => {
@@ -33,12 +32,8 @@ export const ConsoleRoutes = () => {
       />
       <PrivateRoute
         path={ROUTES.Console.THEME_PREVIEW_AND_COLORS}
-        component={ThemePreviewAndColors}
+        component={Colors}
       />
-      {/* <PrivateRoute
-        path={ROUTES.Console.NEW_THEME_PREVIEW_AND_COLORS}
-        component={ThemePreviewAndColors}
-      /> */}
       <PrivateRoute
         path={ROUTES.Console.THEME_BUTTONS}
         component={ThemeButtons}

--- a/frontend/src/ui/components/App/styles.scss
+++ b/frontend/src/ui/components/App/styles.scss
@@ -3,4 +3,5 @@
 .app-container {
     display: flex;
     flex-direction: column;
+    min-height: 100vh;
 }

--- a/frontend/src/ui/components/Main/styles.scss
+++ b/frontend/src/ui/components/Main/styles.scss
@@ -1,3 +1,4 @@
 .app-main {
     flex: 1;
+    flex-grow: 1;
 }


### PR DESCRIPTION
Implements Colors Edit page with ThemeColors component moved to the Sidebar.

**Related Tickets** [BB-3787](https://tasks.opencraft.com/browse/BB-3787) [Gitlab#715](https://gitlab.com/opencraft/dev/opencraft/-/issues/715)

**Testing Instructions**:
1. Checkout to this branch
2. Run the frontend server using `npm run start`
3. Visit http://localhost:3000/newconsole/theming/colors/edit
4. Verify that the page looks according to the [design](https://app.zeplin.io/project/5ea850e04326be273e4bcf5a/screen/6040a3f3e3a09417c18ff8bb) in general.

**Screenshots**

![Screenshot from 2021-03-19 13-59-54](https://user-images.githubusercontent.com/18226212/111752257-7c439d80-88bb-11eb-8222-fe8cfbbf8f95.png)

Updated Screenshot after outline page
![Screenshot from 2021-04-03 18-29-31](https://user-images.githubusercontent.com/18226212/113479117-b19ade80-94aa-11eb-9947-d9a51992aea3.png)


**Author Notes**
1. The Save button is left out of this implementation. See [this comment](https://tasks.opencraft.com/browse/BB-3787?focusedCommentId=192903&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-192903)
2. Flexbox styles are added to `App` and `Main` components such that the UI covers entire viewport (heading at top, footer at bottom and expanded content in remaining area)