### PR TITLE
BB-3870 Add ThemeNavigationPage for newConsole

### DIFF
--- a/frontend/src/newConsole/components/ThemeNavigationPage/ThemeNavigationPage.spec.tsx
+++ b/frontend/src/newConsole/components/ThemeNavigationPage/ThemeNavigationPage.spec.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { setupComponentForTesting } from "utils/testing";
+import { ThemeNavigationPage } from './ThemeNavigationPage';
+
+it('renders without crashing', () => {
+  const tree = setupComponentForTesting(
+    <ThemeNavigationPage />,
+    {
+      console: {
+        loading: false,
+        activeInstance: {
+          data: {
+            id: 1,
+            instanceName: "test",
+            subdomain: "test",
+            draftThemeConfig: {
+              version: 1,
+              mainColor: "#444444",
+              linkColor: "#FFAAFF"
+            },
+            draftStaticContentOverrides: {
+              homepageOverlayHtml: "Test overlay",
+            }
+          },
+          loading: ['draftThemeConfig'],
+          deployment: null,
+        },
+        instances: [{
+          id: 1,
+          instanceName: "test",
+          subdomain: "test",
+        }],
+        history: {
+          goBack: () => { }
+        }
+      }
+    }).toJSON();
+  expect(tree).toMatchSnapshot();
+});

--- a/frontend/src/newConsole/components/ThemeNavigationPage/ThemeNavigationPage.tsx
+++ b/frontend/src/newConsole/components/ThemeNavigationPage/ThemeNavigationPage.tsx
@@ -1,0 +1,114 @@
+import { InstancesModel } from 'console/models';
+import { RootState } from 'global/state';
+import * as React from 'react';
+import { connect } from 'react-redux';
+import { updateThemeFieldValue } from 'console/actions';
+import { WrappedMessage } from 'utils/intl';
+import { ColorInputField } from 'ui/components';
+import { ConsolePage } from '../newConsolePage';
+import messages from './displayMessages';
+import './styles.scss';
+
+interface State {}
+
+interface ActionProps {
+  updateThemeFieldValue: Function;
+}
+
+interface StateProps extends InstancesModel {}
+
+interface Props extends StateProps, ActionProps {
+  history: {
+    goBack: Function;
+  };
+}
+
+export class ThemeNavigationComponent extends React.PureComponent<
+  Props,
+  State
+> {
+  private onChangeColor = (fieldName: string, newColor: string) => {
+    const instance = this.props.activeInstance;
+
+    if (instance.data) {
+      this.props.updateThemeFieldValue(instance.data.id, fieldName, newColor);
+    }
+  };
+
+  public render() {
+    const instance = this.props.activeInstance;
+    let themeData;
+
+    if (instance.data && instance.data.draftThemeConfig) {
+      themeData = instance.data.draftThemeConfig;
+    }
+
+    return (
+      <ConsolePage
+        contentLoading={this.props.loading}
+        goBack={this.props.history.goBack}
+        showSideBarEditComponent
+      >
+        <div>
+          <h2 className="edit-heading">
+            <WrappedMessage messages={messages} id="themeNavigation" />
+          </h2>
+
+          {themeData && themeData.version === 1 && (
+            <div className="theme-navigation-container">
+              <div>
+                <ColorInputField
+                  fieldName="headerBg"
+                  initialValue={themeData.headerBg || ''}
+                  onChange={this.onChangeColor}
+                  messages={messages}
+                  loading={instance.loading.includes('draftThemeConfig')}
+                />
+                <ColorInputField
+                  fieldName="mainNavLinkColor"
+                  initialValue={themeData.mainNavLinkColor || ''}
+                  onChange={this.onChangeColor}
+                  messages={messages}
+                  loading={instance.loading.includes('draftThemeConfig')}
+                />
+                <ColorInputField
+                  fieldName="mainNavItemBorderBottomColor"
+                  initialValue={themeData.mainNavItemBorderBottomColor || ''}
+                  onChange={this.onChangeColor}
+                  messages={messages}
+                  loading={instance.loading.includes('draftThemeConfig')}
+                />
+                <ColorInputField
+                  fieldName="mainNavItemHoverBorderBottomColor"
+                  initialValue={
+                    themeData.mainNavItemHoverBorderBottomColor || ''
+                  }
+                  onChange={this.onChangeColor}
+                  messages={messages}
+                  loading={instance.loading.includes('draftThemeConfig')}
+                />
+                <ColorInputField
+                  fieldName="userDropdownColor"
+                  initialValue={themeData.userDropdownColor || ''}
+                  onChange={this.onChangeColor}
+                  messages={messages}
+                  loading={instance.loading.includes('draftThemeConfig')}
+                />
+              </div>
+            </div>
+          )}
+        </div>
+      </ConsolePage>
+    );
+  }
+}
+
+export const ThemeNavigationPage = connect<
+  StateProps,
+  ActionProps,
+  {},
+  Props,
+  RootState
+>((state: RootState) => state.console, {
+  updateThemeFieldValue
+})(ThemeNavigationComponent);

--- a/frontend/src/newConsole/components/ThemeNavigationPage/__snapshots__/ThemeNavigationPage.spec.tsx.snap
+++ b/frontend/src/newConsole/components/ThemeNavigationPage/__snapshots__/ThemeNavigationPage.spec.tsx.snap
@@ -1,0 +1,1129 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders without crashing 1`] = `
+<div
+  className="console-page"
+>
+  <div
+    className="d-flex justify-content-center align-middle email-activation-alert"
+  >
+    <i
+      className="alert-icon fas fa-exclamation-triangle fa-xs"
+    />
+    One of your email addresses is pending confirmation. Please confirm it to begin managing your Open edX instance.
+  </div>
+  <div
+    className="new-console-page-container"
+  >
+    <div
+      className="new-console-page-content row"
+    >
+      <div
+        className="container-fluid"
+      >
+        <div
+          className="justify-content-center row"
+        >
+          <div
+            className="col-md-3"
+          >
+            <button
+              className="back-button btn btn-link btn-sm"
+              disabled={false}
+              onClick={[Function]}
+              type="button"
+            >
+              <span>
+                <i
+                  aria-hidden="true"
+                  className="fa fa-angle-left sm"
+                />
+              </span>
+              <span>
+                Back
+              </span>
+            </button>
+            <div>
+              <h2
+                className="edit-heading"
+              >
+                Navigation
+              </h2>
+              <div
+                className="theme-navigation-container"
+              >
+                <div>
+                  <div
+                    className="color-input form-group"
+                  >
+                    <label
+                      className="form-label"
+                    >
+                      Background
+                    </label>
+                    <div
+                      className="row"
+                    >
+                      <input
+                        className="input-field-color form-control"
+                        disabled={true}
+                        name="headerBg"
+                        onClick={[Function]}
+                        readOnly={true}
+                        value=""
+                      />
+                      <div
+                        className="input-field-preview"
+                        style={
+                          Object {
+                            "backgroundColor": "",
+                          }
+                        }
+                      />
+                      <div
+                        className="info-icon"
+                        onBlur={[Function]}
+                        onFocus={[Function]}
+                        onMouseOut={[Function]}
+                        onMouseOver={[Function]}
+                      >
+                        <i
+                          className="fas fa-info-circle"
+                        />
+                      </div>
+                    </div>
+                    <p>
+                      <button
+                        className="reset-value"
+                        onClick={[Function]}
+                        type="button"
+                      >
+                        Reset
+                      </button>
+                    </p>
+                  </div>
+                  <div
+                    className="color-input form-group"
+                  >
+                    <label
+                      className="form-label"
+                    >
+                      Links
+                    </label>
+                    <div
+                      className="row"
+                    >
+                      <input
+                        className="input-field-color form-control"
+                        disabled={true}
+                        name="mainNavLinkColor"
+                        onClick={[Function]}
+                        readOnly={true}
+                        value=""
+                      />
+                      <div
+                        className="input-field-preview"
+                        style={
+                          Object {
+                            "backgroundColor": "",
+                          }
+                        }
+                      />
+                      <div
+                        className="info-icon"
+                        onBlur={[Function]}
+                        onFocus={[Function]}
+                        onMouseOut={[Function]}
+                        onMouseOver={[Function]}
+                      >
+                        <i
+                          className="fas fa-info-circle"
+                        />
+                      </div>
+                    </div>
+                    <p>
+                      <button
+                        className="reset-value"
+                        onClick={[Function]}
+                        type="button"
+                      >
+                        Reset
+                      </button>
+                    </p>
+                  </div>
+                  <div
+                    className="color-input form-group"
+                  >
+                    <label
+                      className="form-label"
+                    >
+                      Active links
+                    </label>
+                    <div
+                      className="row"
+                    >
+                      <input
+                        className="input-field-color form-control"
+                        disabled={true}
+                        name="mainNavItemBorderBottomColor"
+                        onClick={[Function]}
+                        readOnly={true}
+                        value=""
+                      />
+                      <div
+                        className="input-field-preview"
+                        style={
+                          Object {
+                            "backgroundColor": "",
+                          }
+                        }
+                      />
+                      <div
+                        className="info-icon"
+                        onBlur={[Function]}
+                        onFocus={[Function]}
+                        onMouseOut={[Function]}
+                        onMouseOver={[Function]}
+                      >
+                        <i
+                          className="fas fa-info-circle"
+                        />
+                      </div>
+                    </div>
+                    <p>
+                      <button
+                        className="reset-value"
+                        onClick={[Function]}
+                        type="button"
+                      >
+                        Reset
+                      </button>
+                    </p>
+                  </div>
+                  <div
+                    className="color-input form-group"
+                  >
+                    <label
+                      className="form-label"
+                    >
+                      Active link on hover
+                    </label>
+                    <div
+                      className="row"
+                    >
+                      <input
+                        className="input-field-color form-control"
+                        disabled={true}
+                        name="mainNavItemHoverBorderBottomColor"
+                        onClick={[Function]}
+                        readOnly={true}
+                        value=""
+                      />
+                      <div
+                        className="input-field-preview"
+                        style={
+                          Object {
+                            "backgroundColor": "",
+                          }
+                        }
+                      />
+                      <div
+                        className="info-icon"
+                        onBlur={[Function]}
+                        onFocus={[Function]}
+                        onMouseOut={[Function]}
+                        onMouseOver={[Function]}
+                      >
+                        <i
+                          className="fas fa-info-circle"
+                        />
+                      </div>
+                    </div>
+                    <p>
+                      <button
+                        className="reset-value"
+                        onClick={[Function]}
+                        type="button"
+                      >
+                        Reset
+                      </button>
+                    </p>
+                  </div>
+                  <div
+                    className="color-input form-group"
+                  >
+                    <label
+                      className="form-label"
+                    >
+                      Dropdown arrow
+                    </label>
+                    <div
+                      className="row"
+                    >
+                      <input
+                        className="input-field-color form-control"
+                        disabled={true}
+                        name="userDropdownColor"
+                        onClick={[Function]}
+                        readOnly={true}
+                        value=""
+                      />
+                      <div
+                        className="input-field-preview"
+                        style={
+                          Object {
+                            "backgroundColor": "",
+                          }
+                        }
+                      />
+                      <div
+                        className="info-icon"
+                        onBlur={[Function]}
+                        onFocus={[Function]}
+                        onMouseOut={[Function]}
+                        onMouseOver={[Function]}
+                      >
+                        <i
+                          className="fas fa-info-circle"
+                        />
+                      </div>
+                    </div>
+                    <p>
+                      <button
+                        className="reset-value"
+                        onClick={[Function]}
+                        type="button"
+                      >
+                        Reset
+                      </button>
+                    </p>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="col-md-7"
+          >
+            <div
+              className="preview-box card"
+            >
+              <div
+                className="theme-preview-navigation container-fluid"
+              >
+                <div
+                  className="d-flex felx-row main-navigation-menu navigation-menu row"
+                  style={
+                    Object {
+                      "background": undefined,
+                    }
+                  }
+                >
+                  <div
+                    className="logo"
+                  />
+                  <div
+                    className="flex-grow-1 d-flex flex-row ml-4 mr-4"
+                  >
+                    <div
+                      className="course-header mr-4"
+                    >
+                      <span
+                        className="course-org"
+                      >
+                        edX: Demox
+                      </span>
+                      <span
+                        className="course-name"
+                      >
+                        Demonstration Course
+                      </span>
+                    </div>
+                    <button
+                      className="customizable-link"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                      style={
+                        Object {
+                          "borderBottomColor": undefined,
+                          "color": undefined,
+                        }
+                      }
+                      type="button"
+                    >
+                      Discover New
+                    </button>
+                  </div>
+                  <div>
+                    <div
+                      className="navigation-menu navigation-submenu row"
+                    >
+                      <div
+                        className="col"
+                      >
+                        <button
+                          className="customizable-link noHover"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
+                          style={
+                            Object {
+                              "borderBottomColor": undefined,
+                              "color": undefined,
+                            }
+                          }
+                          type="button"
+                        >
+                          Help
+                        </button>
+                        <img
+                          alt="Avatar"
+                          src="avatar-default.png"
+                        />
+                        <button
+                          className="customizable-link noHover"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
+                          style={
+                            Object {
+                              "borderBottomColor": undefined,
+                              "color": undefined,
+                            }
+                          }
+                          type="button"
+                        >
+                          JoeSoap
+                        </button>
+                        <button
+                          className="customizable-link noHover"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
+                          style={
+                            Object {
+                              "borderBottomColor": undefined,
+                              "color": undefined,
+                            }
+                          }
+                          type="button"
+                        >
+                          <i
+                            className="fas fa-caret-down"
+                          />
+                        </button>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                className="theme-outline"
+              >
+                <nav
+                  className="theme-course-tabs navbar navbar-expand navbar-light bg-transparent"
+                >
+                  <div
+                    className="mr-auto navbar-nav"
+                    onKeyDown={[Function]}
+                  >
+                    <button
+                      className="customizable-link active"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                      style={
+                        Object {
+                          "borderBottomColor": "#FFAAFF",
+                          "color": "#FFAAFF",
+                        }
+                      }
+                      type="button"
+                    >
+                      <span>
+                        Course
+                      </span>
+                    </button>
+                    <button
+                      className="customizable-link"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                      style={
+                        Object {
+                          "borderBottomColor": undefined,
+                          "color": undefined,
+                        }
+                      }
+                      type="button"
+                    >
+                      <span>
+                        Progress
+                      </span>
+                    </button>
+                    <button
+                      className="customizable-link"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                      style={
+                        Object {
+                          "borderBottomColor": undefined,
+                          "color": undefined,
+                        }
+                      }
+                      type="button"
+                    >
+                      <span>
+                        Discussion
+                      </span>
+                    </button>
+                    <button
+                      className="customizable-link"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                      style={
+                        Object {
+                          "borderBottomColor": undefined,
+                          "color": undefined,
+                        }
+                      }
+                      type="button"
+                    >
+                      <span>
+                        Wiki
+                      </span>
+                    </button>
+                  </div>
+                </nav>
+                <div
+                  className="theme-course-outline-view"
+                >
+                  <nav
+                    className="outline-header navbar navbar-expand navbar-light"
+                  >
+                    <h2
+                      className="m-0"
+                    >
+                      Demonstration Course
+                    </h2>
+                    <form
+                      className="ml-auto mr-1 form-inline"
+                    >
+                      <input
+                        className="mr-0 searchBox form-control"
+                        placeholder="Search"
+                        type="text"
+                      />
+                      <button
+                        className="customizable-button"
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
+                        style={
+                          Object {
+                            "background": undefined,
+                            "borderColor": undefined,
+                            "color": undefined,
+                          }
+                        }
+                        type="button"
+                      >
+                        Search
+                      </button>
+                    </form>
+                    <button
+                      className="customizable-button"
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                      style={
+                        Object {
+                          "background": undefined,
+                          "borderColor": undefined,
+                          "color": undefined,
+                        }
+                      }
+                      type="button"
+                    >
+                      Start Course
+                    </button>
+                  </nav>
+                  <div
+                    className="outline-body"
+                  >
+                    <div
+                      className="outline-container"
+                    >
+                      <div
+                        className="outline-tree-action-wrapper"
+                      >
+                        <button
+                          className="customizable-button"
+                          onMouseEnter={[Function]}
+                          onMouseLeave={[Function]}
+                          style={
+                            Object {
+                              "background": undefined,
+                              "borderColor": undefined,
+                              "color": undefined,
+                            }
+                          }
+                          type="button"
+                        >
+                          Expand All
+                        </button>
+                      </div>
+                      <div
+                        className="theme-course-outline-tree accordion"
+                      >
+                        <div
+                          className="course-outline-section"
+                        >
+                          <button
+                            className="toggle-btn btn btn-link"
+                            disabled={false}
+                            onClick={[Function]}
+                            type="button"
+                          >
+                            <span
+                              className="fa fa-chevron-right"
+                              style={
+                                Object {
+                                  "color": "#FFAAFF",
+                                }
+                              }
+                            />
+                            Introduction
+                          </button>
+                          <div
+                            aria-expanded={null}
+                            className="collapse show"
+                          >
+                            <div
+                              className="course-outline-subsection"
+                            >
+                              <button
+                                className="customizable-link"
+                                onMouseEnter={[Function]}
+                                onMouseLeave={[Function]}
+                                style={
+                                  Object {
+                                    "borderBottomColor": undefined,
+                                    "color": "#FFAAFF",
+                                  }
+                                }
+                                type="button"
+                              >
+                                Demo Course Overview
+                              </button>
+                            </div>
+                          </div>
+                        </div>
+                        <div
+                          className="course-outline-section"
+                        >
+                          <button
+                            className="toggle-btn btn btn-link"
+                            disabled={false}
+                            onClick={[Function]}
+                            type="button"
+                          >
+                            <span
+                              className="fa fa-chevron-right"
+                              style={
+                                Object {
+                                  "color": "#FFAAFF",
+                                }
+                              }
+                            />
+                            Example Week 1: Getting Started
+                          </button>
+                          <div
+                            aria-expanded={null}
+                            className="collapse"
+                          >
+                            <div
+                              className="course-outline-subsection"
+                            >
+                              <button
+                                className="customizable-link"
+                                onMouseEnter={[Function]}
+                                onMouseLeave={[Function]}
+                                style={
+                                  Object {
+                                    "borderBottomColor": undefined,
+                                    "color": "#FFAAFF",
+                                  }
+                                }
+                                type="button"
+                              >
+                                Lesson 1 - Getting Started
+                              </button>
+                              <button
+                                className="customizable-link"
+                                onMouseEnter={[Function]}
+                                onMouseLeave={[Function]}
+                                style={
+                                  Object {
+                                    "borderBottomColor": undefined,
+                                    "color": "#FFAAFF",
+                                  }
+                                }
+                                type="button"
+                              >
+                                <span
+                                  className="far fa-edit"
+                                />
+                                Homework - Question Styles (7 Questions)
+                              </button>
+                            </div>
+                          </div>
+                        </div>
+                        <div
+                          className="course-outline-section"
+                        >
+                          <button
+                            className="toggle-btn btn btn-link"
+                            disabled={false}
+                            onClick={[Function]}
+                            type="button"
+                          >
+                            <span
+                              className="fa fa-chevron-right"
+                              style={
+                                Object {
+                                  "color": "#FFAAFF",
+                                }
+                              }
+                            />
+                            Example Week 2: Get Interactive
+                          </button>
+                          <div
+                            aria-expanded={null}
+                            className="collapse"
+                          >
+                            <div
+                              className="course-outline-subsection"
+                            >
+                              <button
+                                className="customizable-link"
+                                onMouseEnter={[Function]}
+                                onMouseLeave={[Function]}
+                                style={
+                                  Object {
+                                    "borderBottomColor": undefined,
+                                    "color": "#FFAAFF",
+                                  }
+                                }
+                                type="button"
+                              >
+                                Lesson 2 - Let's Get Interactive!
+                              </button>
+                              <button
+                                className="customizable-link"
+                                onMouseEnter={[Function]}
+                                onMouseLeave={[Function]}
+                                style={
+                                  Object {
+                                    "borderBottomColor": undefined,
+                                    "color": "#FFAAFF",
+                                  }
+                                }
+                                type="button"
+                              >
+                                Homework - Lab and Demos (5 Questions)
+                              </button>
+                              <button
+                                className="customizable-link"
+                                onMouseEnter={[Function]}
+                                onMouseLeave={[Function]}
+                                style={
+                                  Object {
+                                    "borderBottomColor": undefined,
+                                    "color": "#FFAAFF",
+                                  }
+                                }
+                                type="button"
+                              >
+                                Homework - Essays
+                              </button>
+                            </div>
+                          </div>
+                        </div>
+                        <div
+                          className="course-outline-section"
+                        >
+                          <button
+                            className="toggle-btn btn btn-link"
+                            disabled={false}
+                            onClick={[Function]}
+                            type="button"
+                          >
+                            <span
+                              className="fa fa-chevron-right"
+                              style={
+                                Object {
+                                  "color": "#FFAAFF",
+                                }
+                              }
+                            />
+                            Example Week 3: Be Social
+                          </button>
+                          <div
+                            aria-expanded={null}
+                            className="collapse"
+                          >
+                            <div
+                              className="course-outline-subsection"
+                            >
+                              <button
+                                className="customizable-link"
+                                onMouseEnter={[Function]}
+                                onMouseLeave={[Function]}
+                                style={
+                                  Object {
+                                    "borderBottomColor": undefined,
+                                    "color": "#FFAAFF",
+                                  }
+                                }
+                                type="button"
+                              >
+                                Lesson 3 - Be Social
+                              </button>
+                              <button
+                                className="customizable-link"
+                                onMouseEnter={[Function]}
+                                onMouseLeave={[Function]}
+                                style={
+                                  Object {
+                                    "borderBottomColor": undefined,
+                                    "color": "#FFAAFF",
+                                  }
+                                }
+                                type="button"
+                              >
+                                Homework - Find Your Study Buddy
+                              </button>
+                              <button
+                                className="customizable-link"
+                                onMouseEnter={[Function]}
+                                onMouseLeave={[Function]}
+                                style={
+                                  Object {
+                                    "borderBottomColor": undefined,
+                                    "color": "#FFAAFF",
+                                  }
+                                }
+                                type="button"
+                              >
+                                More Ways to Connect
+                              </button>
+                            </div>
+                          </div>
+                        </div>
+                        <div
+                          className="course-outline-section"
+                        >
+                          <button
+                            className="toggle-btn btn btn-link"
+                            disabled={false}
+                            onClick={[Function]}
+                            type="button"
+                          >
+                            <span
+                              className="fa fa-chevron-right"
+                              style={
+                                Object {
+                                  "color": "#FFAAFF",
+                                }
+                              }
+                            />
+                            About Exams and Certificates
+                          </button>
+                          <div
+                            aria-expanded={null}
+                            className="collapse"
+                          >
+                            <div
+                              className="course-outline-subsection"
+                            >
+                              <button
+                                className="customizable-link"
+                                onMouseEnter={[Function]}
+                                onMouseLeave={[Function]}
+                                style={
+                                  Object {
+                                    "borderBottomColor": undefined,
+                                    "color": "#FFAAFF",
+                                  }
+                                }
+                                type="button"
+                              >
+                                edX Exams (6 Questions)
+                              </button>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      className="course-outline-sidebar"
+                    >
+                      <div
+                        className="sidebar-section"
+                      >
+                        <h3
+                          className="hd-6"
+                        >
+                          Course Tools
+                        </h3>
+                        <ul
+                          className="list-unstyled"
+                        >
+                          <li>
+                            <button
+                              className="customizable-link"
+                              onMouseEnter={[Function]}
+                              onMouseLeave={[Function]}
+                              style={
+                                Object {
+                                  "borderBottomColor": undefined,
+                                  "color": "#FFAAFF",
+                                }
+                              }
+                              type="button"
+                            >
+                              <i
+                                className="fa fa-bookmark"
+                              />
+                              Bookmarks
+                            </button>
+                          </li>
+                        </ul>
+                      </div>
+                      <div
+                        className="sidebar-section"
+                      >
+                        <h3
+                          className="hd-6"
+                        >
+                          Course Handouts
+                        </h3>
+                        <ol>
+                          <li>
+                            <button
+                              className="customizable-link"
+                              onMouseEnter={[Function]}
+                              onMouseLeave={[Function]}
+                              style={
+                                Object {
+                                  "borderBottomColor": undefined,
+                                  "color": "#FFAAFF",
+                                }
+                              }
+                              type="button"
+                            >
+                              Example handout
+                            </button>
+                          </li>
+                        </ol>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                className="theme-footer row"
+              >
+                <div
+                  className="col"
+                >
+                  <div
+                    className="custom-footer"
+                    style={
+                      Object {
+                        "background": undefined,
+                      }
+                    }
+                  >
+                    <div
+                      className="row"
+                    >
+                      <div
+                        className="col-md-4"
+                      >
+                        <div
+                          className="footer-top-links row"
+                        >
+                          <button
+                            className="customizable-link noHover"
+                            onMouseEnter={[Function]}
+                            onMouseLeave={[Function]}
+                            style={
+                              Object {
+                                "borderBottomColor": undefined,
+                                "color": undefined,
+                              }
+                            }
+                            type="button"
+                          >
+                            <span>
+                              About
+                            </span>
+                          </button>
+                          <button
+                            className="customizable-link noHover"
+                            onMouseEnter={[Function]}
+                            onMouseLeave={[Function]}
+                            style={
+                              Object {
+                                "borderBottomColor": undefined,
+                                "color": undefined,
+                              }
+                            }
+                            type="button"
+                          >
+                            <span>
+                              Blog
+                            </span>
+                          </button>
+                          <button
+                            className="customizable-link noHover"
+                            onMouseEnter={[Function]}
+                            onMouseLeave={[Function]}
+                            style={
+                              Object {
+                                "borderBottomColor": undefined,
+                                "color": undefined,
+                              }
+                            }
+                            type="button"
+                          >
+                            <span>
+                              Contact
+                            </span>
+                          </button>
+                          <button
+                            className="customizable-link noHover"
+                            onMouseEnter={[Function]}
+                            onMouseLeave={[Function]}
+                            style={
+                              Object {
+                                "borderBottomColor": undefined,
+                                "color": undefined,
+                              }
+                            }
+                            type="button"
+                          >
+                            <span>
+                              Donate
+                            </span>
+                          </button>
+                        </div>
+                      </div>
+                      <div
+                        className="col-md-5"
+                      />
+                      <div
+                        className="openedx-logo col-md-3"
+                      >
+                        <img
+                          alt="Open edX logo"
+                          src="openedx-logo-footer.png"
+                        />
+                      </div>
+                    </div>
+                    <div
+                      className="row"
+                    >
+                      <div
+                        className="logo col-md-1"
+                      />
+                    </div>
+                    <div
+                      className="row"
+                    >
+                      <div
+                        className="copyright"
+                        style={
+                          Object {
+                            "color": undefined,
+                          }
+                        }
+                      >
+                        © test. 
+                        All rights reserved except where noted. edX, Open edX and their respective logos are registered trademarks of edX Inc.
+                      </div>
+                    </div>
+                    <div
+                      className="legal row"
+                    >
+                      <button
+                        className="customizable-link noHover"
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
+                        style={
+                          Object {
+                            "borderBottomColor": undefined,
+                            "color": undefined,
+                          }
+                        }
+                        type="button"
+                      >
+                        <span>
+                          Privacy Policy
+                        </span>
+                      </button>
+                      <button
+                        className="customizable-link noHover"
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
+                        style={
+                          Object {
+                            "borderBottomColor": undefined,
+                            "color": undefined,
+                          }
+                        }
+                        type="button"
+                      >
+                        <span>
+                          Terms of Service
+                        </span>
+                      </button>
+                      <button
+                        className="customizable-link noHover"
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
+                        style={
+                          Object {
+                            "borderBottomColor": undefined,
+                            "color": undefined,
+                          }
+                        }
+                        type="button"
+                      >
+                        <span>
+                          Honor Code
+                        </span>
+                      </button>
+                      <button
+                        className="customizable-link noHover"
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
+                        style={
+                          Object {
+                            "borderBottomColor": undefined,
+                            "color": undefined,
+                          }
+                        }
+                        type="button"
+                      >
+                        <span>
+                          Take free online courses at edX.org
+                        </span>
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/frontend/src/newConsole/components/ThemeNavigationPage/displayMessages.ts
+++ b/frontend/src/newConsole/components/ThemeNavigationPage/displayMessages.ts
@@ -1,0 +1,50 @@
+const messages = {
+  themeNavigation: {
+    defaultMessage: 'Navigation',
+    description: ''
+  },
+  headerBg: {
+    defaultMessage: 'Background',
+    description: ''
+  },
+  headerBgHelp: {
+    defaultMessage:
+      'The background of the navigation header will be of this color.',
+    description: ''
+  },
+  mainNavLinkColor: {
+    defaultMessage: 'Links',
+    description: ''
+  },
+  mainNavLinkColorHelp: {
+    defaultMessage: 'The main links in navigation will be of this color.',
+    description: ''
+  },
+  mainNavItemBorderBottomColor: {
+    defaultMessage: 'Active links',
+    description: ''
+  },
+  mainNavItemBorderBottomColorHelp: {
+    defaultMessage:
+      'The active navigation links on your site will be of this color.',
+    description: ''
+  },
+  mainNavItemHoverBorderBottomColor: {
+    defaultMessage: 'Active link on hover',
+    description: ''
+  },
+  mainNavItemHoverBorderBottomColorHelp: {
+    defaultMessage: 'The navigation links will change to this color on hover.',
+    description: ''
+  },
+  userDropdownColor: {
+    defaultMessage: 'Dropdown arrow',
+    description: ''
+  },
+  userDropdownColorHelp: {
+    defaultMessage: 'The dropdown caret in navigation will be of this color.',
+    description: ''
+  }
+};
+
+export default messages;

--- a/frontend/src/newConsole/components/ThemeNavigationPage/index.ts
+++ b/frontend/src/newConsole/components/ThemeNavigationPage/index.ts
@@ -1,0 +1,1 @@
+export * from './ThemeNavigationPage';

--- a/frontend/src/newConsole/components/ThemeNavigationPage/styles.scss
+++ b/frontend/src/newConsole/components/ThemeNavigationPage/styles.scss
@@ -1,0 +1,26 @@
+@import '~styles/theme';
+
+.console-page {
+  .edit-heading{
+    text-align: left;
+    color: #0f1f24;
+    font-family: $playfair-font;
+    font-weight: bold;
+    font-size: 28px;
+    margin-top: 37px;
+    margin-bottom: 31.5px;
+  }
+
+  .theme-navigation-container {
+    .color-input {
+      .row {
+        display: flex;
+        align-items: center;
+        .info-icon {
+          padding: 5px 10px;
+          color: $primary-1;
+        }
+      }
+    }
+  }
+}

--- a/frontend/src/newConsole/components/index.ts
+++ b/frontend/src/newConsole/components/index.ts
@@ -5,3 +5,4 @@ export * from './PreviewBox';
 export * from './CourseOutlinePreview';
 export * from './ConsoleHome';
 export * from './newFooter';
+export * from './ThemeNavigationPage';

--- a/frontend/src/routes/console.tsx
+++ b/frontend/src/routes/console.tsx
@@ -7,13 +7,17 @@ import {
   Logos,
   NoticeBoard,
   ThemeButtons,
-  ThemeNavigation,
   ThemePreviewAndColors,
   CustomPages,
   CoursesManage
 } from 'console/components';
-import { ConsoleHome, ThemeFooterSideBar } from 'newConsole/components';
+import {
+  ConsoleHome,
+  ThemeFooterSideBar,
+  ThemeNavigationPage
+} from 'newConsole/components';
 import { PrivateRoute } from 'auth/components';
+
 import { ROUTES } from '../global/constants';
 
 export const ConsoleRoutes = () => {
@@ -42,7 +46,7 @@ export const ConsoleRoutes = () => {
       <PrivateRoute path={ROUTES.Console.LOGOS} component={Logos} />
       <PrivateRoute
         path={ROUTES.Console.THEME_NAVIGATION}
-        component={ThemeNavigation}
+        component={ThemeNavigationPage}
       />
       <PrivateRoute path={ROUTES.Console.HERO} component={Hero} />
       <PrivateRoute


### PR DESCRIPTION
Adds new ThemeNavigationPage for newConsole and
move the Color Picker components to the sidebar

**JIRA Tickets** [BB-3870](https://tasks.opencraft.com/browse/BB-3870) [Gitlab#722](https://gitlab.com/opencraft/dev/opencraft/-/issues/722)

**Testing Instructions**
1. Checkout to this branch
2. Run OCIM frontend and backend dev servers.
3. Make sure that a test instance is created in OCIM admin.
4. Visit http://localhost:3000/console/theming/navigation
5. Make sure that all the elements are present in Sidebar.
6. Verify that changing `ColorInputField` values changes the theme data in `BetaTestApplication`

**Author Notes**
1. This PR is dependent on #719 for Static Page previews.

**Screenshot**

Version 1

![navigation-theme](https://user-images.githubusercontent.com/18226212/111994811-35b1a580-8b3e-11eb-85a9-7dc7272d6b47.png)

Update:

Version 2 (updated titles)
![navigation-title-new](https://user-images.githubusercontent.com/18226212/113100620-42f32200-9219-11eb-9bc7-bdf83c46efd4.png)

Version 3 (with tooltips)
![navigation with tooltip](https://user-images.githubusercontent.com/18226212/113589988-b1881380-964f-11eb-8f8e-717acee7ac51.png)


