### PR TITLE
[FAL-1742] Import TinyMCE icons to compile them

### DIFF
--- a/frontend/src/utils/setup_tinymce.ts
+++ b/frontend/src/utils/setup_tinymce.ts
@@ -1,4 +1,5 @@
 import 'tinymce/tinymce';
+import 'tinymce/icons/default';
 import 'tinymce/themes/silver';
 import 'tinymce/skins/ui/oxide/skin.min.css';
 import 'tinymce/skins/ui/oxide/content.min.css';


### PR DESCRIPTION
This pull request is about importing TinyMCE icons in `setup_tinymce.ts` so that the `icons.js` file is also compiled by `react-scripts` (`webpack`).

**Jira tickets**

- [FAL-1742](https://tasks.opencraft.com/browse/FAL-1742)

**Testing instructions**

TBA

**Reviewers**

- @mtyaka 