### PR TITLE
SE-4282 add db DEFAULT CHARACTER SET

### DIFF
--- a/instance/models/mixins/openedx_database.py
+++ b/instance/models/mixins/openedx_database.py
@@ -194,7 +194,7 @@ class OpenEdXDatabaseMixin(MySQLInstanceMixin, MongoDBInstanceMixin, RabbitMQIns
         with self.mysql_server.get_admin_cursor() as cursor:
             # We can't use prepared style queries here, because the database name can't be a string.
             # We should never use this with user input anyway, so it should be OK.
-            cursor.execute(f'CREATE DATABASE {db_name}')
+            cursor.execute(f'CREATE DATABASE {db_name} DEFAULT CHARACTER SET utf8')
 
     def drop_db(self, db_suffix):
         """

--- a/instance/tests/models/test_openedx_instance.py
+++ b/instance/tests/models/test_openedx_instance.py
@@ -1319,7 +1319,9 @@ class OpenEdXInstanceTestCase(TestCase):
         mock_cursor = mock_cursor_context.return_value.__enter__.return_value
         instance = OpenEdXInstanceFactory(mysql_server=MySQLServerFactory(), sub_domain='create_test')
         instance.create_db('edxapp')
-        mock_cursor.execute.assert_called_with('CREATE DATABASE create_test_example_com_edxapp')
+        mock_cursor.execute.assert_called_with(
+            'CREATE DATABASE create_test_example_com_edxapp DEFAULT CHARACTER SET utf8'
+        )
 
 
 @skip_unless_consul_running()


### PR DESCRIPTION
<!--
Please give the pull request a short but descriptive title.
Use [conventional commits](https://www.conventionalcommits.org/) to separate and summarize commits logically.

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

Set `DEFAULT CHARACTER SET` to `utf-8` for `openedx_database` creating command, because default character set on the server is `latin1`, not `utf-8`

According to review:
https://github.com/open-craft/opencraft/pull/672#discussion_r598963816

## Supporting information

**JIRA Ticket** [SE-4282](https://tasks.opencraft.com/browse/SE-4282)

## Testing instructions

1. Pull this branch
2. Run command in terminal to recreate db: `honcho run python3 manage.py recreate_db   --domain=artem.stage.opencraft.hosting    --admin="Your Name"    --reason="Testing latest changes in pull request"`

## Deadline

None

## Other information

@nizarmah Sorry for this, but I renamed this branch to include my name, so #751 was automatically closed.
