### PR TITLE
WIP: [BB-3967] Show uploaded logo/favicon images

### DIFF
--- a/frontend/src/utils/setup_tinymce.ts
+++ b/frontend/src/utils/setup_tinymce.ts
@@ -1,4 +1,5 @@
 import 'tinymce/tinymce';
+import 'tinymce/icons/default';
 import 'tinymce/themes/silver';
 import 'tinymce/skins/ui/oxide/skin.min.css';
 import 'tinymce/skins/ui/oxide/content.min.css';

--- a/instance/models/mixins/openedx_database.py
+++ b/instance/models/mixins/openedx_database.py
@@ -194,7 +194,7 @@ class OpenEdXDatabaseMixin(MySQLInstanceMixin, MongoDBInstanceMixin, RabbitMQIns
         with self.mysql_server.get_admin_cursor() as cursor:
             # We can't use prepared style queries here, because the database name can't be a string.
             # We should never use this with user input anyway, so it should be OK.
-            cursor.execute(f'CREATE DATABASE {db_name}')
+            cursor.execute(f'CREATE DATABASE {db_name} DEFAULT CHARACTER SET utf8')
 
     def drop_db(self, db_suffix):
         """

--- a/instance/tests/models/test_openedx_instance.py
+++ b/instance/tests/models/test_openedx_instance.py
@@ -1319,7 +1319,9 @@ class OpenEdXInstanceTestCase(TestCase):
         mock_cursor = mock_cursor_context.return_value.__enter__.return_value
         instance = OpenEdXInstanceFactory(mysql_server=MySQLServerFactory(), sub_domain='create_test')
         instance.create_db('edxapp')
-        mock_cursor.execute.assert_called_with('CREATE DATABASE create_test_example_com_edxapp')
+        mock_cursor.execute.assert_called_with(
+            'CREATE DATABASE create_test_example_com_edxapp DEFAULT CHARACTER SET utf8'
+        )
 
 
 @skip_unless_consul_running()


### PR DESCRIPTION
**Description**

These changes aim to show a preview of the updated logos one uploaded.

**Supporting information**

The changes were recommended as part of [this](https://gitlab.com/opencraft/dev/opencraft/-/issues/702#note_529450749) review

[Gitlab issue](https://gitlab.com/opencraft/dev/opencraft/-/issues/724)
[Jira ticket](https://tasks.opencraft.com/browse/BB-3967)

**Testing instructions**
1. Sign in to the console
2. Navigate to the Theme > Logos page
3. Update the logos and confirm that the uploaded logo is displayed instead of the "Upload file" test
4. Confirm that the logos display in the sizes that they will appear on the instance
5. Confirm that spaces between the elements match the design shown in the linked comment


