### PR TITLE
WIP: [BB-3967] Show uploaded logo/favicon images

### DIFF
--- a/frontend/src/newConsole/components/newLogos/LogoSidebar.tsx
+++ b/frontend/src/newConsole/components/newLogos/LogoSidebar.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import './styles.scss';
 import { ConsolePageCustomizationContainer } from 'console/components';
 import { ConsolePage } from 'newConsole/components';
-import { Row, Col } from 'react-bootstrap';
 import { InstancesModel } from 'console/models';
 import { ImageUploadField } from 'ui/components';
 import faviconTooltipImage from 'assets/faviconTooltipImage.png';
@@ -48,15 +47,6 @@ export class LogosSideBarComponent extends React.PureComponent<Props, State> {
             <h2>
               <WrappedMessage messages={messages} id="logos" />
             </h2>
-            <Row>
-              <Col md={3} className="image-container">
-                <div>
-                  {instance.data && instance.data.logo && (
-                    <img src={instance.data.logo} alt="Logo" />
-                  )}
-                </div>
-              </Col>
-            </Row>
             <ImageUploadField
               customUploadMessage={
                 <WrappedMessage messages={messages} id="siteLogo" />
@@ -71,16 +61,10 @@ export class LogosSideBarComponent extends React.PureComponent<Props, State> {
                 this.props.clearErrorMessage('logo');
               }}
               tooltipTextId="logoTooltip"
+              imageValue={(instance.data && instance.data.logo) || ''}
+              imageAltText="logo"
             />
-            <Row>
-              <Col md={3} className="image-container">
-                <div>
-                  {instance.data && instance.data.favicon && (
-                    <img src={instance.data.favicon} alt="favicon" />
-                  )}
-                </div>
-              </Col>
-            </Row>
+            <div className="my-4" />
             <ImageUploadField
               customUploadMessage={
                 <WrappedMessage messages={messages} id="favicon" />
@@ -96,6 +80,8 @@ export class LogosSideBarComponent extends React.PureComponent<Props, State> {
               }}
               tooltipTextId="faviconTooltip"
               tooltipImage={faviconTooltipImage}
+              imageValue={(instance.data && instance.data.favicon) || ''}
+              imageAltText="favicon"
             />
           </ConsolePageCustomizationContainer>
         </div>

--- a/frontend/src/newConsole/components/newLogos/styles.scss
+++ b/frontend/src/newConsole/components/newLogos/styles.scss
@@ -3,6 +3,9 @@
 .custom-logo-pages {
   h2 {
     margin-bottom: 0px !important;
+    color: #0f1f24;
+    text-align: left;
+    margin-top: 20px;
   }
 
   p {

--- a/frontend/src/ui/components/ImageUploadField/ImageUploadField.tsx
+++ b/frontend/src/ui/components/ImageUploadField/ImageUploadField.tsx
@@ -16,6 +16,8 @@ interface ImageUploadFieldProps {
   reset?: Function;
   tooltipTextId?: string;
   tooltipImage?: string;
+  imageValue?: string;
+  imageAltText?: string;
 }
 
 interface Image {
@@ -79,20 +81,38 @@ export const ImageUploadField: React.FC<ImageUploadFieldProps> = (
           </OverlayTrigger>
         )}
       </div>
-      <Button
-        variant="outline-primary"
-        size="lg"
-        onClick={handleShow}
-        disabled={props.loading}
-        className="uploadButton"
-      >
-        <div className="buttonContents">
-          <img className="uploadIcon" src={upArrowIcon} alt="Upload icon" />
-          <h4>
-            <WrappedMessage messages={messages} id="change" />
-          </h4>
+      {props.imageValue ? (
+        <div className="imagePreview">
+          <img src={props.imageValue} alt={props.imageAltText} />
         </div>
-      </Button>
+      ) : (
+        <Button
+          variant="outline-primary"
+          size="lg"
+          onClick={handleShow}
+          disabled={props.loading}
+          className="uploadButton"
+        >
+          <div className="buttonContents">
+            <img className="uploadIcon" src={upArrowIcon} alt="Upload icon" />
+            <h4>
+              <WrappedMessage messages={messages} id="change" />
+            </h4>
+          </div>
+        </Button>
+      )}
+      {props.imageValue && (
+        <p className="changeFile my-2">
+          <Button
+            variant="link"
+            size="sm"
+            className="changeFileButton"
+            onClick={handleShow}
+          >
+            <WrappedMessage messages={messages} id="changeFile" />
+          </Button>
+        </p>
+      )}
       {props.parentMessages && props.recommendationTextId && (
         <p>
           <WrappedMessage

--- a/frontend/src/ui/components/ImageUploadField/displayMessages.ts
+++ b/frontend/src/ui/components/ImageUploadField/displayMessages.ts
@@ -10,6 +10,10 @@ const messages = {
   cancel: {
     defaultMessage: 'Cancel',
     description: ''
+  },
+  changeFile: {
+    defaultMessage: 'Change file',
+    description: ''
   }
 };
 

--- a/frontend/src/ui/components/ImageUploadField/styles.scss
+++ b/frontend/src/ui/components/ImageUploadField/styles.scss
@@ -124,3 +124,22 @@
         width: 100%;
     }
 }
+
+.changeFile {
+    button {
+        color: #0074B4;
+        padding: 0;
+        text-transform: initial;
+        font-size: 14px;
+        border-left-width: 0px;
+    }
+}
+
+.imagePreview {
+    min-width: 100%;
+    text-align: center;
+    border: solid 1px #636363;
+    border-style: dashed;
+    padding-top: 5px;
+    padding-bottom: 5px;
+}


### PR DESCRIPTION
**Description**

These changes aim to show a preview of the updated logos one uploaded.

**Supporting information**

The changes were recommended as part of [this](https://gitlab.com/opencraft/dev/opencraft/-/issues/702#note_529450749) review

[Gitlab issue](https://gitlab.com/opencraft/dev/opencraft/-/issues/724)
[Jira ticket](https://tasks.opencraft.com/browse/BB-3967)

**Testing instructions**
1. Sign in to the console
2. Navigate to the Theme > Logos page
3. Update the logos and confirm that the uploaded logo is displayed instead of the "Upload file" test
4. Confirm that the logos display in the sizes that they will appear on the instance
5. Confirm that spaces between the elements match the design shown in the linked comment