### PR TITLE
WIP: [BB-3969] Show color picker on swatch click

### DIFF
--- a/frontend/src/ui/components/ColorInputField/ColorInputField.tsx
+++ b/frontend/src/ui/components/ColorInputField/ColorInputField.tsx
@@ -8,7 +8,7 @@ import {
   OverlayTrigger
 } from 'react-bootstrap';
 
-import { SketchPicker } from 'react-color';
+import { PhotoshopPicker } from 'react-color';
 import { WrappedMessage } from 'utils/intl';
 import { messages as internalMessages } from './displayMessages';
 import './styles.scss';
@@ -38,11 +38,30 @@ export const ColorInputField: React.FC<ColorInputFieldProps> = (
     setColorPicker(!colorPicker);
   };
 
+  const onKeyToggleColorPicker = (event: any) => {
+    if (event && event.type === 'keyup') {
+      toggleColorPicker();
+    }
+  };
+
   const resetColor = () => {
     // This will reset the field value to the default theme value
     // TODO: this will need to be updated when the Theme configuration endpoint
     // get updated to improve consistency
     props.onChange(props.fieldName, '');
+  };
+
+  const hideColorPicker = () => {
+    setColorPicker(false);
+  };
+
+  const hideColorPickerAndSubmit = () => {
+    hideColorPicker();
+
+    if (selectedColor !== props.initialValue) {
+      // Only trigger action if value changed
+      props.onChange(props.fieldName, selectedColor);
+    }
   };
 
   /**
@@ -51,14 +70,6 @@ export const ColorInputField: React.FC<ColorInputFieldProps> = (
    * props.initialColor and never made the request.
    */
   React.useEffect(() => {
-    const hideColorPickerAndSubmit = () => {
-      setColorPicker(false);
-
-      if (selectedColor !== props.initialValue) {
-        // Only trigger action if value changed
-        props.onChange(props.fieldName, selectedColor);
-      }
-    };
     /**
      * Bind function to document to detect when
      * user clicks outside color picker.
@@ -68,7 +79,7 @@ export const ColorInputField: React.FC<ColorInputFieldProps> = (
         pickerContainer.current &&
         !pickerContainer.current.contains(event.target)
       ) {
-        hideColorPickerAndSubmit();
+        hideColorPicker();
       }
     };
     document.addEventListener('mousedown', handleClick);
@@ -101,12 +112,16 @@ export const ColorInputField: React.FC<ColorInputFieldProps> = (
           name={props.fieldName}
           value={fieldValue()}
           disabled={props.loading}
-          onClick={toggleColorPicker}
           readOnly
         />
 
         <div
           className="input-field-preview"
+          onClick={toggleColorPicker}
+          onKeyUp={onKeyToggleColorPicker}
+          role="button"
+          aria-label="Toggle color picker"
+          tabIndex={0}
           style={{
             backgroundColor: props.initialValue
           }}
@@ -139,10 +154,15 @@ export const ColorInputField: React.FC<ColorInputFieldProps> = (
 
       {colorPicker ? (
         <div ref={pickerContainer} className="input-color-picker">
-          <SketchPicker
+          <PhotoshopPicker
             color={selectedColor}
             onChangeComplete={color => {
               setColor(color.hex);
+            }}
+            onAccept={hideColorPickerAndSubmit}
+            onCancel={() => {
+              setColor(props.initialValue);
+              hideColorPicker();
             }}
           />
         </div>

--- a/frontend/src/ui/components/ColorInputField/styles.scss
+++ b/frontend/src/ui/components/ColorInputField/styles.scss
@@ -20,6 +20,7 @@
     position: absolute;
     border: 1px solid black;
     margin-left: 10px;
+    cursor: pointer;
   }
 
   .reset-value {


### PR DESCRIPTION
**Description**
This PR implements the following changes:

1. Replaces SketchPicker with PhotoshopPicker to allow the use of "Ok" and "Cancel" buttons
2. Removes color picker toggle from hex field
3. Save color changes once accepted

**Supporting information**
[Gitlab issue](https://gitlab.com/opencraft/dev/opencraft/-/issues/725)
[Jira ticket](https://tasks.opencraft.com/browse/BB-3969)

The Gitlab issue mentions having a "Choose" button but this PR has the button as "Ok"

**Testing instructions**
1. Sign in to the console
2. Navigate to any page containing a color input field e.g. Footer
3. Click on the swatch to confirm that a color picker is displayed
4. Confirm that the changes on the color picker are saved only when the "Ok" button is clicked