### PR TITLE
[BB-4015] Cronjob for getting monthly active user count

### DIFF
--- a/instance/management/commands/instance_statistics_csv.py
+++ b/instance/management/commands/instance_statistics_csv.py
@@ -299,8 +299,8 @@ class Command(BaseCommand):
 
         csv_writer = csv.writer(out, quoting=csv.QUOTE_NONNUMERIC)
         csv_writer.writerow([
-                'Fully Qualified Domain Name',
-                'Active Users'])
+            'Fully Qualified Domain Name',
+            'Active Users'])
 
         for instance in instances:
             cursor = instance.get_mysql_cursor_for_db('edxapp')

--- a/reports/tasks.py
+++ b/reports/tasks.py
@@ -128,6 +128,7 @@ def send_trial_instances_report(recipients=settings.TRIAL_INSTANCES_REPORT_RECIP
 
     return email.send()
 
+
 # Run on the 1st of every month
 @db_periodic_task(
     crontab(


### PR DESCRIPTION
## Description

This adds a task similar to the existing monthly report. It sends an email with the number of logged in users for the past month for each instance.

## Supporting information

BB-4015

## Testing instructions

The management script can be run manually and it will generate a CSV.

The Huey task can be tested by setting it to run more frequently (on stage?) and check whether the results are ok.


## Other information

It may make sense to refactor this, as the new periodic task is very similar of the existing one.
The crontab setting may need to be different so it does not reuse the exact same ones as the other report task.