### PR TITLE
Remove installing of Xenial-specific packages

### DIFF
--- a/instance/tests/integration/ansible/playbooks/failignore.yml
+++ b/instance/tests/integration/ansible/playbooks/failignore.yml
@@ -1,15 +1,4 @@
 ---
-- name: Bootstrap instance(s)
-  hosts: all
-  gather_facts: no
-  become: True
-  tasks:
-    - name: Update apt-get
-      raw: "apt-get update -qq"
-
-    - name: Install packages
-      raw: "apt-get install -qq python-minimal"
-
 - name: Fail and ignore on purpose
   hosts: all
   become: true

--- a/instance/tests/integration/ansible/playbooks/failure.yml
+++ b/instance/tests/integration/ansible/playbooks/failure.yml
@@ -1,15 +1,4 @@
 ---
-- name: Bootstrap instance(s)
-  hosts: all
-  gather_facts: no
-  become: True
-  tasks:
-    - name: Update apt-get
-      raw: "apt-get update -qq"
-
-    - name: Install packages
-      raw: "apt-get install -qq python-minimal"
-
 - name: Fail on purpose
   hosts: all
   tasks:


### PR DESCRIPTION
We started using Ubuntu 20.04 image for integration tests. It doesn't have `python-minimal` package.

Test instructions:
1. Verify that all CI checks passed.