### PR TITLE
Allow disabling of bulk emails 

### DIFF
--- a/e2e_tests/tests/test_password_reset.py
+++ b/e2e_tests/tests/test_password_reset.py
@@ -369,7 +369,7 @@ class ResetPasswordConfirmTestCase(BrowserLiveServerTestCase):
         password_field.send_keys(self.strong_password)
         submit_btn.click()
         self.wait.until(
-            EC.url_changes((By.CLASS_NAME, self.login_page_url))
+            EC.url_changes(self.login_page_url)
         )
 
         self.assertEqual(self.browser.current_url, self.console_home_url)

--- a/instance/models/openedx_appserver.py
+++ b/instance/models/openedx_appserver.py
@@ -395,7 +395,7 @@ class OpenEdXAppServer(AppServer, OpenEdXAppConfiguration, AnsibleAppServerMixin
             source_repo=os.path.join(settings.SITE_ROOT, 'playbooks/enable_bulk_emails'),
             requirements_path='requirements.txt',
             playbook_path='enable_bulk_emails.yml',
-            variables='{}',
+            variables=self.configuration_settings,
         )
 
     def get_playbooks(self):

--- a/playbooks/enable_bulk_emails/enable_bulk_emails.yml
+++ b/playbooks/enable_bulk_emails/enable_bulk_emails.yml
@@ -5,6 +5,9 @@
 
 - hosts: all
   become: yes
+  vars:
+    ENABLE_BULK_EMAILS: True
   tasks:
     - name: Create BulkEmailFlag object with enabled field set to true.
-      shell: "echo 'from bulk_email.models import BulkEmailFlag; BulkEmailFlag.objects.create(enabled=True, require_course_email_auth=False)' | /edx/bin/edxapp-shell-lms"
+      shell: "echo 'from lms.djangoapps.bulk_email.models import BulkEmailFlag; BulkEmailFlag.objects.create(enabled=True, require_course_email_auth=False)' | /edx/bin/edxapp-shell-lms"
+      when: ENABLE_BULK_EMAILS


### PR DESCRIPTION
This PR fixes deprecated in recent `edx-platform` way to import LMS application. Also, it adds gating flag to `enable_bulk_emails.yml`, so we can disable this playbook for new instances on older releases, which don't support new import style.

Also, second commit fixes typo because of which `e2e-tests` CI step was flaky.

**JIRA tickets**:
- [FAL-51](https://tasks.opencraft.com/browse/FAL-51)

**Discussions**:
- [MatterMost thread](https://chat.opencraft.com/opencraft/pl/cazshxzz7b8j7jg7gtb5k4r4me).

**Testing instructions**:

1. Check extra configuration of [this instance](https://stage.manage.opencraft.com/instance/7700/) and ensure that it has `ENABLE_BULK_EMAILS` equal to `false`.
2. Open Ansible logs for the app server and check that task with `Create BulkEmailFlag object with enabled field set to true` name was skipped.

**Reviewers**
- [x] @farhaanbukhsh or @giovannicimolin 

**Settings**
```yaml
ENABLE_BULK_EMAILS: false
```