### PR TITLE
[BB-4096] koa.2a -> koa.3

### DIFF
--- a/documentation/howtos.md
+++ b/documentation/howtos.md
@@ -54,7 +54,7 @@ ECOMMERCE_REPOS:
     REPO: 'ecommerce.git'
     # Use a branch which contains this fix:
     # https://github.com/open-craft/ecommerce/pull/13/files
-    VERSION: opencraft-release/koa.2a
+    VERSION: opencraft-release/koa.3
     DESTINATION: "{{ ecommerce_code_dir }}"
     SSH_KEY: '{{ ECOMMERCE_GIT_IDENTITY }}'
 

--- a/instance/models/mixins/openedx_config.py
+++ b/instance/models/mixins/openedx_config.py
@@ -460,7 +460,7 @@ class OpenEdXConfigMixin(ConfigMixinBase):
         if self._is_openedx_release_in(['koa']):
             # See https://github.com/open-craft/cs_comments_service/pull/10
             template["forum_source_repo"] = "https://github.com/open-craft/cs_comments_service.git"
-            template["FORUM_VERSION"] = "opencraft-release/koa.2a"
+            template["FORUM_VERSION"] = "opencraft-release/koa.3"
 
         return template
 

--- a/instance/tests/integration/factories/instance.py
+++ b/instance/tests/integration/factories/instance.py
@@ -79,8 +79,8 @@ class OpenEdXInstanceFactory(DjangoModelFactory):
     # or a release candidate tag will work.  We point both the edx-platform and the configuration
     # versions to the branch "integration" in our own forks.  These branches are based on the
     # corresponding openedx_release versions from upstream, but can contain custom modifications.
-    openedx_release = 'open-release/koa.2a'
+    openedx_release = 'open-release/koa.3'
     configuration_source_repo_url = 'https://github.com/open-craft/configuration.git'
-    configuration_version = 'integration-koa'
+    configuration_version = 'integration-koa.3'
     edx_platform_repository_url = 'https://github.com/open-craft/edx-platform.git'
-    edx_platform_commit = 'opencraft-release/koa.2a'
+    edx_platform_commit = 'opencraft-release/koa.3'

--- a/opencraft/settings.py
+++ b/opencraft/settings.py
@@ -432,7 +432,7 @@ DEFAULT_CONFIGURATION_VERSION = env('DEFAULT_CONFIGURATION_VERSION', default=DEF
 
 # Git ref for stable Open edX release. Used as a default refspec for
 # configuration, edx-platform, forum, notifier, xqueue, and certs when creating production instances.
-OPENEDX_RELEASE_STABLE_REF = env('OPENEDX_RELEASE_STABLE_REF', default='open-release/koa.2a')
+OPENEDX_RELEASE_STABLE_REF = env('OPENEDX_RELEASE_STABLE_REF', default='open-release/koa.3')
 
 # The edx-platform repository used by default for production instances
 STABLE_EDX_PLATFORM_REPO_URL = env(
@@ -444,7 +444,7 @@ STABLE_EDX_PLATFORM_COMMIT = env('STABLE_EDX_PLATFORM_COMMIT', default=OPENEDX_R
 STABLE_CONFIGURATION_REPO_URL = env(
     'STABLE_CONFIGURATION_REPO_URL', default=DEFAULT_CONFIGURATION_REPO_URL
 )
-STABLE_CONFIGURATION_VERSION = env('STABLE_CONFIGURATION_VERSION', default='opencraft-release/koa.2a')
+STABLE_CONFIGURATION_VERSION = env('STABLE_CONFIGURATION_VERSION', default='opencraft-release/koa.3')
 
 # The name of the security group to use for edxapp App servers.
 # This is used to set appropriate firewall rules to prevent external access to


### PR DESCRIPTION
This PR updates Ocim to use `opencraft-release/koa.3` branch for new instances and `integration-koa.3` branch for integration tests.

**JIRA tickets**:
- [BB-4096](https://tasks.opencraft.com/browse/BB-4096)

**Dependencies**:
- https://github.com/open-craft/ansible-secrets/pull/264

**Testing instructions**:

Ensure that PR passed all CI pipeline checks.

**Reviewers**
- [ ] @janimo 