### PR TITLE
[FAL-960] Copy static overrides to instance on creation

### DIFF
--- a/playbooks/enable_bulk_emails/enable_bulk_emails.yml
+++ b/playbooks/enable_bulk_emails/enable_bulk_emails.yml
@@ -1,7 +1,6 @@
 ---
-# A simple one-off playbook that allows starting and stopping instance services.
-# This is used by Ocim to stop celery workers from inactive appservers to pick
-# up tasks.
+# This playbook creates a BulkEmailFlag to automatically enable bulk email for new instances.
+# It is run when provisioning the first appserver for the instance.
 
 - hosts: all
   become: yes

--- a/registration/provision.py
+++ b/registration/provision.py
@@ -86,6 +86,11 @@ def _provision_instance(sender, **kwargs):
             application.instance.deploy_simpletheme = True
             application.instance.save()
 
+        # Add static content overrides to the instance
+        if application.draft_static_content_overrides:
+            application.instance.static_content_overrides = application.draft_static_content_overrides
+            application.instance.save()
+
         # If using external domain, set it up
         if application.external_domain:
             application.instance.external_lms_domain = application.external_domain


### PR DESCRIPTION
Copy draft static overrides when provisioning a new betatest instance.

We were already copying other configuration from the betatest app, but forgot about static overrides.
Copying everything ensures that the UI doesn't show any pending changes while the first appserver is being provisioned.

Ticket: [FAL-960](https://tasks.opencraft.com/browse/FAL-960)

**Test instructions**:

1. Register a new account on Ocim stage and validate your email.
2. Your instance should start being provisioned.
3. Verify that the deployment toolbar says "Publishing" and that there are no pending changes.
4. Make some changes to your instance configuration.
5. Verify that the deployment toolbar now shows the number of pending changes.

**Reviewers**

- [ ] @farhaanbukhsh 