### PR TITLE
BB-4097 Add settings and variables for self hosted Oracle JDK

### DIFF
--- a/instance/models/mixins/openedx_config.py
+++ b/instance/models/mixins/openedx_config.py
@@ -415,6 +415,16 @@ class OpenEdXConfigMixin(ConfigMixinBase):
                     "FUNCTION": "retirement_lms_retire",
                 },
             ],
+
+            # Self-hosted OracleJDK settings
+            "USE_PRIVATE_ORACLEJDK": settings.USE_PRIVATE_ORACLEJDK,
+            "oraclejdk_s3": {
+                "region": settings.AWS_S3_ORACLEJDK_REGION,
+                "access_key": settings.AWS_S3_ORACLEJDK_ACCESS_KEY_ID,
+                "secret_key": settings.AWS_S3_ORACLEJDK_ACCESS_SECRET_KEY,
+                "bucket_name": settings.AWS_S3_ORACLEJDK_BUCKET,
+                "filename": settings.AWS_S3_ORACLEJDK_FILE,
+            }
         }
 
         if self.smtp_relay_settings:

--- a/opencraft/settings.py
+++ b/opencraft/settings.py
@@ -956,3 +956,19 @@ MAILCHIMP_LIST_ID_FOR_TRIAL_USERS = env('MAILCHIMP_LIST_ID_FOR_TRIAL_USERS', def
 # Batched updates are maximum 500 members at a time, as per
 # https://github.com/VingtCinq/python-mailchimp/blob/ad09dee/mailchimp3/entities/lists.py#L146
 MAILCHIMP_BATCH_SIZE = env.int('MAILCHIMP_BATCH_SIZE', default=500)
+
+# Self hosted OracleJDK settings
+USE_PRIVATE_ORACLEJDK = env.bool("USE_PRIVATE_ORACLEJDK", False)
+
+# Must be set to access the Oracle JDK file when provisioning Appserver
+#
+# Minimum permissions required for this IAM user
+#
+# iam:AmazonS3ReadOnlyAccess
+#
+
+AWS_S3_ORACLEJDK_ACCESS_KEY_ID = env("AWS_S3_ORACLEJDK_ACCESS_KEY_ID", default="")
+AWS_S3_ORACLEJDK_ACCESS_SECRET_KEY = env("AWS_S3_ORACLEJDK_ACCESS_SECRET_KEY", default="")
+AWS_S3_ORACLEJDK_REGION = env("AWS_S3_ORACLEJDK_REGION", default="")
+AWS_S3_ORACLEJDK_BUCKET = env("AWS_S3_ORACLEJDK_BUCKET", default="")
+AWS_S3_ORACLEJDK_FILE = env("AWS_S3_ORACLEJDK_FILE", default="")


### PR DESCRIPTION
Adds settings related to self-hosted oracle jdk and add them to ansible variables for appserver

**Related Tickets**: [BB-4097](https://tasks.opencraft.com/browse/BB-4097)

**Testing Instructions**:
1. Checkout to this branch
2. Open configuration pull request at https://github.com/open-craft/configuration/pull/158/files
3. Verify that correspondingly correct ansible variables are added for "Download Oracle Java from private S3 bucket" tasks.
4. Verify that all added ansible variables are configurable through django settings.

Author Notes:

1. The changes done here might have to be reverted after [FAL-1865](https://tasks.opencraft.com/browse/FAL-1865) is resolved
2. I have deployed and instance appserver https://stage.manage.opencraft.com/instance/7770/edx-appserver/3280/. The working can be verified by looking at the configuration and logs of this appserver.