### PR TITLE
fix: fixed the style for registration page

### DIFF
--- a/frontend/src/registration/components/RegistrationContainer/styles.scss
+++ b/frontend/src/registration/components/RegistrationContainer/styles.scss
@@ -1,0 +1,8 @@
+@import '~styles/theme';
+
+.registration-container {
+  background-image: url("~assets/header-background.jpg");
+  background-color: $primary-1;
+  background-size: 100% 350px;
+  background-repeat: no-repeat;
+}


### PR DESCRIPTION
Fix the registration styling in the page

**JIRA tickets**: [BB-3786](https://tasks.opencraft.com/browse/BB-3786)

**Discussions**: [Mattermost](https://chat.opencraft.com/opencraft/pl/aeq3b9x8i7noxqsugnqd8mj58o)

**Dependencies**: None

**Screenshots**: 

Before:
![image](https://user-images.githubusercontent.com/7670449/116522385-c5433480-a8f2-11eb-8f10-1d2000ad1123.png)

After:
![image](https://user-images.githubusercontent.com/7670449/116522450-d8560480-a8f2-11eb-8030-d18729448cd5.png)



**Sandbox URL**: TBD - sandbox is being provisioned.


**Testing instructions**:

1. Set up the Devstack
2. Go to the registration page it should have the background image

**Author notes and concerns**:

This is a way to fix the current UI

**Reviewers**

- [ ] @0x29a 