### PR TITLE
BB-4097: Add setting OPENEDX_ORACLEJDK_URL

### DIFF
--- a/instance/models/mixins/openedx_config.py
+++ b/instance/models/mixins/openedx_config.py
@@ -469,6 +469,9 @@ class OpenEdXConfigMixin(ConfigMixinBase):
             template["forum_source_repo"] = "https://github.com/open-craft/cs_comments_service.git"
             template["FORUM_VERSION"] = "opencraft-release/koa.3"
 
+        if settings.OPENEDX_ORACLEJDK_URL:
+            template["oraclejdk_url"] = settings.OPENEDX_ORACLEJDK_URL
+
         return template
 
     def _get_prometheus_variables(self):

--- a/opencraft/settings.py
+++ b/opencraft/settings.py
@@ -962,3 +962,7 @@ MAILCHIMP_BATCH_SIZE = env.int('MAILCHIMP_BATCH_SIZE', default=500)
 # Marketing app settings
 MARKETING_DELETE_FOLLOWUP_EMAILS_AFTER_DAYS = env.int('MARKETING_DELETE_FOLLOWUP_EMAILS_AFTER_DAYS', default=30)
 MARKETING_EMAIL_SENDER = env('MARKETING_EMAIL_SENDER', default=DEFAULT_FROM_EMAIL)
+
+# The download url for Oracle JDK to use when provisioning Appserver.
+# This will be passed to ansible playbook variable `oraclejdk_url`.
+OPENEDX_ORACLEJDK_URL = env.str('OPENEDX_ORACLEJDK_URL', default='')


### PR DESCRIPTION
Adds setting OPENEDX_ORACLEJDK_URL which is used
in appserver configuration variables as `oraclejdk_url`

**JIRA Ticket** [BB-4097](https://tasks.opencraft.com/browse/BB-4097)

**Testing Instructions**
TBD