### PR TITLE
fix: [BB-4143] Reused style in registration

### DIFF
--- a/frontend/src/registration/components/RegistrationContainer/styles.scss
+++ b/frontend/src/registration/components/RegistrationContainer/styles.scss
@@ -1,8 +1,5 @@
 @import '~styles/theme';
 
 .registration-container {
-  background-image: url("~assets/header-background.jpg");
-  background-color: $primary-1;
-  background-size: 100% 350px;
-  background-repeat: no-repeat;
+  @include add-background-image;
 }

--- a/frontend/src/registration/components/RegistrationContainer/styles.scss
+++ b/frontend/src/registration/components/RegistrationContainer/styles.scss
@@ -1,5 +1,5 @@
 @import '~styles/theme';
 
 .registration-container {
-  @include add-background-image;
+  @include set-header-background;
 }

--- a/frontend/src/styles/_theme.scss
+++ b/frontend/src/styles/_theme.scss
@@ -81,3 +81,10 @@ body {
     color: $secondary-1;
   }
 }
+
+@mixin add-background-image {
+  background-image: url("~assets/header-background.jpg");
+  background-color: $primary-1;
+  background-size: 100% 350px;
+  background-repeat: no-repeat;
+}

--- a/frontend/src/styles/_theme.scss
+++ b/frontend/src/styles/_theme.scss
@@ -82,7 +82,7 @@ body {
   }
 }
 
-@mixin add-background-image {
+@mixin set-header-background {
   background-image: url("~assets/header-background.jpg");
   background-color: $primary-1;
   background-size: 100% 350px;

--- a/frontend/src/ui/components/ContentPage/styles.scss
+++ b/frontend/src/ui/components/ContentPage/styles.scss
@@ -6,7 +6,7 @@
   flex-direction: column;
   align-items: stretch;
   width: 100%;
-  @include add-background-image;
+  @include set-header-background;
 
   .title-container {
     margin: 60px;

--- a/frontend/src/ui/components/ContentPage/styles.scss
+++ b/frontend/src/ui/components/ContentPage/styles.scss
@@ -6,10 +6,7 @@
   flex-direction: column;
   align-items: stretch;
   width: 100%;
-  background-image: url("~assets/header-background.jpg");
-  background-color: $primary-1;
-  background-size: 100% 350px;
-  background-repeat: no-repeat;
+  @include add-background-image;
 
   .title-container {
     margin: 60px;


### PR DESCRIPTION
Reused the style for background image

**JIRA tickets**: [BB-4143](https://tasks.opencraft.com/browse/BB-4143)

**Discussions**: [PR](https://github.com/open-craft/opencraft/pull/784#pullrequestreview-648083241)

~~**Dependencies**: None~~

**Screenshots**:

![image](https://user-images.githubusercontent.com/7670449/117048122-46a22900-ad30-11eb-80d8-6db255bc5080.png)
 

~~**Sandbox URL**: TBD - sandbox is being provisioned.~~

~~**Merge deadline**: "None" if there's no rush, "ASAP" if it's critical, or provide a specific date if there is one.~~

**Testing instructions**:

1. Get the devstack running 
2. Check http://localhost:3000/registration/domain
3. Check the congratulation page as well

**Author notes and concerns**:

1. Instead of using the same class I went with mixin approach

**Reviewers**
- [ ] @0x29a 
