### PR TITLE
WIP: [FAL-1865] Update default openedx_config to use openjdk instead of oraclejdk

### DIFF
--- a/instance/models/mixins/openedx_config.py
+++ b/instance/models/mixins/openedx_config.py
@@ -415,6 +415,9 @@ class OpenEdXConfigMixin(ConfigMixinBase):
                     "FUNCTION": "retirement_lms_retire",
                 },
             ],
+
+            # Install OpenJDK instead of OracleJDK
+            "USE_OPENJDK": True,
         }
 
         if self.smtp_relay_settings:


### PR DESCRIPTION
Update the default sandbox config so that openjdk is installed instead of oraclejdk.

**JIRA tickets**:  https://tasks.opencraft.com/browse/FAL-1865

**Dependencies**:  https://github.com/open-craft/configuration/pull/161

**Testing instructions**:

1.

**Author notes and concerns**:

1.

**Reviewers**:

- [ ] <GitLab username>
