### PR TITLE
Stay logged in to our instances [MNG-1938]

### DIFF
--- a/instance/models/mixins/openedx_config.py
+++ b/instance/models/mixins/openedx_config.py
@@ -34,6 +34,17 @@ class OpenEdXConfigMixin(ConfigMixinBase):
         """
         Creates and returns a dictionary of ansible configuration variables for the instance
         """
+        # Vars that need to be set in both EDXAPP_LMS_ENV_EXTRA and EDXAPP_CMS_ENV_EXTRA:
+        extra_config = {
+            "BROKER_HEARTBEAT": 0,
+            "ADDL_INSTALLED_APPS": [],
+            # Stay logged in for one year, not two weeks
+            "SESSION_COOKIE_AGE": 31536000,
+            # Use database-backed sessions to stay logged in across appserver deploys.
+            # (We have EDXAPP_CLEARSESSIONS_CRON_ENABLED to clean up old data.)
+            "SESSION_ENGINE": "django.contrib.sessions.backends.cached_db",
+        }
+
         template = {
             # System
             "COMMON_HOSTNAME": self.server_hostname,
@@ -63,14 +74,10 @@ class OpenEdXConfigMixin(ConfigMixinBase):
             # Note: use EDXAPP_CMS_ENV_EXTRA and/or EDXAPP_LMS_ENV_EXTRA; don't use
             # EDXAPP_ENV_EXTRA as the other two overwrite this.
             "EDXAPP_CMS_ENV_EXTRA": {
-                "BROKER_HEARTBEAT": 0,
-                "ADDL_INSTALLED_APPS": [
-                ],
+                **extra_config,
             },
             "EDXAPP_LMS_ENV_EXTRA": {
-                "BROKER_HEARTBEAT": 0,
-                "ADDL_INSTALLED_APPS": [
-                ],
+                **extra_config,
                 "HEARTBEAT_EXTENDED_CHECKS": [
                     # celery check is default, but we need to include it here
                     # because we also add other extended checks


### PR DESCRIPTION
[MNG-1938](https://tasks.opencraft.com/browse/MNG-1938)

This PR changes the default config for all our instances so that:
* Users stay logged in for a full year, not the default of two weeks
* Database-backed sessions ensure that users don't get logged out every time we deploy a new app server

The motivation for this is that I find it annoying to have to log in again every time I visit courses.opencraft.com.

This configuration has already been tested on the **courses.opencraft.com** Ocim instance, and it works: I stayed logged in for over two weeks and across app server deploys.

Some history:

> In OC-2096, the `SESSION_ENGINE` was changed (#258) but was later reverted (#271 ) due to possibly misplaced concerns about our (A) MySQL server (which at the time was a single server using spinning hard drives), and (B) the potential for sessions to build up in the database and never get cleared. We found that sessions generally only get read/written from the database on login/logout, and we've now upgraded our MySQL to an SSD cluster, so (A) should no longer be an issue, and thanks to OC-3742 we have a cron job that will clear old sessions regularly, solving (B).
>
> So we should now we safe to make these two changes for all our instances.