### PR TITLE
[BB-4059] Stop all workers on appservers that failed provisioning

### DIFF
--- a/instance/models/openedx_appserver.py
+++ b/instance/models/openedx_appserver.py
@@ -660,6 +660,7 @@ class OpenEdXAppServer(AppServer, OpenEdXAppConfiguration, AnsibleAppServerMixin
                 self.logger.info('Provisioning failed')
                 self._status_to_configuration_failed()
                 self.provision_failed_email("AppServer deploy failed: Ansible play exited with non-zero exit code", log)
+                self.manage_instance_services(active=False)
                 return False
 
             # Reboot
@@ -677,6 +678,7 @@ class OpenEdXAppServer(AppServer, OpenEdXAppConfiguration, AnsibleAppServerMixin
             message = "AppServer deploy failed: unhandled exception"
             self.logger.exception(message)
             self.provision_failed_email(message)
+            self.manage_instance_services(active=False)
             return False
 
     def manage_instance_services(self, active):


### PR DESCRIPTION
If Ansible process exited with non-zero code, we want to stop celery workers, because they are stealing tasks from other, healthy app servers.

**JIRA tickets**:
- [BB-4059](https://tasks.opencraft.com/browse/BB-4059)

**Sandbox URL**:
- https://stage.manage.opencraft.com/instance/7920/edx-appserver/3309/

**Testing instructions**:

What I did:
1. Created a [branch](https://github.com/open-craft/configuration/tree/0x29a/bb4059/stop_services_if_provision_failed) in `open-craft/configuration` repo with change that makes main playbook fail early.
2. Created [instance](https://stage.manage.opencraft.com/instance/7920) and configured it to use this branch.
3. Then I switched staging Ocim to `0x29a/bb4059/stop_services_if_provision_failed` branch and created [appserver](https://stage.manage.opencraft.com/instance/7920/edx-appserver/3309/).

What reviewer has to test:
1. Go to https://stage.manage.opencraft.com/instance/7920/edx-appserver/3309/ and click on "Logs".
2. Check these logs and verify that after configuration failed, Ocim tried to stop celery workers.

**Reviewers**
- [ ] @kewne 