### PR TITLE
[BB-3729] Bug: OCIM allots a RabbitMQServer randomly and ignores the accepts_new_clients flag

### DIFF
--- a/instance/tests/models/factories/__init__.py
+++ b/instance/tests/models/factories/__init__.py
@@ -1,0 +1,7 @@
+"""
+Factories module.
+"""
+from .database_server import MySQLServerFactory
+from .openedx_appserver import make_test_appserver
+from .openedx_instance import OpenEdXInstanceFactory
+from .rabbitmq_server import RabbitMQServerFactory

--- a/instance/tests/models/factories/rabbitmq_server.py
+++ b/instance/tests/models/factories/rabbitmq_server.py
@@ -1,0 +1,21 @@
+"""
+Factories related to RabbitMQ.
+"""
+import factory
+import factory.django as django_factory
+
+from instance.models.rabbitmq_server import RabbitMQServer
+
+class RabbitMQServerFactory(django_factory.DjangoModelFactory):
+    """
+    Factory for RabbitMQServer.
+    """
+
+    class Meta:
+        model = RabbitMQServer
+
+    name = factory.Sequence(lambda n: f"RabbitMQ {n}")
+    admin_username = "admin"
+    admin_password = "admin"
+    instance_host = factory.Sequence(lambda n: f"rabbitmq-{n}.test")
+    api_url = factory.LazyAttribute(lambda o: f"https://{o.instance_host}/api")


### PR DESCRIPTION
This adds tests that verify new `OpenEdXInstance` instances are correctly assigned RabbitMQ instances that have `accepts_new_clients=True`.


# Related issues
* [BB-3729](https://tasks.opencraft.com/browse/BB-3729)

# Testing

```sh
make test.one make test.one instance.tests.models.test_openedx_instance.OpenEDXInstanceRabbitMQTestCase
```