### PR TITLE
fix: Separate tos and honor mktg links

### DIFF
--- a/instance/models/mixins/openedx_config.py
+++ b/instance/models/mixins/openedx_config.py
@@ -89,7 +89,14 @@ class OpenEdXConfigMixin(ConfigMixinBase):
                     "BLOG": "",
                     # use different contact page
                     "CONTACT": "/contact",
+                    # Explicitly set TOS_AND_HONOR link to '#' so that they are not combined.
+                    "TOS_AND_HONOR": "#"
                 },
+            },
+            "EDXAPP_MKTG_URL_LINK_MAP": {
+                # set the tos and honor pages separately. Required for koa and above.
+                "TOS": "tos",
+                "HONOR": "honor"
             },
             "EDXAPP_LMS_NGINX_PORT": 80,
             "EDXAPP_LMS_SSL_NGINX_PORT": 443,


### PR DESCRIPTION
With koa, the tos and honor link in footer
are combined to one. To separate them TOS and HONOR
is set in EDXAPP_MKTG_URL_LINK_MAP to use static templates

### Related Tickets
[BB-4145](https://tasks.opencraft.com/browse/BB-4145)

### Testing Instructions

1. Visit https://stage.manage.opencraft.com/instance/7770/edx-appserver/3310/
2. Verify that following configuration is present in appserver
```
EDXAPP_MKTG_URL_LINK_MAP:
  HONOR: honor
  TOS: tos
```
3. Verify that the instance runs on `koa`
4. Visit https://bb-4097.stage.opencraft.hosting/
5. Verify that the `ToS` and `Honor` links are separate