### PR TITLE
[BB-4226] fix: handle the exceptions when deleting the obsolete appservers

### DIFF
--- a/instance/tasks.py
+++ b/instance/tasks.py
@@ -241,8 +241,11 @@ def terminate_obsolete_appservers_all_instances():
     Terminate obsolete app servers for all instances.
     """
     for instance in OpenEdXInstance.objects.all():
-        instance.logger.info("Terminating obsolete appservers for instance")
-        instance.terminate_obsolete_appservers()
+        instance.logger.info("Terminating obsolete appservers for instance %s", instance.domain)
+        try:
+            instance.terminate_obsolete_appservers()
+        except Exception:  # pylint:disable=broad-except
+            instance.logger.exception('Error deleting the obsolete appservers for instance %s', instance.domain)
 
 
 @db_periodic_task(crontab(day='*/1', hour='1', minute='0'))


### PR DESCRIPTION
This will prevent the cleanup task from aborting due to any exceptions
and missing the cleanup of all the remaining instances.