### PR TITLE
[BB-4226] test: fixes test when terminating obsolete appservers

### DIFF
--- a/instance/tests/test_tasks.py
+++ b/instance/tests/test_tasks.py
@@ -379,7 +379,7 @@ class CleanUpTestCase(TestCase):
 
         self.assertEqual(mock_terminate_appservers.call_count, 5)
         self.assertEqual(mock_logger.call_count, 10)
-        mock_logger.assert_called_with("Terminating obsolete appservers for instance", {})
+        mock_logger.assert_called_with("Terminating obsolete appservers for instance %s", {})
 
     @ddt.data(
         {'pr_state': 'closed', 'pr_days_since_closed': 4, 'instance_is_archived': False},


### PR DESCRIPTION
Makes the same adjustment that was created in https://github.com/open-craft/opencraft/pull/797 to the unit test which was failing because the mock logger wasn't being called with the updated string