### PR TITLE
BB-4198: Fix issues with package upgrades.

### DIFF
--- a/instance/models/server.py
+++ b/instance/models/server.py
@@ -364,9 +364,7 @@ class OpenStackServer(Server):
                 # server must have been terminated.
                 self.logger.debug('Server does not exist anymore: %s', self)
                 self._status_to_terminated()
-            except (requests.RequestException,
-                    novaclient.exceptions.ClientException,
-                    novaclient.exceptions.EndpointNotFound) as exc:
+            except (requests.RequestException, novaclient.exceptions.ClientException) as exc:
                 self.logger.debug('Could not reach the OpenStack API due to %s', exc)
                 if self.status != Status.Unknown:
                     self._status_to_unknown()
@@ -397,7 +395,7 @@ class OpenStackServer(Server):
                 key_name=key_name,
                 **kwargs
             )
-        except (novaclient.exceptions.ClientException, novaclient.exceptions.EndpointNotFound) as exc:
+        except novaclient.exceptions.ClientException as exc:
             self.logger.error('Failed to start server: %s', exc)
             self._status_to_build_failed()
         else:
@@ -456,9 +454,7 @@ class OpenStackServer(Server):
         except novaclient.exceptions.NotFound:
             self.logger.error('Error while attempting to terminate server: could not find OS server')
             self._status_to_terminated()
-        except (requests.RequestException,
-                novaclient.exceptions.ClientException,
-                novaclient.exceptions.EndpointNotFound) as exc:
+        except (requests.RequestException, novaclient.exceptions.ClientException) as exc:
             self.logger.error('Unable to reach the OpenStack API due to %s', exc)
             if self.status != Status.Unknown:
                 self._status_to_unknown()

--- a/instance/tasks.py
+++ b/instance/tasks.py
@@ -248,6 +248,19 @@ def terminate_obsolete_appservers_all_instances():
             instance.logger.exception('Error deleting the obsolete appservers for instance %s', instance.domain)
 
 
+@db_task()
+def terminate_appserver(appserver_id):
+    """
+    Terminate a appserver on the background (in worker thread).
+    """
+    logger.info("Terminating appserver %s.", appserver_id)
+    try:
+        app_server = OpenEdXAppServer.objects.get(id=appserver_id)
+        app_server.terminate_vm()
+    except Exception as exc:  # pylint:disable=broad-except
+        logger.exception('Error terminating appserver %s: %s', appserver_id, exc)
+
+
 @db_periodic_task(crontab(day='*/1', hour='1', minute='0'))
 def clean_up():
     """

--- a/instance/tests/models/test_server.py
+++ b/instance/tests/models/test_server.py
@@ -395,7 +395,6 @@ class OpenStackServerTestCase(TestCase):
     @data(
         requests.RequestException('Error'),
         novaclient.exceptions.ClientException('Error'),
-        novaclient.exceptions.EndpointNotFound('Error'),
     )
     def test_terminate_server_openstack_api_error(self, exception):
         """


### PR DESCRIPTION
Fixes two issues:
1. From Openstack package upgrade: an exception class was removed in favor of a more generic one.
2. Bug found while testing: Terminate VM is not a background task, which makes the web worker halt if the VM takes too long to shutdown (moved to a huey task).

This is currently deployed to stage.

**Reviewers:**
- [ ] Any FFs: @clemente @symbolist @itsjeyd (high priority review, some Ocim methods are broken on `master` without this)