### PR TITLE
[BB-4306] Fix Can't upgrade a READER transaction to a WRITER mid-transaction issue

### DIFF
--- a/instance/utils.py
+++ b/instance/utils.py
@@ -44,6 +44,7 @@ from dictdiffer import diff
 if TYPE_CHECKING:
     from registration.models import BetaTestApplication  # pylint: disable=cyclic-import, useless-suppression
 
+
 # Logging #####################################################################
 
 logger = logging.getLogger(__name__)
@@ -81,7 +82,8 @@ def to_json(obj):
 
 
 def get_requests_retry(total=10, connect=10, read=10, redirect=10, backoff_factor=0,
-                       status_forcelist=range(500, 600)):
+                       status_forcelist=settings.OPENSTACK_RETRYABLE_STATUS_CODES,
+                       method_whitelist=settings.OPENSTACK_RETRYABLE_METHOD_WHITELIST):
     """
     Returns a urllib3 `Retry` object, with the default requests retry policy
     """
@@ -92,6 +94,7 @@ def get_requests_retry(total=10, connect=10, read=10, redirect=10, backoff_facto
         redirect=redirect,
         backoff_factor=backoff_factor,
         status_forcelist=status_forcelist,
+        method_whitelist=method_whitelist,
     )
 
 

--- a/opencraft/settings.py
+++ b/opencraft/settings.py
@@ -331,6 +331,20 @@ OPENSTACK_PRODUCTION_INSTANCE_FLAVOR = env.json(
     default={"ram": 8192, "disk": 80}
 )
 
+# Openstack fails to connect randomly, thus we retry on certain status codes.
+# for example Openstack throws 400, and it will work if we keep retrying,
+# more on https://github.com/open-craft/opencraft/pull/805
+OPENSTACK_RETRYABLE_STATUS_CODES = env.list(
+    'OPENSTACK_RETRYABLE_STATUS_CODES',
+    default=list(range(500, 600))
+)
+
+# Set of uppercased HTTP method verbs that we should retry on.
+OPENSTACK_RETRYABLE_METHOD_WHITELIST = env.list(
+    'OPENSTACK_RETRYABLE_METHOD_WHITELIST',
+    default=frozenset(["HEAD", "GET", "PUT", "DELETE", "OPTIONS", "TRACE"])
+)
+
 # Separate credentials for Swift.  These credentials are currently passed on to each instance
 # when Swift is enabled.
 


### PR DESCRIPTION
## Description

This PR adds a fix for `Can't upgrade a READER transaction to a WRITER mid-transaction` issue during integration testing. This issue happens due to random failure thrown by OVH OpenStack API.

The solution provided is to retry on such failures. For example, the error mentioned above throws a 400 bad request error. We can retry all these errors with `Retry` provided in the `urllib3` package that `requests` uses. 

But the error mentioned above is thrown from a `POST` request and by default `Retry` doesn't retry on `POST` requests, to avoid multiple insertions. For our use case, we needed to override that by setting `method_whitelist`. 

## Supporting information

- https://tasks.opencraft.com/browse/BB-4306

## Testing instructions

- Check there is no `Can't upgrade a READER transaction to a WRITER mid-transaction` error in integration test

## Deadline

ASAP

## Other information

**Notes**
- `method_whitelist` exists in [urllib3 v1.25.3](https://github.com/urllib3/urllib3/blob/1.25.3/src/urllib3/util/retry.py#L97) (the version we currently use). But the latest version deprecated it (to be removed in urllib3 v2), instead it has [allowed_methods](https://github.com/urllib3/urllib3/blob/1.26.5/src/urllib3/util/retry.py#L154).


**Reviewers**

- [x] @arjunsinghy96 
- [ ] @clemente 