### PR TITLE
feature: Change default `ANSIBLE_PYTHON_PATH` [BB-3900]

### DIFF
--- a/instance/tests/test_ansible.py
+++ b/instance/tests/test_ansible.py
@@ -155,7 +155,7 @@ class AnsibleTestCase(TestCase):
             venv_path='/tmp/venv'
         )
         expected = (
-            'virtualenv -p /usr/bin/python /tmp/venv && '
+            f"virtualenv -p {ansible.ANSIBLE_PYTHON_PATH} /tmp/venv && "
             '/tmp/venv/bin/python -u /tmp/venv/bin/pip install -r /requirements/path.txt && '
             '/tmp/venv/bin/python -u /tmp/venv/bin/ansible-playbook -i /tmp/inventory/path '
             '-e @/tmp/vars/path -u root playbook_name'

--- a/opencraft/settings.py
+++ b/opencraft/settings.py
@@ -600,8 +600,8 @@ GANDI_DEFAULT_BASE_DOMAIN = env('GANDI_DEFAULT_BASE_DOMAIN', default=DEFAULT_INS
 
 # Ansible #####################################################################
 
-# Ansible requires a Python 2 interpreter
-ANSIBLE_PYTHON_PATH = env('ANSIBLE_PYTHON_PATH', default='/usr/bin/python')
+# The Python binary to use for running ansible.
+ANSIBLE_PYTHON_PATH = env('ANSIBLE_PYTHON_PATH', default=None)
 
 # Time in seconds to wait for the next log line when running an Ansible playbook.
 ANSIBLE_LINE_TIMEOUT = env.int('ANSIBLE_LINE_TIMEOUT', default=7200)  # 2 hours


### PR DESCRIPTION
This changes the default value of `ANSIBLE_PYTHON_PATH`
to "python", making it pick up whatever binary is in the
PATH.
For security reasons, this is not usually what you want
for production environments, so a check was created.

Related stories:
* [BB-3900](https://tasks.opencraft.com/browse/BB-3900)

h1. Testing

1. `./manage.py check --deploy` issues a warning if `ANSIBLE_PYTHON_PATH` is not set