### PR TITLE
FAL-1937 Disable learner records by default

### DIFF
--- a/instance/models/mixins/openedx_site_configuration.py
+++ b/instance/models/mixins/openedx_site_configuration.py
@@ -39,6 +39,8 @@ class OpenEdXSiteConfigurationMixin(models.Model):
         site_configuration_settings = {
             # default site configuration
             'CONTACT_US_CUSTOM_LINK': '/contact',
+            # Learner records depends on the credentials service, that isn't set up by default.
+            'ENABLE_LEARNER_RECORDS': False,
         }
 
         if self.static_content_overrides:

--- a/instance/tests/models/test_openedx_appserver.py
+++ b/instance/tests/models/test_openedx_appserver.py
@@ -1030,6 +1030,7 @@ class SiteConfigurationSettingsTestCase(TestCase):
                 {
                     'values': {
                         'CONTACT_US_CUSTOM_LINK': '/contact',
+                        'ENABLE_LEARNER_RECORDS': False,
                         'static_template_about_content': 'Hello world!',
                         'homepage_overlay_html': 'Welcome to the LMS!',
                     }

--- a/instance/tests/models/test_openedx_site_configuration_mixin.py
+++ b/instance/tests/models/test_openedx_site_configuration_mixin.py
@@ -45,6 +45,7 @@ class OpenEdXSiteConfigurationMixinsTestCase(TestCase):
                 {
                     'values': {
                         'CONTACT_US_CUSTOM_LINK': '/contact',
+                        'ENABLE_LEARNER_RECORDS': False,
                     }
                 }
             ]
@@ -70,6 +71,7 @@ class OpenEdXSiteConfigurationMixinsTestCase(TestCase):
                 {
                     'values': {
                         'CONTACT_US_CUSTOM_LINK': '/contact',
+                        'ENABLE_LEARNER_RECORDS': False,
                         'static_template_about_content': 'Hello world!',
                         'static_template_contact_content': 'Email: nobody@example.com',
                         'homepage_overlay_html': 'Welcome to the LMS!',
@@ -96,6 +98,7 @@ class OpenEdXSiteConfigurationMixinsTestCase(TestCase):
                 {
                     'values': {
                         'CONTACT_US_CUSTOM_LINK': '/contact',
+                        'ENABLE_LEARNER_RECORDS': False,
                         'static_template_about_content': 'வணக்கம்!',
                         'homepage_overlay_html': 'வணக்கம்',
                     }
@@ -121,6 +124,7 @@ class OpenEdXSiteConfigurationMixinsTestCase(TestCase):
                 {
                     'values': {
                         'CONTACT_US_CUSTOM_LINK': '/contact',
+                        'ENABLE_LEARNER_RECORDS': False,
                         'static_template_about_content': '<p class="paragraph" id=\'hello\'>Hello world!</p>',
                         'homepage_overlay_html': '<h1>Welcome to the LMS!</h1>',
                     }
@@ -163,6 +167,7 @@ class OpenEdXSiteConfigurationMixinsTestCase(TestCase):
                 'values': {
                     'override': True,
                     'CONTACT_US_CUSTOM_LINK': '/random/place/',
+                    'ENABLE_LEARNER_RECORDS': False,
                     'static_template_about_content': 'static_template_about_content',
                     'homepage_overlay_html': 'homepage_overlay_html',
                 },
@@ -210,6 +215,7 @@ class OpenEdXSiteConfigurationMixinsTestCase(TestCase):
                 "values": {
                     "SOME_SETTING": "some value",
                     "CONTACT_US_CUSTOM_LINK": "/contact",
+                    "ENABLE_LEARNER_RECORDS": False,
                     'static_template_about_content': 'TEST override!',
                     'homepage_overlay_html': 'Text override!',
                 },
@@ -219,6 +225,7 @@ class OpenEdXSiteConfigurationMixinsTestCase(TestCase):
                 "values": {
                     "SPECIFIC_SETTING": "specific value",
                     "CONTACT_US_CUSTOM_LINK": "/contact",
+                    "ENABLE_LEARNER_RECORDS": False,
                     'static_template_about_content': 'TEST override!',
                     'homepage_overlay_html': 'Text override!',
                 },
@@ -227,6 +234,7 @@ class OpenEdXSiteConfigurationMixinsTestCase(TestCase):
                 "site_id": 3,
                 "values": {
                     "CONTACT_US_CUSTOM_LINK": "/custom-contact",
+                    "ENABLE_LEARNER_RECORDS": False,
                     'static_template_about_content': 'TEST override!',
                     'homepage_overlay_html': 'Text override!',
                 },


### PR DESCRIPTION
[FAL-1937](https://tasks.opencraft.com/browse/FAL-1937)

OCIM doesn't set up the credentials service by default,
and learner records depends on the credentials service.
So, we need to also disable learner records by default.

**Sandbox**:

- LMS: https://fal-1937.stage.opencraft.hosting/
- Studio: https://studio.fal-1937.stage.opencraft.hosting/
- ocim: https://stage.manage.opencraft.com/instance/8070/



**Test instructions**:

- launch a new instance with default config
- verify that the 'view my records' button is hidden on your profile page after logging in to the instance

**Reviewers**:

- [x] @mtyaka 