### PR TITLE
[BB-4015] fix: add the missing space between the command flags

### DIFF
--- a/instance/management/commands/instance_statistics_csv.py
+++ b/instance/management/commands/instance_statistics_csv.py
@@ -256,8 +256,9 @@ class Command(BaseCommand):
         log_line.info = log_line
         log_line.error = log_line
 
-        playbook_extra_script_arguments = '--skip-hit-statistics' if settings.INSTANCE_LOGS_SERVER_HOST else ''
-        playbook_extra_script_arguments += f'--start-date {start_date} --end-date {end_date}'
+        playbook_extra_script_arguments = f'--start-date {start_date} --end-date {end_date}'
+        if settings.INSTANCE_LOGS_SERVER_HOST:
+            playbook_extra_script_arguments += ' --skip-hit-statistics'
 
         # Launch the collect_activity playbook, which places a file into the `playbook_output_dir`
         # on this host.


### PR DESCRIPTION
This will fix the syntax error when the 'instance_statistics_csv'
management command is invoked from the periodic tasks.

**Testing instructions**:
* Checkout the source branch of this PR in the production environment or on stage after setting the `INSTANCE_LOGS_SERVER_HOST` environment variable in the `.env` file.
* Run the `instance_statistics_csv` management command with one or more instance domains and the `--start-date`, `--end-date` parameters specified.
* Verify that the `collect_activity.py` script runs on the appservers of the given instances without any errors and returns proper values for the fields like `Total users`, `Total active users`, `Total courses`, etc.