### PR TITLE
[BB-4378] Fix CI cleanup issues

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -490,7 +490,9 @@ workflows:
               ignore: /.*/
             tags:
               only: /^release\-\w+\-\w+$/
-  cleanup-workflow:
+  
+  # used for periodically cleaning up left-over resources
+  scheduled-cleanup:
     triggers:
       - schedule:
           cron: "0 1 * * *"
@@ -500,3 +502,11 @@ workflows:
                 - master
     jobs:
       - cleanup
+
+  on-demand-cleanup:
+    jobs:
+      - cleanup:
+          filters:
+            branches:
+              only:
+              - ci-cleanup

--- a/cleanup_utils/aws_cleanup.py
+++ b/cleanup_utils/aws_cleanup.py
@@ -34,7 +34,7 @@ DEFAULT_POLICY_NAME = "allow_access_s3_bucket"
 
 # Logging #####################################################################
 
-logger = logging.getLogger('integration_cleanup')
+logger = logging.getLogger(__name__)
 
 
 # Classes #####################################################################
@@ -186,7 +186,7 @@ class AwsCleanupInstance:
         """
         Runs the cleanup of the AWS buckets, IAM users and their policies
         """
-        logger.info("\n --- Starting AWS Cleanup ---")
+        logger.info("--- Starting AWS Cleanup ---")
         if self.dry_run:
             logger.info("Running in DRY_RUN mode, no actions will be taken.")
 

--- a/cleanup_utils/integration_cleanup.py
+++ b/cleanup_utils/integration_cleanup.py
@@ -48,16 +48,7 @@ DEFAULT_CUTOFF_TIME = (
 
 # Logging #####################################################################
 
-logger = logging.getLogger('integration_cleanup')
-
-file_handler = logging.FileHandler('integration_cleanup.log')
-file_handler.setLevel(logging.DEBUG)
-
-console_handler = logging.StreamHandler()
-console_handler.setLevel(logging.DEBUG)
-
-logger.addHandler(file_handler)
-logger.addHandler(console_handler)
+logger = logging.getLogger(__name__)
 
 
 # Functions ###################################################################
@@ -179,7 +170,22 @@ def run_integration_cleanup(dry_run=False):
     logger.info("\nIntegration cleanup tool finished.")
 
 
+def configure_logging():
+    """
+    Configure logging.
+    """
+    logging.basicConfig(
+        format="%(asctime)s | %(module)-30s | %(levelname)-7s | %(message)s",
+        handlers=[
+            logging.FileHandler('integration_cleanup.log'),
+            logging.StreamHandler()
+        ],
+        level=logging.INFO,
+    )
+
+
 if __name__ == "__main__":
+    configure_logging()
     parser = argparse.ArgumentParser(
         description="Cleanup all unused resources from integration runs that "
                     "might have been left behind."

--- a/cleanup_utils/load_balancer_cleanup.py
+++ b/cleanup_utils/load_balancer_cleanup.py
@@ -33,7 +33,7 @@ from instance import ansible
 
 # Logging #####################################################################
 
-logger = logging.getLogger('integration_cleanup')
+logger = logging.getLogger(__name__)
 
 # Classes #####################################################################
 
@@ -51,14 +51,14 @@ class LoadBalancerCleanup:
 
     def run_cleanup(self):
         """Run the actual cleanup"""
-        logger.info("\n --- Starting Consul cleanup ---")
+        logger.info("--- Starting Consul cleanup ---")
 
         if self.dry_run:
             logger.info("Running in DRY_RUN mode, no actions will be taken")
 
         self._clean_consul()
 
-        logger.info("\n --- Starting Load balancer fragments cleanup ---")
+        logger.info("--- Starting Load balancer fragments cleanup ---")
 
         if settings.DISABLE_LOAD_BALANCER_CONFIGURATION:
             logger.info("DISABLE_LOAD_BALANCER_CONFIGURATION is set, nothing to do")

--- a/cleanup_utils/mysql_cleanup.py
+++ b/cleanup_utils/mysql_cleanup.py
@@ -33,7 +33,7 @@ from MySQLdb import Error as MySQLError
 
 # Logging ####################################################################
 
-logger = logging.getLogger('integration_cleanup')
+logger = logging.getLogger(__name__)
 
 
 # Functions ##################################################################
@@ -122,6 +122,29 @@ class MySqlCleanupInstance:
             self.cursor.execute(query, params)
         except MySQLError as exc:
             logger.exception('Unable to retrieve old databases: %s', exc)
+            return []
+        return self.cursor.fetchall()
+
+    def _get_empty_databases(self):
+        """
+        Returns a list of empty databases that can be deleted.
+        """
+        if not self.cursor:
+            logger.error('ERROR: Not connected to the database')
+            return []
+
+        query = """SELECT schema_name
+            FROM information_schema.schemata s LEFT JOIN information_schema.tables t
+            ON s.schema_name = t.table_schema
+            WHERE s.schema_name LIKE %(domain_filter)s AND
+            t.table_name IS NULL"""
+        params = {
+            'domain_filter': '%_{}_%'.format(self.domain_suffix)
+        }
+        try:
+            self.cursor.execute(query, params)
+        except MySQLError as exc:
+            logger.exception('Unable to retrieve empty databases: %s', exc)
             return []
         return self.cursor.fetchall()
 
@@ -230,13 +253,46 @@ class MySqlCleanupInstance:
         """
         Runs the cleanup of MySQL databases older than the age limit
         """
-        logger.info("\n --- Starting MySQL Cleanup ---")
+        logger.info("--- Starting MySQL Cleanup ---")
 
         if self.dry_run:
             logger.info("Running in DRY_RUN mode, no actions will be taken.")
         self.drop_old_dbs()
+        self.drop_empty_dbs()
         if self.drop_dbs_and_users:
             self.drop_integration_dbs_and_users()
+
+    def _drop_db_if_matching(self, database, creation_date=None):
+        """
+        Drop the given database if its name matches the domain suffix.
+        """
+        # The regex match here serves a dual purpose: firstly, it acts as
+        # an additional precaution against removing databases not related
+        # to CI. Secondly, it allows us to gather the hashes of the removed
+        # databases so they can be returned to the calling script and used
+        # in DNS cleanup.
+        logger.debug('Considering database %s', database)
+        instance_database_re = r'^([0-9a-f]{6,8})([_0-9a-z]+)?_%s_[a-z0-9\_]+' % (self.domain_suffix,)
+        match = re.match(instance_database_re, database)
+        if not match:
+            logger.info(
+                '    * SKIPPING: Did not match expected format %r.',
+                instance_database_re
+            )
+            return
+        db_hash = match.groups()[0]
+        formatted_creation_date = (
+            'unknown time'
+            if creation_date is None
+            else datetime.strftime(creation_date, '%Y-%m-%dT%H:%M:%SZ')
+        )
+        logger.info(
+            '    * Dropping MySQL DB %s created at %s', database,
+            formatted_creation_date
+        )
+        self._drop_db(database)
+        self.cleaned_up_hashes.append(db_hash)
+        self.drop_db_users(db_hash)
 
     def drop_old_dbs(self):
         """
@@ -246,28 +302,17 @@ class MySqlCleanupInstance:
         logger.info('Found %d old databases', len(databases))
 
         for (database, create_date) in databases:
-            # The regex match here serves a dual purpose: firstly, it acts as
-            # an additional precaution against removing databases not related
-            # to CI. Secondly, it allows us to gather the hashes of the removed
-            # databases so they can be returned to the calling script and used
-            # in DNS cleanup.
-            logger.info('  > Considering database %s', database)
-            instance_database_re = r'^([0-9a-f]{6,8})([_0-9a-z]+)?_%s_[a-z0-9\_]+' % (self.domain_suffix,)
-            match = re.match(instance_database_re, database)
-            if not match:
-                logger.info(
-                    '    * SKIPPING: Did not match expected format %r.',
-                    instance_database_re
-                )
-                continue
-            db_hash = match.groups()[0]
-            logger.info(
-                '    * Dropping MySQL DB %s created at %s', database,
-                datetime.strftime(create_date, '%Y-%m-%dT%H:%M:%SZ')
-            )
-            self._drop_db(database)
-            self.cleaned_up_hashes.append(db_hash)
-            self.drop_db_users(db_hash)
+            self._drop_db_if_matching(database, create_date)
+
+    def drop_empty_dbs(self):
+        """
+        Drop databases which appear to be empty.
+        """
+        databases = self._get_empty_databases()
+        logger.info('Found %d empty databases', len(databases))
+
+        for (database, ) in databases:
+            self._drop_db_if_matching(database)
 
     def drop_db_users(self, db_hash):
         """

--- a/cleanup_utils/openstack_cleanup.py
+++ b/cleanup_utils/openstack_cleanup.py
@@ -29,7 +29,7 @@ import pytz
 
 # Logging #####################################################################
 
-logger = logging.getLogger('integration_cleanup')
+logger = logging.getLogger(__name__)
 
 
 # Classes #####################################################################
@@ -87,7 +87,7 @@ class OpenStackCleanupInstance:
         """
         Runs the cleanup of OpenStack provider
         """
-        logger.info("\n --- Starting OpenStack Provider Cleanup ---")
+        logger.info("--- Starting OpenStack Provider Cleanup ---")
         if not self.openstack_online:
             logger.error(
                 "ERROR: The OpenStack provider couldn't be reached,"

--- a/documentation/development/ci.md
+++ b/documentation/development/ci.md
@@ -1,0 +1,15 @@
+# Continuous Integration
+
+This describes aspects of Continuous Integration setup specifically for OpenCraft,
+and is of limited interest for external contributors.
+
+## Cleaning up left-over resources
+
+Test runs (especially failing ones) may occasionally leave behind resources that,
+over time, clutter the underlying infrastructure.
+
+To avoid this, there is [a `scheduled-cleanup` CircleCI workflow](https://github.com/open-craft/opencraft/blob/master/circle.yml)
+that regularly runs the `cleanup` job.
+
+If necessary (usually when testing changes to it), the job may be run on-demand
+by pushing to the `ci-cleanup` branch.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -23,5 +23,6 @@ nav:
   - "Using the Marketing app": marketing_usage.md
   - "Development":
       - "Docker": development/docker.md
+      - "Continuous Integration": development/ci.md
   - "Operations":
       - "Management Tasks": operations/management-tasks.md


### PR DESCRIPTION
This PR fixes the issues that were preventing the cleanup of some unused CI resources like MySQL databases, Gandi DNS records, etc.

It also changes the CircleCI workflow definitions to allow pushing to the `ci-cleanup` branch for running cleanup on-demand (similar to how `stage` is used for the frontend).

# Testing
1. Push this branch to `ci-cleanup`
2. Verify the output of the `cleanup` job

# Links

* [BB-4378 (OpenCraft Private JIRA)](https://tasks.opencraft.com/browse/BB-4378)