### PR TITLE
fix: Fixed usage of yaml.safe_load in migration

### DIFF
--- a/instance/migrations/0141_features_to_features_extras.py
+++ b/instance/migrations/0141_features_to_features_extras.py
@@ -11,7 +11,7 @@ def forward(apps, schema_editor):
         model = apps.get_model('instance', model_name)
         for config in model.objects.all():
             settings = (
-                yaml.yaml.safe_load(config.configuration_extra_settings)
+                yaml.safe_load(config.configuration_extra_settings)
                 if config.configuration_extra_settings
                 else {}
             )
@@ -31,7 +31,7 @@ def backward(apps, schema_editor):
         model = apps.get_model('instance', model_name)
         for config in model.objects.all():
             settings = (
-                yaml.yaml.safe_load(config.configuration_extra_settings)
+                yaml.safe_load(config.configuration_extra_settings)
                 if config.configuration_extra_settings
                 else {}
             )


### PR DESCRIPTION
This fixes the migration introduced in #806 

I think the bug was missed in tests because `EDXAPP_FEATURES` is never used, so the code path in question is never exercised...

# Testing

1. Apply all previous migrations `./manage.py migrate instance 0140`;
2. Create an `OpenEdXInstance` with `configuration_extra_settings = 'EDXAPP_FEATURES: { TEST_FLAG: true }'`;
Alternatively, use any environment that contains instances where `configuration_extra_settings` contains `EDXAPP_FEATURES`;
3. Apply migration: `./manage.py migrate instance`;
4. Verify that:
    * before the fix it fails with `AttributeError: module 'yaml' has no attribute 'yaml'`
    * after the fix it succeeds

Related tickets:
* [BB-4230](https://tasks.opencraft.com/browse/BB-4230)