### PR TITLE
fix: Server archival no longer fails when delete SSH keys

### DIFF
--- a/instance/ssh.py
+++ b/instance/ssh.py
@@ -1,0 +1,23 @@
+"""
+Utilities for dealing with SSH.
+"""
+import logging
+import subprocess
+
+LOGGER = logging.getLogger(__name__)
+
+
+def remove_known_host_key(ip: str):
+    """
+    Removes the known_hosts key entry for the given IP.
+
+    :param ip: the IP of the entry to delete
+
+    This doesn't check whether the entry existed.
+    """
+    LOGGER.info('Deleting the SSH host key of the server with the IP address "%s" from the SSH known hosts file.', ip)
+    command = f'ssh-keygen -R {ip}'
+    try:
+        subprocess.Popen(command, shell=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    except subprocess.SubprocessError:
+        LOGGER.exception('Failed to delete the SSH host key of the server with the IP address "%s"', ip)

--- a/instance/tests/models/factories/server.py
+++ b/instance/tests/models/factories/server.py
@@ -108,9 +108,6 @@ class OpenStackServerFactory(DjangoModelFactory):
         # This isn't a model field, so it needs to be set separately, not passed to the model `__init__`
         server.nova = Mock()
 
-        # Mock method for deleting SSH key to assert it's called.
-        server._delete_ssh_key = Mock()
-
         # Allow to set OpenStack API data for the current `self.os_server`, using fixtures
         if os_server_fixture is not None:
             add_fixture_to_object(server.nova.servers.get.return_value, os_server_fixture)


### PR DESCRIPTION
This fixes the case where instance archival fails because the VM was already deleted from OpenStack.
Although the code in question already seemed to handle this, deleting the SSH key "covertly" queries the OpenStack API for IP addresses, which fails.

Related tickets:
* [BB-4245](https://tasks.opencraft.com/browse/BB-4245)

# Testing

This includes a new test that verifies the behavior:
```sh
./manage.py test --parallel 4 instance.tests.models.test_server.OpenStackServerTestCase.test_ignores_failure_to_delete_ssh_key
```