### PR TITLE
[BB-4378] Fix CI cleanup issues

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -490,7 +490,9 @@ workflows:
               ignore: /.*/
             tags:
               only: /^release\-\w+\-\w+$/
-  cleanup-workflow:
+  
+  # used for periodically cleaning up left-over resources
+  scheduled-cleanup:
     triggers:
       - schedule:
           cron: "0 1 * * *"
@@ -498,6 +500,15 @@ workflows:
             branches:
               only:
                 - master
-                - guruprasad/BB-4378-fix-CI-cleanup-issues
     jobs:
       - cleanup
+
+  # used for running cleanup on-demand
+  # by pushing to `ci-cleanup` branch
+  ondemand-cleanup:
+    jobs:
+      - cleanup:
+          filters:
+            branches:
+              only:
+                - ci-cleanup

--- a/circle.yml
+++ b/circle.yml
@@ -504,11 +504,11 @@ workflows:
       - cleanup
 
   # used for running cleanup on-demand
-  # by pushing to `ci-cleanup` branch
+  # by pushing to branches that start with `ci-cleanup/`
   ondemand-cleanup:
     jobs:
       - cleanup:
           filters:
             branches:
               only:
-                - ci-cleanup
+                - /ci-cleanup\/.*/

--- a/circle.yml
+++ b/circle.yml
@@ -498,5 +498,6 @@ workflows:
             branches:
               only:
                 - master
+                - guruprasad/BB-4378-fix-CI-cleanup-issues
     jobs:
       - cleanup

--- a/cleanup_utils/aws_cleanup.py
+++ b/cleanup_utils/aws_cleanup.py
@@ -34,7 +34,7 @@ DEFAULT_POLICY_NAME = "allow_access_s3_bucket"
 
 # Logging #####################################################################
 
-logger = logging.getLogger('integration_cleanup')
+logger = logging.getLogger(__name__)
 
 
 # Classes #####################################################################
@@ -186,7 +186,7 @@ class AwsCleanupInstance:
         """
         Runs the cleanup of the AWS buckets, IAM users and their policies
         """
-        logger.info("\n --- Starting AWS Cleanup ---")
+        logger.info("--- Starting AWS Cleanup ---")
         if self.dry_run:
             logger.info("Running in DRY_RUN mode, no actions will be taken.")
 

--- a/cleanup_utils/dns_cleanup.py
+++ b/cleanup_utils/dns_cleanup.py
@@ -28,7 +28,7 @@ from instance.gandi import GandiV5API
 
 # Logging #####################################################################
 
-logger = logging.getLogger('integration_cleanup')
+logger = logging.getLogger(__name__)
 
 
 # Constants ###################################################################
@@ -53,7 +53,7 @@ class DNSCleanupInstance:
         Cleans up the DNS records using the Gandi API.
         """
 
-        logger.info('\n --- Starting Gandi DNS cleanup ---')
+        logger.info(' --- Starting Gandi DNS cleanup ---')
         if self.dry_run:
             logger.info('Running in DRY_RUN mode, no actions will be taken.')
 

--- a/cleanup_utils/dns_cleanup.py
+++ b/cleanup_utils/dns_cleanup.py
@@ -59,7 +59,9 @@ class DNSCleanupInstance:
 
         logger.info('Deleting the following DNS records:')
         for hash_ in hashes_to_clean:
-            record = '{}.integration.{}'.format(hash_, self.base_domain) if not hash_.endswith(self.base_domain) else hash_
+            record = '{}.integration.{}'.format(
+                hash_, self.base_domain
+            ) if not hash_.endswith(self.base_domain) else hash_
 
             if not self.dry_run:
                 logger.info('  Deleting %s', record)

--- a/cleanup_utils/dns_cleanup.py
+++ b/cleanup_utils/dns_cleanup.py
@@ -59,8 +59,17 @@ class DNSCleanupInstance:
 
         logger.info('Deleting the following DNS records:')
         for hash_ in hashes_to_clean:
-            record = '{}.{}'.format(hash_, self.base_domain) if not hash_.endswith(self.base_domain) else hash_
-            logger.info('  %s', record)
+            record = '{}.integration.{}'.format(hash_, self.base_domain) if not hash_.endswith(self.base_domain) else hash_
 
             if not self.dry_run:
+                logger.info('  Deleting %s', record)
                 self.client.remove_dns_record(record, type='CNAME')
+
+                for sub_domain in ('studio', 'preview', 'discovery', 'ecommerce', 'custom1', 'custom2'):
+                    sub_domain_record = '{}.{}'.format(sub_domain, record)
+                    logger.info('  Deleting %s', sub_domain_record)
+                    self.client.remove_dns_record(sub_domain_record, type='CNAME')
+
+                active_vm_record = 'vm1.{}'.format(record)
+                logger.info('  Deleting %s', active_vm_record)
+                self.client.remove_dns_record(active_vm_record, type='A')

--- a/cleanup_utils/integration_cleanup.py
+++ b/cleanup_utils/integration_cleanup.py
@@ -170,6 +170,9 @@ def run_integration_cleanup(dry_run=False):
     logger.info("\nIntegration cleanup tool finished.")
 
 def configure_logging():
+    """
+    Configure logging.
+    """
     logging.basicConfig(
         format="%(asctime)s | %(module)-30s | %(levelname)-7s | %(msg)s",
         handlers=[
@@ -178,6 +181,7 @@ def configure_logging():
         ],
         level=logging.INFO,
     )
+
 
 if __name__ == "__main__":
     configure_logging()

--- a/cleanup_utils/integration_cleanup.py
+++ b/cleanup_utils/integration_cleanup.py
@@ -48,16 +48,7 @@ DEFAULT_CUTOFF_TIME = (
 
 # Logging #####################################################################
 
-logger = logging.getLogger('integration_cleanup')
-
-file_handler = logging.FileHandler('integration_cleanup.log')
-file_handler.setLevel(logging.DEBUG)
-
-console_handler = logging.StreamHandler()
-console_handler.setLevel(logging.DEBUG)
-
-logger.addHandler(file_handler)
-logger.addHandler(console_handler)
+logger = logging.getLogger(__name__)
 
 
 # Functions ###################################################################
@@ -178,8 +169,18 @@ def run_integration_cleanup(dry_run=False):
 
     logger.info("\nIntegration cleanup tool finished.")
 
+def configure_logging():
+    logging.basicConfig(
+        format="%(asctime)s | %(module)-30s | %(levelname)-7s | %(msg)s",
+        handlers=[
+            logging.FileHandler('integration_cleanup.log'),
+            logging.StreamHandler()
+        ],
+        level=logging.INFO,
+    )
 
 if __name__ == "__main__":
+    configure_logging()
     parser = argparse.ArgumentParser(
         description="Cleanup all unused resources from integration runs that "
                     "might have been left behind."

--- a/cleanup_utils/integration_cleanup.py
+++ b/cleanup_utils/integration_cleanup.py
@@ -175,7 +175,7 @@ def configure_logging():
     Configure logging.
     """
     logging.basicConfig(
-        format="%(asctime)s | %(module)-30s | %(levelname)-7s | %(msg)s",
+        format="%(asctime)s | %(module)-30s | %(levelname)-7s | %(message)s",
         handlers=[
             logging.FileHandler('integration_cleanup.log'),
             logging.StreamHandler()

--- a/cleanup_utils/integration_cleanup.py
+++ b/cleanup_utils/integration_cleanup.py
@@ -169,6 +169,7 @@ def run_integration_cleanup(dry_run=False):
 
     logger.info("\nIntegration cleanup tool finished.")
 
+
 def configure_logging():
     """
     Configure logging.

--- a/cleanup_utils/load_balancer_cleanup.py
+++ b/cleanup_utils/load_balancer_cleanup.py
@@ -33,7 +33,7 @@ from instance import ansible
 
 # Logging #####################################################################
 
-logger = logging.getLogger('integration_cleanup')
+logger = logging.getLogger(__name__)
 
 # Classes #####################################################################
 
@@ -51,14 +51,14 @@ class LoadBalancerCleanup:
 
     def run_cleanup(self):
         """Run the actual cleanup"""
-        logger.info("\n --- Starting Consul cleanup ---")
+        logger.info("--- Starting Consul cleanup ---")
 
         if self.dry_run:
             logger.info("Running in DRY_RUN mode, no actions will be taken")
 
         self._clean_consul()
 
-        logger.info("\n --- Starting Load balancer fragments cleanup ---")
+        logger.info("--- Starting Load balancer fragments cleanup ---")
 
         if settings.DISABLE_LOAD_BALANCER_CONFIGURATION:
             logger.info("DISABLE_LOAD_BALANCER_CONFIGURATION is set, nothing to do")

--- a/cleanup_utils/mysql_cleanup.py
+++ b/cleanup_utils/mysql_cleanup.py
@@ -33,7 +33,7 @@ from MySQLdb import Error as MySQLError
 
 # Logging ####################################################################
 
-logger = logging.getLogger('integration_cleanup')
+logger = logging.getLogger(__name__)
 
 
 # Functions ##################################################################
@@ -253,7 +253,7 @@ class MySqlCleanupInstance:
         """
         Runs the cleanup of MySQL databases older than the age limit
         """
-        logger.info("\n --- Starting MySQL Cleanup ---")
+        logger.info("--- Starting MySQL Cleanup ---")
 
         if self.dry_run:
             logger.info("Running in DRY_RUN mode, no actions will be taken.")
@@ -261,6 +261,38 @@ class MySqlCleanupInstance:
         self.drop_empty_dbs()
         if self.drop_dbs_and_users:
             self.drop_integration_dbs_and_users()
+
+    def _drop_db_if_matching(self, database, creation_date=None):
+        """
+        Drop the given database if its name matches the domain suffix.
+        """
+        # The regex match here serves a dual purpose: firstly, it acts as
+        # an additional precaution against removing databases not related
+        # to CI. Secondly, it allows us to gather the hashes of the removed
+        # databases so they can be returned to the calling script and used
+        # in DNS cleanup.
+        logger.debug('Considering database %s', database)
+        instance_database_re = r'^([0-9a-f]{6,8})([_0-9a-z]+)?_%s_[a-z0-9\_]+' % (self.domain_suffix,)
+        match = re.match(instance_database_re, database)
+        if not match:
+            logger.info(
+                '    * SKIPPING: Did not match expected format %r.',
+                instance_database_re
+            )
+            return
+        db_hash = match.groups()[0]
+        formatted_creation_date = (
+            'unknown time'
+            if creation_date is None
+            else datetime.strftime(creation_date, '%Y-%m-%dT%H:%M:%SZ')
+        )
+        logger.info(
+            '    * Dropping MySQL DB %s created at %s', database,
+            formatted_creation_date
+        )
+        self._drop_db(database)
+        self.cleaned_up_hashes.append(db_hash)
+        self.drop_db_users(db_hash)
 
     def drop_old_dbs(self):
         """
@@ -270,57 +302,17 @@ class MySqlCleanupInstance:
         logger.info('Found %d old databases', len(databases))
 
         for (database, create_date) in databases:
-            # The regex match here serves a dual purpose: firstly, it acts as
-            # an additional precaution against removing databases not related
-            # to CI. Secondly, it allows us to gather the hashes of the removed
-            # databases so they can be returned to the calling script and used
-            # in DNS cleanup.
-            logger.info('  > Considering database %s', database)
-            instance_database_re = r'^([0-9a-f]{6,8})([_0-9a-z]+)?_%s_[a-z0-9\_]+' % (self.domain_suffix,)
-            match = re.match(instance_database_re, database)
-            if not match:
-                logger.info(
-                    '    * SKIPPING: Did not match expected format %r.',
-                    instance_database_re
-                )
-                continue
-            db_hash = match.groups()[0]
-            logger.info(
-                '    * Dropping MySQL DB %s created at %s', database,
-                datetime.strftime(create_date, '%Y-%m-%dT%H:%M:%SZ')
-            )
-            self._drop_db(database)
-            self.cleaned_up_hashes.append(db_hash)
-            self.drop_db_users(db_hash)
+            self._drop_db_if_matching(database, create_date)
 
     def drop_empty_dbs(self):
         """
-        Drop databases older than `age_limit`.
+        Drop databases which appear to be empty.
         """
         databases = self._get_empty_databases()
         logger.info('Found %d empty databases', len(databases))
 
         for (database, ) in databases:
-            # The regex match here serves a dual purpose: firstly, it acts as
-            # an additional precaution against removing databases not related
-            # to CI. Secondly, it allows us to gather the hashes of the removed
-            # databases so they can be returned to the calling script and used
-            # in DNS cleanup.
-            logger.info('  > Considering database %s', database)
-            instance_database_re = r'^([0-9a-f]{6,8})([_0-9a-z]+)?_%s_[a-z0-9\_]+' % (self.domain_suffix,)
-            match = re.match(instance_database_re, database)
-            if not match:
-                logger.info(
-                    '    * SKIPPING: Did not match expected format %r.',
-                    instance_database_re
-                )
-                continue
-            logger.info('    * Dropping empty MySQL DB %s created at unknown time', database)
-
-            db_hash = match.groups()[0]
-            self._drop_db(database)
-            self.cleaned_up_hashes.append(db_hash)
-            self.drop_db_users(db_hash)
+            self._drop_db_if_matching(database)
 
     def drop_db_users(self, db_hash):
         """

--- a/cleanup_utils/openstack_cleanup.py
+++ b/cleanup_utils/openstack_cleanup.py
@@ -29,7 +29,7 @@ import pytz
 
 # Logging #####################################################################
 
-logger = logging.getLogger('integration_cleanup')
+logger = logging.getLogger(__name__)
 
 
 # Classes #####################################################################
@@ -87,7 +87,7 @@ class OpenStackCleanupInstance:
         """
         Runs the cleanup of OpenStack provider
         """
-        logger.info("\n --- Starting OpenStack Provider Cleanup ---")
+        logger.info("--- Starting OpenStack Provider Cleanup ---")
         if not self.openstack_online:
             logger.error(
                 "ERROR: The OpenStack provider couldn't be reached,"


### PR DESCRIPTION
This PR fixes the issues that were preventing the cleanup of some unused CI resources like MySQL databases, Gandi DNS records, etc.

It also changes the CircleCI workflow definitions to allow pushing to the branches with names starting with `ci-cleanupl` for running cleanup on-demand (similar to how `stage` is used for the frontend).

# Testing
1. Verify that `cleanup` job for this branch passes correctly

# Links

* [BB-4378 (OpenCraft Private JIRA)](https://tasks.opencraft.com/browse/BB-4378)
* [@lgp171188's original PR](https://github.com/open-craft/opencraft/pull/815)