### PR TITLE
[BB-4387] When provisioning an App Server and security group checks fail, state is left in New

### DIFF
--- a/instance/models/appserver.py
+++ b/instance/models/appserver.py
@@ -158,7 +158,7 @@ class AppServer(ValidateModelMixin, TimeStampedModel):
         from_states=Status.WaitingForServer, to_state=Status.ConfiguringServer
     )
     _status_to_error = status.transition(
-        from_states=Status.WaitingForServer, to_state=Status.Error
+        from_states=(Status.New, Status.WaitingForServer), to_state=Status.Error
     )
     _status_to_running = status.transition(
         from_states=Status.ConfiguringServer, to_state=Status.Running


### PR DESCRIPTION
This fixes an issue where, if something failed while checking security group definitions on OpenStack, the machine state would be left in New; the user would only be able to tell the process failed in the UI by looking through the logs.

Now, the machine state is set to error.

# Related issues
* [BB-4387 (OpenCraft Private JIRA)](https://tasks.opencraft.com/browse/BB-4387)

# Testing
```sh
./manage.py test instance.tests.models.test_openedx_appserver.OpenEdXAppServerTestCase.test_provision_security_group_check_failed
```