### PR TITLE
fix: add extra context to template in marketing app

### DIFF
--- a/marketing/admin.py
+++ b/marketing/admin.py
@@ -28,6 +28,7 @@ from django.template import Context
 
 from marketing import models
 from registration.models import BetaTestApplication
+from opencraft.utils import get_site_url
 
 
 class EmailTemplateAdmin(admin.ModelAdmin): #pylint: disable=missing-docstring
@@ -46,6 +47,9 @@ class EmailTemplateAdmin(admin.ModelAdmin): #pylint: disable=missing-docstring
             instance_name="EmailTemplate Sample"
         )
         context = Context({
+            "base_url": get_site_url(),
+            "signature_title": settings.EMAIL_SIGNATURE_TITLE,
+            "signature_name": settings.EMAIL_SIGNATURE_NAME,
             "full_name": request.user.get_full_name(),
             "username": request.user.username,
             "instance_name": "EmailTemplate Sample",

--- a/marketing/utils.py
+++ b/marketing/utils.py
@@ -28,6 +28,7 @@ from django.core.mail import send_mail
 from django.template import Context
 
 from marketing.models import Subscriber, EmailTemplate, SentEmail
+from opencraft.utils import get_site_url
 
 
 # Logging #####################################################################
@@ -43,6 +44,9 @@ def render_and_dispatch_email(template: EmailTemplate, subscriber: Subscriber):
     application = subscriber.user.betatestapplication
     user = subscriber.user
     context = Context({
+        "base_url": get_site_url(),
+        "signature_title": settings.EMAIL_SIGNATURE_TITLE,
+        "signature_name": settings.EMAIL_SIGNATURE_NAME,
         "full_name": user.profile.full_name,
         "username": user.get_username(),
         "instance_name": application.instance_name,


### PR DESCRIPTION
Adds extra context base_url, signature_name and
signature_title to the context of email templates.

### Related Tickets

- [BB-4368](https://tasks.opencraft.com/browse/BB-4368)

### Testing Instructions

Including the testing instructions relative to stage OCIM server for easier testing.

1. Redeploy this branch to stage if not already deployed.
2. Visit [templates admin page](https://stage.manage.opencraft.com/admin/marketing/emailtemplate/)
3. Select template with id 2 ( `BB-4368 Test template` )
4. Select `Send sample` option and click `Go`.
5. Check you email inbox for received email and verify that the email does not have broken images.

