### PR TITLE
feat: Adds an global NPM override to install the simple theme for any MFEs configured for an instance

### DIFF
--- a/instance/models/mixins/openedx_theme.py
+++ b/instance/models/mixins/openedx_theme.py
@@ -19,11 +19,11 @@
 """
 Open edX instance theme mixin, e.g. for simple_theme related settings
 """
-import yaml
 from colour import Color
 from django.conf import settings
 from django.contrib.postgres.fields import JSONField
 from django.db import models
+import yaml
 
 from instance.schemas.theming import theme_schema_validate
 
@@ -171,7 +171,10 @@ class OpenEdXThemeMixin(models.Model):
         return {
             "EDXAPP_COMPREHENSIVE_THEME_SOURCE_REPO": settings.SIMPLE_THEME_SKELETON_THEME_REPO,
             "EDXAPP_COMPREHENSIVE_THEME_VERSION": settings.SIMPLE_THEME_SKELETON_THEME_VERSION,
-            'SIMPLETHEME_SASS_OVERRIDES': sass_overrides,
+            "SIMPLETHEME_SASS_OVERRIDES": sass_overrides,
+            "MFE_DEPLOY_NPM_OVERRIDES": [
+                "@edx/brand@file:/edx/var/edxapp/themes/simple-theme/",
+            ],
         }
 
     def get_footer_logo_customizations(self, application):

--- a/instance/models/mixins/openedx_theme.py
+++ b/instance/models/mixins/openedx_theme.py
@@ -19,11 +19,11 @@
 """
 Open edX instance theme mixin, e.g. for simple_theme related settings
 """
+import yaml
 from colour import Color
 from django.conf import settings
 from django.contrib.postgres.fields import JSONField
 from django.db import models
-import yaml
 
 from instance.schemas.theming import theme_schema_validate
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -12,7 +12,7 @@ appdirs==1.4.4
     # via
     #   openstacksdk
     #   virtualenv
-asgiref==3.3.4
+asgiref==3.4.1
     # via
     #   channels
     #   channels-redis
@@ -41,7 +41,7 @@ botocore==1.12.253
     # via
     #   boto3
     #   s3transfer
-certifi==2020.12.5
+certifi==2021.5.30
     # via requests
 cffi==1.14.5
     # via cryptography
@@ -57,13 +57,13 @@ cheroot==8.5.2
     # via cherrypy
 cherrypy==18.1.2
     # via -r requirements/base.in
-click==8.0.0
+click==8.0.1
     # via pip-tools
-cliff==3.7.0
+cliff==3.8.0
     # via
     #   osc-lib
     #   python-openstackclient
-cmd2==1.5.0
+cmd2==2.1.1
     # via cliff
 colorama==0.4.4
     # via cmd2
@@ -88,7 +88,7 @@ cryptography==3.2.1
     #   pyopenssl
     #   requests
     #   service-identity
-cssutils==2.2.0
+cssutils==2.3.0
     # via pynliner
 daphne==2.5.0
     # via channels
@@ -103,7 +103,7 @@ decorator==5.0.9
     #   openstacksdk
 dictdiffer==0.8.1
     # via -r requirements/base.in
-distlib==0.3.1
+distlib==0.3.2
     # via virtualenv
 django-appconf==1.0.4
     # via django-compressor
@@ -135,7 +135,7 @@ django-storages==1.7.1
     # via -r requirements/base.in
 django-zurb-foundation==5.5.0
     # via -r requirements/base.in
-django==2.2.23
+django==2.2.24
     # via
     #   -r requirements/base.in
     #   channels
@@ -163,7 +163,7 @@ docutils==0.14
     # via
     #   -r requirements/base.in
     #   botocore
-dogpile.cache==1.1.2
+dogpile.cache==1.1.3
     # via openstacksdk
 drf-yasg==1.20.0
     # via -r requirements/base.in
@@ -200,16 +200,18 @@ idna==2.10
     #   requests
     #   tldextract
     #   twisted
-importlib-metadata==4.0.1
+importlib-metadata==4.6.1
     # via
+    #   click
     #   cmd2
     #   cssutils
     #   jsonschema
     #   openstacksdk
     #   oslo.config
+    #   prettytable
     #   stevedore
     #   virtualenv
-importlib-resources==5.1.3
+importlib-resources==5.2.0
     # via
     #   netaddr
     #   virtualenv
@@ -232,7 +234,7 @@ jaraco.functools==3.3.0
     #   tempora
 jedi==0.17.2
     # via -r requirements/base.in
-jinja2==3.0.0
+jinja2==3.0.1
     # via coreschema
 jmespath==0.10.0
     # via
@@ -258,15 +260,15 @@ keystoneauth1==4.3.1
     #   python-glanceclient
     #   python-keystoneclient
     #   python-novaclient
-libsass==0.20.1
+libsass==0.21.0
     # via django-libsass
 mailchimp3==3.0.13
     # via -r requirements/base.in
-markupsafe==2.0.0
+markupsafe==2.0.1
     # via jinja2
 mccabe==0.6.1
     # via -r requirements/base.in
-more-itertools==8.7.0
+more-itertools==8.8.0
     # via
     #   cheroot
     #   cherrypy
@@ -283,11 +285,11 @@ netaddr==0.8.0
     # via
     #   oslo.config
     #   oslo.utils
-netifaces==0.10.9
+netifaces==0.11.0
     # via
     #   openstacksdk
     #   oslo.utils
-openstacksdk==0.56.0
+openstacksdk==0.57.0
     # via
     #   -r requirements/base.in
     #   os-client-config
@@ -299,7 +301,7 @@ os-service-types==1.7.0
     # via
     #   keystoneauth1
     #   openstacksdk
-osc-lib==2.4.0
+osc-lib==2.4.1
     # via python-openstackclient
 oslo.config==8.7.0
     # via python-keystoneclient
@@ -317,7 +319,7 @@ oslo.serialization==4.1.0
     # via
     #   python-keystoneclient
     #   python-novaclient
-oslo.utils==4.9.0
+oslo.utils==4.9.1
     # via
     #   osc-lib
     #   oslo.serialization
@@ -326,7 +328,7 @@ oslo.utils==4.9.0
     #   python-keystoneclient
     #   python-novaclient
     #   python-openstackclient
-packaging==20.9
+packaging==21.0
     # via
     #   drf-yasg
     #   oslo.utils
@@ -349,13 +351,13 @@ pbr==5.6.0
     #   python-novaclient
     #   python-openstackclient
     #   stevedore
-pillow==8.2.0
+pillow==8.3.0
     # via -r requirements/base.in
 pip-tools==5.5.0
     # via -r requirements/base.in
 portend==2.7.1
     # via cherrypy
-prettytable==0.7.2
+prettytable==2.1.0
     # via
     #   cliff
     #   python-cinderclient
@@ -395,7 +397,7 @@ pyparsing==2.4.7
     #   packaging
 pyperclip==1.8.2
     # via cmd2
-pyrsistent==0.17.3
+pyrsistent==0.18.0
     # via jsonschema
 python-cinderclient==7.4.0
     # via python-openstackclient
@@ -403,22 +405,22 @@ python-consul==1.1.0
     # via -r requirements/base.in
 python-dateutil==2.8.1
     # via botocore
-python-glanceclient==3.3.0
+python-glanceclient==3.4.0
     # via -r requirements/base.in
 python-keystoneclient==4.2.0
     # via
     #   -r requirements/base.in
     #   django-storage-swift
     #   python-openstackclient
-python-magic==0.4.22
+python-magic==0.4.24
     # via django-storage-swift
-python-novaclient==17.4.0
+python-novaclient==17.5.0
     # via
     #   -r requirements/base.in
     #   python-openstackclient
 python-openstackclient==5.5.0
     # via -r requirements/base.in
-python-swiftclient==3.11.1
+python-swiftclient==3.12.0
     # via
     #   -r requirements/base.in
     #   django-storage-swift
@@ -471,9 +473,9 @@ rfc3986==1.5.0
     # via oslo.config
 rjsmin==1.1.0
     # via django-compressor
-ruamel.yaml.clib==0.2.2
+ruamel.yaml.clib==0.2.6
     # via ruamel.yaml
-ruamel.yaml==0.17.4
+ruamel.yaml==0.17.10
     # via drf-yasg
 s3transfer==0.2.1
     # via boto3
@@ -528,7 +530,7 @@ stevedore==3.3.0
     #   python-keystoneclient
     #   python-novaclient
     #   python-openstackclient
-tempora==4.0.2
+tempora==4.1.1
     # via portend
 tldextract==2.2.3
     # via
@@ -541,6 +543,7 @@ txaio==21.2.1
 typing-extensions==3.10.0.0
     # via
     #   asgiref
+    #   cmd2
     #   importlib-metadata
 uritemplate==3.0.1
     # via
@@ -551,12 +554,14 @@ urllib3==1.25.3
     #   -r requirements/base.in
     #   botocore
     #   requests
-virtualenv==20.4.6
+virtualenv==20.4.7
     # via -r requirements/base.in
 warlock==1.3.3
     # via python-glanceclient
 wcwidth==0.2.5
-    # via cmd2
+    # via
+    #   cmd2
+    #   prettytable
 werkzeug==0.15.4
     # via -r requirements/base.in
 wrapt==1.12.1
@@ -565,7 +570,7 @@ wrapt==1.12.1
     #   python-glanceclient
 zc.lockfile==2.0
     # via cherrypy
-zipp==3.4.1
+zipp==3.5.0
     # via
     #   importlib-metadata
     #   importlib-resources

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=requirements/dev.txt requirements/dev.in
 #
-git+https://github.com/open-craft/django-angular.git@v1-with-django2-support#egg=django_angular
+-e git+https://github.com/open-craft/django-angular.git@v1-with-django2-support#egg=django_angular
     # via -r requirements/base.in
 aioredis==1.3.1
     # via channels-redis
@@ -12,7 +12,7 @@ appdirs==1.4.4
     # via
     #   openstacksdk
     #   virtualenv
-asgiref==3.3.4
+asgiref==3.4.1
     # via
     #   channels
     #   channels-redis
@@ -48,7 +48,7 @@ botocore==1.12.253
     # via
     #   boto3
     #   s3transfer
-certifi==2020.12.5
+certifi==2021.5.30
     # via requests
 cffi==1.14.5
     # via cryptography
@@ -64,13 +64,13 @@ cheroot==8.5.2
     # via cherrypy
 cherrypy==18.1.2
     # via -r requirements/base.in
-click==8.0.0
+click==8.0.1
     # via pip-tools
-cliff==3.7.0
+cliff==3.8.0
     # via
     #   osc-lib
     #   python-openstackclient
-cmd2==1.5.0
+cmd2==2.1.1
     # via cliff
 colorama==0.4.4
     # via cmd2
@@ -99,7 +99,7 @@ cryptography==3.2.1
     #   pyopenssl
     #   requests
     #   service-identity
-cssutils==2.2.0
+cssutils==2.3.0
     # via pynliner
 daphne==2.5.0
     # via channels
@@ -118,7 +118,7 @@ decorator==5.0.9
     #   traitlets
 dictdiffer==0.8.1
     # via -r requirements/base.in
-distlib==0.3.1
+distlib==0.3.2
     # via virtualenv
 django-appconf==1.0.4
     # via django-compressor
@@ -152,7 +152,7 @@ django-storages==1.7.1
     # via -r requirements/base.in
 django-zurb-foundation==5.5.0
     # via -r requirements/base.in
-django==2.2.23
+django==2.2.24
     # via
     #   -r requirements/base.in
     #   channels
@@ -183,7 +183,7 @@ docutils==0.14
     #   botocore
 dodgy==0.2.1
     # via prospector
-dogpile.cache==1.1.2
+dogpile.cache==1.1.3
     # via openstacksdk
 drf-yasg==1.20.0
     # via -r requirements/base.in
@@ -191,7 +191,7 @@ entrypoints==0.3
     # via -r requirements/base.in
 factory-boy==2.12.0
     # via -r requirements/test.in
-faker==8.1.4
+faker==8.9.1
     # via
     #   -r requirements/test.in
     #   factory-boy
@@ -234,16 +234,18 @@ idna==2.10
     #   requests
     #   tldextract
     #   twisted
-importlib-metadata==4.0.1
+importlib-metadata==4.6.1
     # via
+    #   click
     #   cmd2
     #   cssutils
     #   jsonschema
     #   openstacksdk
     #   oslo.config
+    #   prettytable
     #   stevedore
     #   virtualenv
-importlib-resources==5.1.3
+importlib-resources==5.2.0
     # via
     #   netaddr
     #   virtualenv
@@ -280,7 +282,7 @@ jedi==0.17.2
     # via
     #   -r requirements/base.in
     #   ipython
-jinja2==3.0.0
+jinja2==3.0.1
     # via coreschema
 jmespath==0.10.0
     # via
@@ -308,11 +310,11 @@ keystoneauth1==4.3.1
     #   python-novaclient
 lazy-object-proxy==1.6.0
     # via astroid
-libsass==0.20.1
+libsass==0.21.0
     # via django-libsass
 mailchimp3==3.0.13
     # via -r requirements/base.in
-markupsafe==2.0.0
+markupsafe==2.0.1
     # via jinja2
 mccabe==0.6.1
     # via
@@ -320,7 +322,7 @@ mccabe==0.6.1
     #   flake8
     #   prospector
     #   pylint
-more-itertools==8.7.0
+more-itertools==8.8.0
     # via
     #   cheroot
     #   cherrypy
@@ -337,13 +339,13 @@ netaddr==0.8.0
     # via
     #   oslo.config
     #   oslo.utils
-netifaces==0.10.9
+netifaces==0.11.0
     # via
     #   openstacksdk
     #   oslo.utils
 nose==1.3.7
     # via -r requirements/test.in
-openstacksdk==0.56.0
+openstacksdk==0.57.0
     # via
     #   -r requirements/base.in
     #   os-client-config
@@ -355,7 +357,7 @@ os-service-types==1.7.0
     # via
     #   keystoneauth1
     #   openstacksdk
-osc-lib==2.4.0
+osc-lib==2.4.1
     # via python-openstackclient
 oslo.config==8.7.0
     # via python-keystoneclient
@@ -373,7 +375,7 @@ oslo.serialization==4.1.0
     # via
     #   python-keystoneclient
     #   python-novaclient
-oslo.utils==4.9.0
+oslo.utils==4.9.1
     # via
     #   osc-lib
     #   oslo.serialization
@@ -382,7 +384,7 @@ oslo.utils==4.9.0
     #   python-keystoneclient
     #   python-novaclient
     #   python-openstackclient
-packaging==20.9
+packaging==21.0
     # via
     #   drf-yasg
     #   oslo.utils
@@ -411,19 +413,19 @@ pexpect==4.8.0
     # via ipython
 pickleshare==0.7.5
     # via ipython
-pillow==8.2.0
+pillow==8.3.0
     # via -r requirements/base.in
 pip-tools==5.5.0
     # via -r requirements/base.in
 portend==2.7.1
     # via cherrypy
-prettytable==0.7.2
+prettytable==2.1.0
     # via
     #   cliff
     #   python-cinderclient
     #   python-glanceclient
     #   python-novaclient
-prompt-toolkit==3.0.18
+prompt-toolkit==3.0.19
     # via ipython
 prospector==1.1.4
     # via -r requirements/test.in
@@ -445,7 +447,7 @@ pycparser==2.20
     # via cffi
 pycryptodomex==3.10.1
     # via pyjwkest
-pydocstyle==6.0.0
+pydocstyle==6.1.1
     # via prospector
 pyflakes==1.6.0
     # via
@@ -498,7 +500,7 @@ pyparsing==2.4.7
     #   packaging
 pyperclip==1.8.2
     # via cmd2
-pyrsistent==0.17.3
+pyrsistent==0.18.0
     # via jsonschema
 python-cinderclient==7.4.0
     # via python-openstackclient
@@ -509,22 +511,22 @@ python-dateutil==2.8.1
     #   botocore
     #   faker
     #   freezegun
-python-glanceclient==3.3.0
+python-glanceclient==3.4.0
     # via -r requirements/base.in
 python-keystoneclient==4.2.0
     # via
     #   -r requirements/base.in
     #   django-storage-swift
     #   python-openstackclient
-python-magic==0.4.22
+python-magic==0.4.24
     # via django-storage-swift
-python-novaclient==17.4.0
+python-novaclient==17.5.0
     # via
     #   -r requirements/base.in
     #   python-openstackclient
 python-openstackclient==5.5.0
     # via -r requirements/base.in
-python-swiftclient==3.11.1
+python-swiftclient==3.12.0
     # via
     #   -r requirements/base.in
     #   django-storage-swift
@@ -580,9 +582,9 @@ rfc3986==1.5.0
     # via oslo.config
 rjsmin==1.1.0
     # via django-compressor
-ruamel.yaml.clib==0.2.2
+ruamel.yaml.clib==0.2.6
     # via ruamel.yaml
-ruamel.yaml==0.17.4
+ruamel.yaml==0.17.10
     # via drf-yasg
 s3transfer==0.2.1
     # via boto3
@@ -648,7 +650,7 @@ stevedore==3.3.0
     #   python-keystoneclient
     #   python-novaclient
     #   python-openstackclient
-tempora==4.0.2
+tempora==4.1.1
     # via portend
 testfixtures==6.10.3
     # via -r requirements/test.in
@@ -669,6 +671,7 @@ typed-ast==1.4.3
 typing-extensions==3.10.0.0
     # via
     #   asgiref
+    #   cmd2
     #   importlib-metadata
 uritemplate==3.0.1
     # via
@@ -680,13 +683,14 @@ urllib3==1.25.3
     #   botocore
     #   requests
     #   selenium
-virtualenv==20.4.6
+virtualenv==20.4.7
     # via -r requirements/base.in
 warlock==1.3.3
     # via python-glanceclient
 wcwidth==0.2.5
     # via
     #   cmd2
+    #   prettytable
     #   prompt-toolkit
 werkzeug==0.15.4
     # via -r requirements/base.in
@@ -697,7 +701,7 @@ wrapt==1.12.1
     #   python-glanceclient
 zc.lockfile==2.0
     # via cherrypy
-zipp==3.4.1
+zipp==3.5.0
     # via
     #   importlib-metadata
     #   importlib-resources

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -12,7 +12,7 @@ appdirs==1.4.4
     # via
     #   openstacksdk
     #   virtualenv
-asgiref==3.3.4
+asgiref==3.4.1
     # via
     #   channels
     #   channels-redis
@@ -46,7 +46,7 @@ botocore==1.12.253
     # via
     #   boto3
     #   s3transfer
-certifi==2020.12.5
+certifi==2021.5.30
     # via requests
 cffi==1.14.5
     # via cryptography
@@ -62,13 +62,13 @@ cheroot==8.5.2
     # via cherrypy
 cherrypy==18.1.2
     # via -r requirements/base.in
-click==8.0.0
+click==8.0.1
     # via pip-tools
-cliff==3.7.0
+cliff==3.8.0
     # via
     #   osc-lib
     #   python-openstackclient
-cmd2==1.5.0
+cmd2==2.1.1
     # via cliff
 colorama==0.4.4
     # via cmd2
@@ -96,7 +96,7 @@ cryptography==3.2.1
     #   pyopenssl
     #   requests
     #   service-identity
-cssutils==2.2.0
+cssutils==2.3.0
     # via pynliner
 daphne==2.5.0
     # via channels
@@ -113,7 +113,7 @@ decorator==5.0.9
     #   openstacksdk
 dictdiffer==0.8.1
     # via -r requirements/base.in
-distlib==0.3.1
+distlib==0.3.2
     # via virtualenv
 django-appconf==1.0.4
     # via django-compressor
@@ -145,7 +145,7 @@ django-storages==1.7.1
     # via -r requirements/base.in
 django-zurb-foundation==5.5.0
     # via -r requirements/base.in
-django==2.2.23
+django==2.2.24
     # via
     #   -r requirements/base.in
     #   channels
@@ -175,7 +175,7 @@ docutils==0.14
     #   botocore
 dodgy==0.2.1
     # via prospector
-dogpile.cache==1.1.2
+dogpile.cache==1.1.3
     # via openstacksdk
 drf-yasg==1.20.0
     # via -r requirements/base.in
@@ -183,7 +183,7 @@ entrypoints==0.3
     # via -r requirements/base.in
 factory-boy==2.12.0
     # via -r requirements/test.in
-faker==8.1.4
+faker==8.9.1
     # via
     #   -r requirements/test.in
     #   factory-boy
@@ -226,16 +226,18 @@ idna==2.10
     #   requests
     #   tldextract
     #   twisted
-importlib-metadata==4.0.1
+importlib-metadata==4.6.1
     # via
+    #   click
     #   cmd2
     #   cssutils
     #   jsonschema
     #   openstacksdk
     #   oslo.config
+    #   prettytable
     #   stevedore
     #   virtualenv
-importlib-resources==5.1.3
+importlib-resources==5.2.0
     # via
     #   netaddr
     #   virtualenv
@@ -250,7 +252,7 @@ iso8601==0.1.14
     #   oslo.utils
     #   python-novaclient
     #   python-openstackclient
-isort==5.8.0
+isort==5.9.1
     # via pylint
 itypes==1.2.0
     # via coreapi
@@ -260,7 +262,7 @@ jaraco.functools==3.3.0
     #   tempora
 jedi==0.17.2
     # via -r requirements/base.in
-jinja2==3.0.0
+jinja2==3.0.1
     # via coreschema
 jmespath==0.10.0
     # via
@@ -288,11 +290,11 @@ keystoneauth1==4.3.1
     #   python-novaclient
 lazy-object-proxy==1.6.0
     # via astroid
-libsass==0.20.1
+libsass==0.21.0
     # via django-libsass
 mailchimp3==3.0.13
     # via -r requirements/base.in
-markupsafe==2.0.0
+markupsafe==2.0.1
     # via jinja2
 mccabe==0.6.1
     # via
@@ -300,7 +302,7 @@ mccabe==0.6.1
     #   flake8
     #   prospector
     #   pylint
-more-itertools==8.7.0
+more-itertools==8.8.0
     # via
     #   cheroot
     #   cherrypy
@@ -317,13 +319,13 @@ netaddr==0.8.0
     # via
     #   oslo.config
     #   oslo.utils
-netifaces==0.10.9
+netifaces==0.11.0
     # via
     #   openstacksdk
     #   oslo.utils
 nose==1.3.7
     # via -r requirements/test.in
-openstacksdk==0.56.0
+openstacksdk==0.57.0
     # via
     #   -r requirements/base.in
     #   os-client-config
@@ -335,7 +337,7 @@ os-service-types==1.7.0
     # via
     #   keystoneauth1
     #   openstacksdk
-osc-lib==2.4.0
+osc-lib==2.4.1
     # via python-openstackclient
 oslo.config==8.7.0
     # via python-keystoneclient
@@ -353,7 +355,7 @@ oslo.serialization==4.1.0
     # via
     #   python-keystoneclient
     #   python-novaclient
-oslo.utils==4.9.0
+oslo.utils==4.9.1
     # via
     #   osc-lib
     #   oslo.serialization
@@ -362,7 +364,7 @@ oslo.utils==4.9.0
     #   python-keystoneclient
     #   python-novaclient
     #   python-openstackclient
-packaging==20.9
+packaging==21.0
     # via
     #   drf-yasg
     #   oslo.utils
@@ -387,13 +389,13 @@ pbr==5.6.0
     #   stevedore
 pep8-naming==0.4.1
     # via prospector
-pillow==8.2.0
+pillow==8.3.0
     # via -r requirements/base.in
 pip-tools==5.5.0
     # via -r requirements/base.in
 portend==2.7.1
     # via cherrypy
-prettytable==0.7.2
+prettytable==2.1.0
     # via
     #   cliff
     #   python-cinderclient
@@ -417,7 +419,7 @@ pycparser==2.20
     # via cffi
 pycryptodomex==3.10.1
     # via pyjwkest
-pydocstyle==6.0.0
+pydocstyle==6.1.1
     # via prospector
 pyflakes==1.6.0
     # via
@@ -466,7 +468,7 @@ pyparsing==2.4.7
     #   packaging
 pyperclip==1.8.2
     # via cmd2
-pyrsistent==0.17.3
+pyrsistent==0.18.0
     # via jsonschema
 python-cinderclient==7.4.0
     # via python-openstackclient
@@ -477,22 +479,22 @@ python-dateutil==2.8.1
     #   botocore
     #   faker
     #   freezegun
-python-glanceclient==3.3.0
+python-glanceclient==3.4.0
     # via -r requirements/base.in
 python-keystoneclient==4.2.0
     # via
     #   -r requirements/base.in
     #   django-storage-swift
     #   python-openstackclient
-python-magic==0.4.22
+python-magic==0.4.24
     # via django-storage-swift
-python-novaclient==17.4.0
+python-novaclient==17.5.0
     # via
     #   -r requirements/base.in
     #   python-openstackclient
 python-openstackclient==5.5.0
     # via -r requirements/base.in
-python-swiftclient==3.11.1
+python-swiftclient==3.12.0
     # via
     #   -r requirements/base.in
     #   django-storage-swift
@@ -548,9 +550,9 @@ rfc3986==1.5.0
     # via oslo.config
 rjsmin==1.1.0
     # via django-compressor
-ruamel.yaml.clib==0.2.2
+ruamel.yaml.clib==0.2.6
     # via ruamel.yaml
-ruamel.yaml==0.17.4
+ruamel.yaml==0.17.10
     # via drf-yasg
 s3transfer==0.2.1
     # via boto3
@@ -613,7 +615,7 @@ stevedore==3.3.0
     #   python-keystoneclient
     #   python-novaclient
     #   python-openstackclient
-tempora==4.0.2
+tempora==4.1.1
     # via portend
 testfixtures==6.10.3
     # via -r requirements/test.in
@@ -632,6 +634,7 @@ typed-ast==1.4.3
 typing-extensions==3.10.0.0
     # via
     #   asgiref
+    #   cmd2
     #   importlib-metadata
 uritemplate==3.0.1
     # via
@@ -643,12 +646,14 @@ urllib3==1.25.3
     #   botocore
     #   requests
     #   selenium
-virtualenv==20.4.6
+virtualenv==20.4.7
     # via -r requirements/base.in
 warlock==1.3.3
     # via python-glanceclient
 wcwidth==0.2.5
-    # via cmd2
+    # via
+    #   cmd2
+    #   prettytable
 werkzeug==0.15.4
     # via -r requirements/base.in
 wrapt==1.12.1
@@ -658,7 +663,7 @@ wrapt==1.12.1
     #   python-glanceclient
 zc.lockfile==2.0
     # via cherrypy
-zipp==3.4.1
+zipp==3.5.0
     # via
     #   importlib-metadata
     #   importlib-resources


### PR DESCRIPTION
The [simple theme package](https://github.com/open-craft/edx-simple-theme/) now supports being installed as a theme package for MFEs. This change adds configuration to deploy it as an npm theme package by default. 