### PR TITLE
[FAL-2137] Ocim: don't run periodic builds for archived instances

### DIFF
--- a/periodic_builds/tasks.py
+++ b/periodic_builds/tasks.py
@@ -47,7 +47,10 @@ def launch_periodic_builds():
     """
     Automatically deploy new servers for all Open edX instances configured for periodic builds.
     """
-    instances = OpenEdXInstance.objects.filter(periodic_builds_enabled=True)
+    instances = OpenEdXInstance.objects.filter(
+        periodic_builds_enabled=True,
+        ref_set__is_archived=False,
+    )
 
     now = datetime.datetime.now(tz=datetime.timezone.utc)
     for instance in instances:


### PR DESCRIPTION
"Is archived" filter added in launch_periodic_builds function

**Jira ticket:** [FAL-2137](https://tasks.opencraft.com/browse/FAL-2137)

- On test_tasks.py of periodic_build, I added a filter to avoid get the archived instances
- Test updated to demonstrate that change in the function behavior

**How to test:**

- Create a test instance with the periodic build enabled.
- Test if the periodic build works normally.
- Archive the instance.
- Test if the periodic build is no longer performed.

