### PR TITLE
fix: Dropping orphaned MySQL databases uses actual db name

### DIFF
--- a/instance/management/commands/find_orphan_dbs.py
+++ b/instance/management/commands/find_orphan_dbs.py
@@ -183,7 +183,7 @@ class Command(BaseCommand):
                 orphans = self._find_mysql_orphans(eligible_db_names)
                 for db in orphans:
                     if kwargs['rm'] and self.confirm(f"Are you sure you want to drop {db}"):
-                        cursor.execute(f"drop database db")
+                        cursor.execute(f"drop database `{db}`")
                 self._print_orphans(
                     "mysql",
                     f"{mysql_server.hostname}:{mysql_server.port}",


### PR DESCRIPTION
Apparently it was attempting to drop database `db` due to a missing interpolated variable.

Related tickets:
* [BB-4255 (OpenCraft Internal)](https://tasks.opencraft.com/browse/BB-4255)

# Testing

1. Run `./manage.py prune_orphan_dbs --rm mysql`
2. Confirm database deletion