### PR TITLE
[BB-4447] Handle 413 Entity Too Large responses when uploading images

### DIFF
--- a/documentation/development/console.md
+++ b/documentation/development/console.md
@@ -1,0 +1,17 @@
+# Developing the console frontend
+
+## Using a different backend
+
+If you only want to make changes to the console frontend
+(or don't have credentials for running a functional backend),
+you can point your devserver at a deployed environment (usually `stage`):
+
+    REACT_APP_OCIM_API_BASE=https://stage.manage.opencraft.com npm start
+
+However, if you then try to access the frontend at `localhost`, you'll
+run into CORS issues.
+To avoid those, add an entry to your `/etc/hosts` file:
+
+    127.0.0.1 localhost.opencraft.com
+
+You can then access the devserver at http://localhost.opencraft.com:3000.

--- a/frontend/src/console/components/Hero/Hero.tsx
+++ b/frontend/src/console/components/Hero/Hero.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { IntlContext } from 'react-intl';
 import { InstancesModel } from 'console/models';
 import { ThemeSchema } from 'ocim-client';
 import { ConsolePage } from 'newConsole/components';
@@ -207,7 +208,8 @@ export class HeroComponent extends React.PureComponent<Props, State> {
       this.props.updateImages(
         this.props.activeInstance.data!.id,
         imageName,
-        image
+        image,
+        this.context
       );
     }
   };
@@ -311,6 +313,8 @@ export class HeroComponent extends React.PureComponent<Props, State> {
     );
   }
 }
+
+HeroComponent.contextType = IntlContext;
 
 export const Hero = connect<StateProps, ActionProps, {}, Props, RootState>(
   (state: RootState) => state.console,

--- a/frontend/src/console/components/Logos/Logos.tsx
+++ b/frontend/src/console/components/Logos/Logos.tsx
@@ -7,6 +7,7 @@ import {
 import { Row, Col } from 'react-bootstrap';
 import { InstancesModel } from 'console/models';
 import { ImageUploadField } from 'ui/components';
+import { IntlContext } from 'react-intl';
 import { connect } from 'react-redux';
 import { RootState } from 'global/state';
 import { WrappedMessage } from 'utils/intl';
@@ -28,7 +29,8 @@ export class LogosComponent extends React.PureComponent<Props, State> {
       this.props.updateImages(
         this.props.activeInstance.data.id,
         imageName,
-        image
+        image,
+        this.context
       );
     }
   };
@@ -98,6 +100,8 @@ export class LogosComponent extends React.PureComponent<Props, State> {
     );
   }
 }
+
+LogosComponent.contextType = IntlContext;
 
 export const Logos = connect<StateProps, ActionProps, {}, Props, RootState>(
   (state: RootState) => state.console,

--- a/frontend/src/newConsole/components/newLogos/LogoSidebar.tsx
+++ b/frontend/src/newConsole/components/newLogos/LogoSidebar.tsx
@@ -15,6 +15,7 @@ import {
   syncActiveInstanceField
 } from 'console/actions';
 import messages from 'console/components/Logos/displayMessages';
+import { IntlContext } from 'react-intl';
 
 interface State {}
 interface ActionProps {
@@ -32,7 +33,8 @@ export class LogosSideBarComponent extends React.PureComponent<Props, State> {
       this.props.updateImages(
         this.props.activeInstance.data.id,
         imageName,
-        image
+        image,
+        this.context
       );
     }
   };
@@ -153,6 +155,8 @@ export class LogosSideBarComponent extends React.PureComponent<Props, State> {
     );
   }
 }
+
+LogosSideBarComponent.contextType = IntlContext;
 
 export const LogosSideBar = connect<
   StateProps,

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -22,7 +22,8 @@ nav:
   - infrastructure.md
   - "Using the Marketing app": marketing_usage.md
   - "Development":
-      - "Docker": development/docker.md
+      - "Console Frontend": development/console.md
       - "Continuous Integration": development/ci.md
+      - "Docker": development/docker.md
   - "Operations":
       - "Management Tasks": operations/management-tasks.md


### PR DESCRIPTION
This adds handling for 413 Entity Too Large responses when uploading images.

# Related Tickets:
* [BB-4447](https://tasks.opencraft.com/browse/BB-4447)

# Testing

1. Apply the following configuration to NGINX (required to avoid CORS errors):
```
<html><head></head><body>

# internal redirect when request exceeds max_client_body_size
--
error_page 413 = @entity_too_large;
 
# Add CORS headers, we might be able to trim this
location @entity_too_large {
add_header 'Access-Control-Allow-Origin' $http_origin always;
add_header 'Access-Control-Allow-Methods' 'GET,POST,OPTIONS' always;
add_header 'Access-Control-Allow-Headers' 'Authorization,DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range' always;
add_header 'Access-Control-Expose-Headers' 'Content-Length,Content-Range' always;
return 413;
}
 

</body></html>
```
2. Upload a large image (> 1 MB) using any of the console's configuration forms (e.g. `/console/theming/logos`)
3. *Image size is too large* error message should display next to control.