### PR TITLE
[BB-446] fix: Make form field labels consistent in Logos page

### DIFF
--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -44,6 +44,7 @@
       "import/no-extraneous-dependencies": ["error", {"devDependencies": true}],
       "max-len": ["error", {"comments": 100, "code": 130}],
       "import/no-unresolved": ["error",{"ignore": [".scss"]}],
-      "react/jsx-props-no-spreading": ["off"]
+      "react/jsx-props-no-spreading": ["off"],
+      "react/jsx-wrap-multilines": ["error", {"prop": "ignore"}]
     }
 }

--- a/frontend/src/newConsole/components/newLogos/LogoSidebar.tsx
+++ b/frontend/src/newConsole/components/newLogos/LogoSidebar.tsx
@@ -2,7 +2,11 @@ import * as React from 'react';
 import './styles.scss';
 import { ConsolePageCustomizationContainer } from 'console/components';
 import { InstancesModel } from 'console/models';
-import { ImageUploadField, TextInputField } from 'ui/components';
+import {
+  ModalImageInput,
+  OverlayTooltip,
+  TextInputField2
+} from 'ui/components';
 import { ConsolePage } from 'newConsole/components';
 import faviconTooltipImage from 'assets/faviconTooltipImage.png';
 import { connect } from 'react-redux';
@@ -28,15 +32,17 @@ interface StateProps extends InstancesModel {}
 interface Props extends StateProps, ActionProps {}
 
 export class LogosSideBarComponent extends React.PureComponent<Props, State> {
-  updateImage = (imageName: string, image: File) => {
-    if (this.props.activeInstance && this.props.activeInstance.data) {
-      this.props.updateImages(
-        this.props.activeInstance.data.id,
-        imageName,
-        image,
-        this.context
-      );
-    }
+  updateImage = (imageName: string) => {
+    return (image: File) => {
+      if (this.props.activeInstance && this.props.activeInstance.data) {
+        this.props.updateImages(
+          this.props.activeInstance.data.id,
+          imageName,
+          image,
+          this.context
+        );
+      }
+    };
   };
 
   public render() {
@@ -50,22 +56,17 @@ export class LogosSideBarComponent extends React.PureComponent<Props, State> {
     if (instance.data && instance.data.favicon) {
       favicon = instance.data.favicon;
     }
+    const footerLogoImageSourceMessage = (
+      <WrappedMessage messages={messages} id="footerLogoImage" />
+    );
     const footerLogoImageSourceInput = (
-      <ImageUploadField
-        customUploadMessage={
-          <WrappedMessage messages={messages} id="footerLogoImage" />
-        }
-        updateImage={(image: File) => {
-          this.updateImage('footerLogoImage', image);
-        }}
-        parentMessages={messages}
-        error={instance.feedback.footerLogoImage}
-        clearError={() => {
-          this.props.clearErrorMessage('footerLogoImage');
-        }}
-        tooltipTextId="footerLogoImageTooltip"
-        innerPreview={instance.data?.footerLogoImage}
-      >
+      <>
+        <h4 className="font-weight-bold">
+          {footerLogoImageSourceMessage}
+          <OverlayTooltip id="footerLogoImageTooltip">
+            <WrappedMessage messages={messages} id="footerLogoImageTooltip" />
+          </OverlayTooltip>
+        </h4>
         <p>
           <WrappedMessage messages={messages} id="footerLogoImageAdvice" />
         </p>
@@ -81,15 +82,31 @@ export class LogosSideBarComponent extends React.PureComponent<Props, State> {
             />
           </a>
         </p>
-      </ImageUploadField>
+        <ModalImageInput
+          customUploadMessage={footerLogoImageSourceMessage}
+          updateImage={this.updateImage('footerLogoImage')}
+          parentMessages={messages}
+          error={instance.feedback.footerLogoImage}
+          clearError={() => {
+            this.props.clearErrorMessage('footerLogoImage');
+          }}
+          innerPreview={instance.data?.footerLogoImage}
+        />
+      </>
     );
     const footerLogoUrlInput = (
-      <TextInputField
+      <TextInputField2
         error={instance.feedback.footerLogoUrl}
         fieldName="footerLogoUrl"
-        helpMessageId="footerLogoUrlHelp"
+        helpMessage={
+          <WrappedMessage id="footerLogoUrlHelp" messages={messages} />
+        }
+        label={
+          <h4 className="font-weight-bold">
+            <WrappedMessage id="footerLogoUrl" messages={messages} />
+          </h4>
+        }
         loading={instance.loading.includes('footerLogoUrl')}
-        messages={messages}
         onBlur={() => this.props.syncFieldValue('footerLogoUrl')}
         onChange={e => {
           this.props.updateFieldValue('footerLogoUrl', e.target.value);
@@ -98,6 +115,11 @@ export class LogosSideBarComponent extends React.PureComponent<Props, State> {
         value={instance.data?.footerLogoUrl}
       />
     );
+
+    const siteLogoMessage = (
+      <WrappedMessage messages={messages} id="siteLogo" />
+    );
+    const faviconMessage = <WrappedMessage messages={messages} id="favicon" />;
 
     return (
       <ConsolePage contentLoading={this.props.loading} showSideBarEditComponent>
@@ -109,39 +131,40 @@ export class LogosSideBarComponent extends React.PureComponent<Props, State> {
               </h2>
             </div>
             <div className="logo-upload-field sidebar-item">
-              <ImageUploadField
-                customUploadMessage={
-                  <WrappedMessage messages={messages} id="siteLogo" />
-                }
-                updateImage={(image: File) => {
-                  this.updateImage('logo', image);
-                }}
+              <h4 className="font-weight-bold">
+                {siteLogoMessage}
+                <OverlayTooltip id="logoTooltip">
+                  <WrappedMessage messages={messages} id="logoTooltip" />
+                </OverlayTooltip>
+              </h4>
+              <ModalImageInput
+                customUploadMessage={siteLogoMessage}
+                updateImage={this.updateImage('logo')}
                 parentMessages={messages}
                 recommendationTextId="logoRecommendation"
                 error={instance.feedback.logo}
                 clearError={() => {
                   this.props.clearErrorMessage('logo');
                 }}
-                tooltipTextId="logoTooltip"
                 innerPreview={logo}
               />
             </div>
             <div className="favicon-upload-field sidebar-item">
-              <ImageUploadField
-                customUploadMessage={
-                  <WrappedMessage messages={messages} id="favicon" />
-                }
-                updateImage={(image: File) => {
-                  this.updateImage('favicon', image);
-                }}
+              <h4 className="font-weight-bold">
+                {faviconMessage}
+                <OverlayTooltip id="favicon" tooltipImage={faviconTooltipImage}>
+                  <WrappedMessage messages={messages} id="faviconTooltip" />
+                </OverlayTooltip>
+              </h4>
+              <ModalImageInput
+                customUploadMessage={faviconMessage}
+                updateImage={this.updateImage('favicon')}
                 parentMessages={messages}
                 recommendationTextId="faviconRecommendation"
                 error={instance.feedback.favicon}
                 clearError={() => {
                   this.props.clearErrorMessage('favicon');
                 }}
-                tooltipTextId="faviconTooltip"
-                tooltipImage={faviconTooltipImage}
                 innerPreview={favicon}
               />
             </div>

--- a/frontend/src/newConsole/components/newLogos/styles.scss
+++ b/frontend/src/newConsole/components/newLogos/styles.scss
@@ -47,6 +47,14 @@
     margin-inline-end: 30px;
   }
 
+  h1, h2, h3, h4, h5, h6 {
+    font-family: PlayfairDisplay;
+  }
+
+  h4 {
+    font-size: 20px;
+  }
+
   p {
     font-family: $chivo-font;
     font-size: 14px;

--- a/frontend/src/ui/components/ImageUploadField/ImageUploadField.tsx
+++ b/frontend/src/ui/components/ImageUploadField/ImageUploadField.tsx
@@ -5,42 +5,44 @@ import upArrowIcon from 'assets/uparrow.png';
 import messages from './displayMessages';
 import './styles.scss';
 
-interface ImageUploadFieldProps {
+interface ModalImageInputProps {
   customUploadMessage: any;
-  updateImage: Function;
-  clearError: Function;
+  clearError: () => void;
+  error?: string;
+  innerPreview?: string;
+  loading?: boolean;
   parentMessages?: any;
   recommendationTextId?: string;
-  error?: string;
-  loading?: boolean;
   reset?: Function;
+  updateImage: Function;
+}
+
+interface ImageUploadFieldProps extends ModalImageInputProps {
   tooltipTextId?: string;
   tooltipImage?: string;
-  innerPreview?: string;
-  children?: React.ReactNode;
 }
 
 interface Image {
   name?: string;
 }
 
-export const ImageUploadField: React.FC<ImageUploadFieldProps> = (
-  props: ImageUploadFieldProps
+export const ModalImageInput: React.FC<ModalImageInputProps> = (
+  props: ModalImageInputProps
 ) => {
   const [show, setShow] = React.useState(false);
   const [image, setImage] = React.useState();
+
+  const handleClose = () => setShow(false);
+  const handleShow = () => {
+    props.clearError();
+    setShow(true);
+  };
 
   const filename = (file: Image | undefined) => {
     if (file) {
       return file.name;
     }
     return '';
-  };
-
-  const handleClose = () => setShow(false);
-  const handleShow = () => {
-    props.clearError();
-    setShow(true);
   };
 
   const setImageIfValid = (files: any) => {
@@ -71,42 +73,8 @@ export const ImageUploadField: React.FC<ImageUploadFieldProps> = (
       </div>
     );
   };
-
-  let tooltip = null;
-
-  if (props.parentMessages && props.tooltipTextId) {
-    tooltip = (
-      <Tooltip className="image-upload-tooltip" id={props.tooltipTextId}>
-        <p>
-          <WrappedMessage
-            messages={props.parentMessages}
-            id={props.tooltipTextId}
-          />
-        </p>
-        {props.tooltipImage && (
-          <img
-            className="tooltip-image"
-            src={props.tooltipImage}
-            alt="tooltipImage"
-          />
-        )}
-      </Tooltip>
-    );
-  }
-
   return (
-    <div className="image-upload-field">
-      <div className="component-header">
-        <h4 className="upload-field-header">
-          {props.customUploadMessage}
-          {tooltip && (
-            <OverlayTrigger placement="top" overlay={tooltip}>
-              <i className="fas fa-info-circle" />
-            </OverlayTrigger>
-          )}
-        </h4>
-        {props.children}
-      </div>
+    <>
       <Button
         variant="outline-primary"
         size="lg"
@@ -201,6 +169,68 @@ export const ImageUploadField: React.FC<ImageUploadFieldProps> = (
           </Button>
         </Modal.Footer>
       </Modal>
+    </>
+  );
+};
+
+/**
+ * @deprecated Use ModalImageInput instead
+ */
+export const ImageUploadField: React.FC<ImageUploadFieldProps> = (
+  props: ImageUploadFieldProps
+) => {
+  let tooltip = null;
+
+  if (props.parentMessages && props.tooltipTextId) {
+    tooltip = (
+      <OverlayTooltip
+        id={props.tooltipTextId}
+        innerPreview={props.innerPreview}
+        tooltipImage={props.tooltipImage}
+      >
+        <WrappedMessage
+          messages={props.parentMessages}
+          id={props.tooltipTextId}
+        />
+      </OverlayTooltip>
+    );
+  }
+
+  return (
+    <div className="image-upload-field">
+      <div className="component-header">
+        <h4 className="upload-field-header">
+          {props.customUploadMessage}
+          {tooltip}
+        </h4>
+      </div>
+      <ModalImageInput {...props} />
     </div>
+  );
+};
+
+interface OverlayTooltipProps {
+  id: string;
+  tooltipImage?: string;
+  innerPreview?: string;
+  children: React.ReactNode;
+}
+export const OverlayTooltip: React.FC<OverlayTooltipProps> = props => {
+  const tooltip = (
+    <Tooltip className="image-upload-tooltip" id={props.id}>
+      <p>{props.children}</p>
+      {props.tooltipImage && (
+        <img
+          className="tooltip-image"
+          src={props.tooltipImage}
+          alt="tooltipImage"
+        />
+      )}
+    </Tooltip>
+  );
+  return (
+    <OverlayTrigger placement="top" overlay={tooltip}>
+      <i className="fas fa-info-circle" />
+    </OverlayTrigger>
   );
 };

--- a/frontend/src/ui/components/ImageUploadField/styles.scss
+++ b/frontend/src/ui/components/ImageUploadField/styles.scss
@@ -110,8 +110,11 @@
     i {
         color: $secondary-1;
         margin-top: 5px;
-        margin-left: 9.5px;
     }
+}
+
+.fas {
+    margin: 9.5px;
 }
 
 .image-upload-tooltip {

--- a/frontend/src/ui/components/TextInputField/TextInputField.tsx
+++ b/frontend/src/ui/components/TextInputField/TextInputField.tsx
@@ -21,15 +21,46 @@ interface InputFieldProps {
 export const TextInputField: React.FC<InputFieldProps> = (
   props: InputFieldProps
 ) => {
+  let helpMessage;
   const helpMessageId = props.helpMessageId || `${props.fieldName}Help`;
   const hasHelpMessage = helpMessageId in props.messages;
+  if (hasHelpMessage) {
+    helpMessage = (
+      <WrappedMessage id={helpMessageId} messages={props.messages} />
+    );
+  }
 
+  return (
+    <TextInputField2
+      label={<WrappedMessage id={props.fieldName} messages={props.messages} />}
+      helpMessage={helpMessage}
+      {...props}
+    />
+  );
+};
+
+interface TextInputField2Props {
+  autoComplete?: string;
+  error?: string;
+  fieldName: string;
+  helpMessage?: React.ReactNode;
+  isValid?: boolean;
+  label: React.ReactNode;
+  loading?: boolean;
+  onBlur?: React.FocusEventHandler<HTMLInputElement>;
+  onChange?: React.ChangeEventHandler<HTMLInputElement>;
+  reset?: Function;
+  type?: string;
+  value?: string;
+}
+
+export const TextInputField2: React.FC<TextInputField2Props> = (
+  props: TextInputField2Props
+) => {
   return (
     <div className="text-input-container">
       <FormGroup>
-        <FormLabel>
-          <WrappedMessage id={props.fieldName} messages={props.messages} />
-        </FormLabel>
+        <FormLabel>{props.label}</FormLabel>
         <FormControl
           name={props.fieldName}
           value={props.value}
@@ -46,11 +77,7 @@ export const TextInputField: React.FC<InputFieldProps> = (
             {props.error}
           </FormControl.Feedback>
         )}
-        {hasHelpMessage && (
-          <p>
-            <WrappedMessage id={helpMessageId} messages={props.messages} />
-          </p>
-        )}
+        {props.helpMessage && <p>{props.helpMessage}</p>}
       </FormGroup>
 
       {props.reset !== undefined && (


### PR DESCRIPTION
This adds pruned down versions of `ImageUploadField` and `TextInputField` that are easier to style.
It also makes some style tweaks to make things more consistent.

Related tickets:
* [BB-4446 (OpenCraft Internal)](https://tasks.opencraft.com/browse/BB-4446)

# Testing

1. Go to "Logo" section in console;
2. Verify that all input heading are consistent.

# Screenshot

![image](https://user-images.githubusercontent.com/3984777/126492779-c75d744b-d526-40ad-8f8b-bcca3e6325e1.png)
