### PR TITLE
feat: [BB-4532] Add new column to report containing external lms domain, and change default report recipient

### DIFF
--- a/instance/management/commands/instance_statistics_csv.py
+++ b/instance/management/commands/instance_statistics_csv.py
@@ -161,6 +161,7 @@ class Command(BaseCommand):
             name_prefix = appserver.server_name_prefix
             domain = instance.domain
             ref_name = instance.ref.name
+            external_lms_domain = instance.external_lms_domain or 'N/A'
 
             try:
                 betatestapplication = instance.betatestapplication_set.get()
@@ -177,7 +178,8 @@ class Command(BaseCommand):
                 'public_ip': appserver.server.public_ip,
                 'instance_age': datetime.now(instance.created.tzinfo) - instance.created,
                 'email': email,
-                'status': status
+                'status': status,
+                'external_lms_domain': external_lms_domain,
             }
 
         return instance_metadata
@@ -328,7 +330,8 @@ class Command(BaseCommand):
                 'Total Courses',
                 'Total Users',
                 'Active Users',
-                'Age (Days)'
+                'Age (Days)',
+                'Custom External Domain',
             ])
 
             filenames = [os.path.join(playbook_output_dir, f) for f in os.listdir(playbook_output_dir)]
@@ -352,7 +355,8 @@ class Command(BaseCommand):
                     section.get('courses', 'N/A'),
                     section.get('users', 'N/A'),
                     section.get('active_users', 'N/A'),
-                    metadata['instance_age']
+                    metadata['instance_age'],
+                    metadata['external_lms_domain']
                 ])
 
         self.stderr.write(self.style.SUCCESS('Done generating CSV output.'))

--- a/opencraft/settings.py
+++ b/opencraft/settings.py
@@ -927,7 +927,7 @@ INSTANCE_LOGS_SERVER_ELASTICSEARCH_CA_CERT = env('INSTANCE_LOGS_SERVER_ELASTICSE
 
 # Trial Instances Report ######################################################
 
-TRIAL_INSTANCES_REPORT_RECIPIENTS = env.json('TRIAL_INSTANCES_REPORT_RECIPIENTS', default=['billing@opencraft.com'])
+TRIAL_INSTANCES_REPORT_RECIPIENTS = env.json('TRIAL_INSTANCES_REPORT_RECIPIENTS', default=['contact@opencraft.com'])
 
 # Crontab schedule for the Trial Instances Report.
 # Format is '<minute> <hour> <day> <month> <day_of_week>' like normal crontabs


### PR DESCRIPTION
### Description:
This PR adds a new column to the report generated by instance_statistics_csv, which is called by `send_all_instances_report` to generate a report on all instances and then send it to the recipients defined by
`settings.TRIAL_INSTANCES_REPORT_RECIPIENTS`.

Also this PR changes the default recipient for this report  to `contact@opencraft.com`

### Jira Issue: 
https://tasks.opencraft.com/browse/BB-4532

### Test Steps:
- Deploy this branch on stage
- Set external_lms_domain in some instances
- Run `instance_statistics_csv` command, and check that the values in the generated `csv` are correct