### PR TITLE
FAL-2270 Make production extra configuration configurable from config

### DIFF
--- a/instance/factories.py
+++ b/instance/factories.py
@@ -140,21 +140,16 @@ def production_instance_factory(**kwargs):
         logger.warning("Environment not ready. Please fix the problems above, then try again. Aborting.")
         return None
 
-    # Gather settings
-    production_settings = {
-        # Don't create default users on production instances
-        "DEMO_CREATE_STAFF_USER": False,
-        "demo_test_users": [],
-        # Disable certificates process to reduce load on RabbitMQ and MySQL
-        "SANDBOX_ENABLE_CERTIFICATES": False,
-    }
     configuration_extra_settings = kwargs.pop("configuration_extra_settings", "")
     if configuration_extra_settings:
         configuration_extra_settings = yaml.load(configuration_extra_settings, Loader=yaml.SafeLoader)
     else:
         configuration_extra_settings = {}
     extra_settings = yaml.dump(
-        ansible.dict_merge(production_settings, configuration_extra_settings),
+        ansible.dict_merge(
+            settings.PRODUCTION_INSTANCE_EXTRA_CONFIGURATION,
+            configuration_extra_settings
+        ),
         default_flow_style=False
     )
     instance_kwargs = dict(

--- a/opencraft/settings.py
+++ b/opencraft/settings.py
@@ -999,3 +999,6 @@ MARKETING_EMAIL_REPORT_RECIPIENTS = env.json(
 # The download url for Oracle JDK to use when provisioning Appserver.
 # This will be passed to ansible playbook variable `oraclejdk_url`.
 OPENEDX_ORACLEJDK_URL = env.str('OPENEDX_ORACLEJDK_URL', default='')
+
+# The value here will be used as the default configuration_extra_settings for production instances
+PRODUCTION_INSTANCE_EXTRA_CONFIGURATION = env.json('PRODUCTION_INSTANCE_EXTRA_CONFIGURATION', default={})


### PR DESCRIPTION
[FAL-2270](https://tasks.opencraft.com/browse/FAL-2270)

This is so we don't need to update ocim code when the required configuration changes.  

The motivation is that we needed to update the config to add the sysadmin app, and thought why not make the whole config configurable instead of hardcoded.

**Test instructions**:

- deploy https://github.com/open-craft/ansible-secrets/pull/310
- launch a production instance using the prod instance factory
- verify that the sysadmin app is installed

**Reviewers**:

- [x] @pomegranited 