### PR TITLE
[SE-4911] Test bucket existence before creation

### DIFF
--- a/instance/tests/management/test_reprovision_buckets.py
+++ b/instance/tests/management/test_reprovision_buckets.py
@@ -56,11 +56,13 @@ class ReprovisionBucketsTestCase(TestCase):
     @patch('instance.models.mixins.storage.S3BucketInstanceMixin._update_bucket_lifecycle')
     @patch('instance.models.mixins.storage.S3BucketInstanceMixin._update_bucket_cors')
     @patch('instance.models.mixins.storage.S3BucketInstanceMixin._perform_create_bucket')
+    @patch('instance.models.mixins.storage.S3BucketInstanceMixin._is_bucket_exists')
     @patch('instance.models.mixins.storage.S3BucketInstanceMixin._update_iam_policy')
     @patch('instance.models.mixins.storage.S3BucketInstanceMixin.create_iam_user')
     def test_migrate(self,
                      mock_create_iam_user,
                      mock_update_iam,
+                     mock_check_if_bucket_exists,
                      mock_create_bucket,
                      mock_update_cors,
                      mock_update_lifecycle,

--- a/instance/tests/management/test_reprovision_buckets.py
+++ b/instance/tests/management/test_reprovision_buckets.py
@@ -62,7 +62,7 @@ class ReprovisionBucketsTestCase(TestCase):
     def test_migrate(self,
                      mock_create_iam_user,
                      mock_update_iam,
-                     mock_check_if_bucket_exists,
+                     mock_is_bucket_exists,
                      mock_create_bucket,
                      mock_update_cors,
                      mock_update_lifecycle,

--- a/instance/tests/models/test_openedx_storage_mixins.py
+++ b/instance/tests/models/test_openedx_storage_mixins.py
@@ -405,6 +405,7 @@ class S3ContainerInstanceTestCase(ContainerTestCase):
                     storage.USER_POLICY_NAME,
                     instance.get_s3_policy()
                 )
+                stubber.stub_list_buckets()
                 stubber.stub_create_bucket()
                 stubber.stub_put_cors()
                 stubber.stub_set_expiration()
@@ -423,6 +424,7 @@ class S3ContainerInstanceTestCase(ContainerTestCase):
         max_tries = 4
         stubber = Stubber(s3_client)
         for _ in range(max_tries):
+            stubber.add_response('list_buckets', {'Buckets': []})
             stubber.add_client_error('create_bucket')
         with self.assertLogs('instance.models.instance', level='INFO') as cm:
             with stubber:
@@ -450,6 +452,7 @@ class S3ContainerInstanceTestCase(ContainerTestCase):
         instance.s3_bucket_name = 'test'
         max_tries = 4
         stubber = S3Stubber(s3_client)
+        stubber.add_response('list_buckets', {'Buckets': []})
         stubber.stub_create_bucket(location='')
         for _ in range(max_tries):
             stubber.stub_put_cors()
@@ -489,6 +492,7 @@ class S3ContainerInstanceTestCase(ContainerTestCase):
                 storage.USER_POLICY_NAME,
                 instance.get_s3_policy()
             )
+            stubber.stub_list_buckets()
             stubber.stub_create_bucket()
             stubber.stub_put_cors()
             stubber.stub_set_expiration()
@@ -560,6 +564,7 @@ class S3ContainerInstanceTestCase(ContainerTestCase):
                     storage.USER_POLICY_NAME,
                     instance.get_s3_policy()
                 )
+                stubber.stub_list_buckets()
                 stubber.stub_create_bucket(location='')
                 stubber.stub_put_cors()
                 stubber.stub_set_expiration()
@@ -601,6 +606,7 @@ class S3ContainerInstanceTestCase(ContainerTestCase):
                     storage.USER_POLICY_NAME,
                     instance.get_s3_policy()
                 )
+                stubber.stub_list_buckets()
                 stubber.stub_create_bucket(location='')
                 stubber.stub_put_cors()
                 stubber.stub_set_expiration()
@@ -642,6 +648,7 @@ class S3ContainerInstanceTestCase(ContainerTestCase):
                     storage.USER_POLICY_NAME,
                     instance.get_s3_policy()
                 )
+                stubber.stub_list_buckets()
                 stubber.stub_create_bucket()
                 stubber.stub_put_cors()
                 stubber.stub_set_expiration()
@@ -687,6 +694,7 @@ class S3ContainerInstanceTestCase(ContainerTestCase):
                     storage.USER_POLICY_NAME,
                     instance.get_s3_policy()
                 )
+                stubber.stub_list_buckets()
                 stubber.stub_create_bucket()
                 stubber.stub_put_cors()
                 stubber.stub_set_expiration()
@@ -736,6 +744,7 @@ class S3ContainerInstanceTestCase(ContainerTestCase):
                 storage.USER_POLICY_NAME,
                 instance.get_s3_policy()
             )
+            stubber.add_response('list_buckets', {'Buckets': []})
             stubber.stub_create_bucket(bucket=instance.s3_bucket_name, location='')
             stubber.stub_put_cors(bucket=instance.s3_bucket_name)
             stubber.stub_set_expiration(bucket=instance.s3_bucket_name)

--- a/instance/tests/models/test_openedx_storage_mixins.py
+++ b/instance/tests/models/test_openedx_storage_mixins.py
@@ -29,7 +29,6 @@ import ddt
 import yaml
 from botocore.exceptions import ClientError
 from botocore.session import get_session
-from botocore.stub import Stubber
 from django.conf import settings
 from django.test.utils import override_settings
 
@@ -405,7 +404,7 @@ class S3ContainerInstanceTestCase(ContainerTestCase):
                     storage.USER_POLICY_NAME,
                     instance.get_s3_policy()
                 )
-                stubber.stub_list_buckets()
+                stubber.stub_head_bucket()
                 stubber.stub_create_bucket()
                 stubber.stub_put_cors()
                 stubber.stub_set_expiration()
@@ -422,9 +421,9 @@ class S3ContainerInstanceTestCase(ContainerTestCase):
         instance.s3_secret_access_key = 'test'
         instance.s3_bucket_name = 'test'
         max_tries = 4
-        stubber = Stubber(s3_client)
+        stubber = S3Stubber(s3_client)
         for _ in range(max_tries):
-            stubber.add_response('list_buckets', {'Buckets': []})
+            stubber.stub_head_bucket()
             stubber.add_client_error('create_bucket')
         with self.assertLogs('instance.models.instance', level='INFO') as cm:
             with stubber:
@@ -452,7 +451,7 @@ class S3ContainerInstanceTestCase(ContainerTestCase):
         instance.s3_bucket_name = 'test'
         max_tries = 4
         stubber = S3Stubber(s3_client)
-        stubber.add_response('list_buckets', {'Buckets': []})
+        stubber.stub_head_bucket()
         stubber.stub_create_bucket(location='')
         for _ in range(max_tries):
             stubber.stub_put_cors()
@@ -492,7 +491,7 @@ class S3ContainerInstanceTestCase(ContainerTestCase):
                 storage.USER_POLICY_NAME,
                 instance.get_s3_policy()
             )
-            stubber.stub_list_buckets()
+            stubber.stub_head_bucket()
             stubber.stub_create_bucket()
             stubber.stub_put_cors()
             stubber.stub_set_expiration()
@@ -564,7 +563,7 @@ class S3ContainerInstanceTestCase(ContainerTestCase):
                     storage.USER_POLICY_NAME,
                     instance.get_s3_policy()
                 )
-                stubber.stub_list_buckets()
+                stubber.stub_head_bucket()
                 stubber.stub_create_bucket(location='')
                 stubber.stub_put_cors()
                 stubber.stub_set_expiration()
@@ -606,7 +605,7 @@ class S3ContainerInstanceTestCase(ContainerTestCase):
                     storage.USER_POLICY_NAME,
                     instance.get_s3_policy()
                 )
-                stubber.stub_list_buckets()
+                stubber.stub_head_bucket()
                 stubber.stub_create_bucket(location='')
                 stubber.stub_put_cors()
                 stubber.stub_set_expiration()
@@ -648,7 +647,7 @@ class S3ContainerInstanceTestCase(ContainerTestCase):
                     storage.USER_POLICY_NAME,
                     instance.get_s3_policy()
                 )
-                stubber.stub_list_buckets()
+                stubber.stub_head_bucket()
                 stubber.stub_create_bucket()
                 stubber.stub_put_cors()
                 stubber.stub_set_expiration()
@@ -694,7 +693,7 @@ class S3ContainerInstanceTestCase(ContainerTestCase):
                     storage.USER_POLICY_NAME,
                     instance.get_s3_policy()
                 )
-                stubber.stub_list_buckets()
+                stubber.stub_head_bucket()
                 stubber.stub_create_bucket()
                 stubber.stub_put_cors()
                 stubber.stub_set_expiration()
@@ -744,7 +743,7 @@ class S3ContainerInstanceTestCase(ContainerTestCase):
                 storage.USER_POLICY_NAME,
                 instance.get_s3_policy()
             )
-            stubber.add_response('list_buckets', {'Buckets': []})
+            stubber.stub_head_bucket(bucket=instance.s3_bucket_name)
             stubber.stub_create_bucket(bucket=instance.s3_bucket_name, location='')
             stubber.stub_put_cors(bucket=instance.s3_bucket_name)
             stubber.stub_set_expiration(bucket=instance.s3_bucket_name)

--- a/instance/tests/models/utils.py
+++ b/instance/tests/models/utils.py
@@ -14,6 +14,38 @@ class S3Stubber(Stubber):
     Helper class to simplify stubbing S3 operations
     """
 
+    def stub_list_buckets(self, buckets=None):
+        """Stub helper for 'list_buckets'
+        buckets is a list of buckets, in the form of
+        [{'Name': 'test', 'CreationDate': datetime.datetime(2021, 5, 12, 19, 50)}]
+        """
+        if buckets is None:
+            buckets = []
+
+        response = {
+            'ResponseMetadata': {
+                'RequestId': 'RequestId_string',
+                'HostId': 'HostId_string',
+                'HTTPStatusCode': 200,
+                'HTTPHeaders': {
+                    'key': 'value',
+                    'x-amz-request-id': 'string',
+                    'date': 'Thu, 14 Oct 2021 19:07:50 GMT',
+                    'content-type': 'application/xml',
+                    'transfer-encoding': 'chunked',
+                    'server': 'AmazonS3'
+                },
+                'RetryAttempts': 0
+            },
+            'Buckets': buckets,
+            'Owner': {
+                'DisplayName': 'owner_name',
+                'ID': 'ID'
+            }
+        }
+
+        self.add_response('list_buckets', response)
+
     def stub_create_bucket(self, bucket='test', location='test'):
         """ Stub helper for 'create_bucket' """
         if not location or location == 'us-east-1':

--- a/instance/tests/models/utils.py
+++ b/instance/tests/models/utils.py
@@ -14,37 +14,14 @@ class S3Stubber(Stubber):
     Helper class to simplify stubbing S3 operations
     """
 
-    def stub_list_buckets(self, buckets=None):
-        """Stub helper for 'list_buckets'
-        buckets is a list of buckets, in the form of
-        [{'Name': 'test', 'CreationDate': datetime.datetime(2021, 5, 12, 19, 50)}]
-        """
-        if buckets is None:
-            buckets = []
-
-        response = {
-            'ResponseMetadata': {
-                'RequestId': 'RequestId_string',
-                'HostId': 'HostId_string',
-                'HTTPStatusCode': 200,
-                'HTTPHeaders': {
-                    'key': 'value',
-                    'x-amz-request-id': 'string',
-                    'date': 'Thu, 14 Oct 2021 19:07:50 GMT',
-                    'content-type': 'application/xml',
-                    'transfer-encoding': 'chunked',
-                    'server': 'AmazonS3'
-                },
-                'RetryAttempts': 0
-            },
-            'Buckets': buckets,
-            'Owner': {
-                'DisplayName': 'owner_name',
-                'ID': 'ID'
-            }
-        }
-
-        self.add_response('list_buckets', response)
+    def stub_head_bucket(self, bucket='test', bucket_exists=False):
+        """ Stub helper for 'head_bucket' """
+        if bucket_exists:
+            self.add_response('head_bucket', {}, {
+                'Bucket': bucket
+            })
+        else:
+            self.add_client_error('head_bucket', service_error_code='404')
 
     def stub_create_bucket(self, bucket='test', location='test'):
         """ Stub helper for 'create_bucket' """


### PR DESCRIPTION
## Description

PR for https://tasks.opencraft.com/browse/SE-4911

Behavioral specifications

    "When the user provisions a new app server, if S3 is already provisioned and the bucket already exists, the logs should indicate that the bucket already exists instead and Ocim shouldn't provision a new bucket."

## Supporting information

N/A

### Dependencies

N/A

### Screenshots

N/A

## Testing instructions

* checkout the changes on stage
* create a new instance
* start a new app server
* check the output to see the logs are containing the bucket creation
* after the bucket creation, terminate the app server
* start a new app server
* check the output to see the logs are containing "Bucket <bucket name> already exists"

## Deadline

ASAP

## Other information

N/A