### PR TITLE
[FAL-2545] [WIP] Use 'any' instead of 'all' in NewRelic monitoring conditions

### DIFF
--- a/instance/newrelic.py
+++ b/instance/newrelic.py
@@ -190,7 +190,7 @@ def add_alert_nrql_condition(policy_id, monitor_url, name):
                     'threshold': settings.NEWRELIC_NRQL_ALERT_CONDITION_THRESHOLD,
                     'operator': 'above',
                     'priority': 'critical',
-                    'time_function': 'all',
+                    'time_function': 'any',
                 }],
                 'nrql': {
                     'query': query,

--- a/instance/tests/test_newrelic.py
+++ b/instance/tests/test_newrelic.py
@@ -264,7 +264,7 @@ class NewRelicTestCase(TestCase):
                     'threshold': '2',
                     'operator': 'above',
                     'priority': 'critical',
-                    'time_function': 'all',
+                    'time_function': 'any',
                 }],
                 'nrql': {
                     'query': query,


### PR DESCRIPTION
# The problem

- See https://discuss.newrelic.com/t/422-client-error-unprocessable-entity-when-creating-nrql-conditions-for-existing-policies/165928
- We saw: `422 Client Error: Unprocessable Entity`
- I ran `curl -X POST 'https://api.newrelic.com/v2/alerts_nrql_conditions/policies/1677272.json' -H 'X-Api-Key: …' -i -H 'Content-Type: application/json' -d @~/data.json` with that payload, and saw: `terms[].time_function must be 'any' if value is set to 'sum'`

# The right value

- `any` means „at least once“, according to [the documentation](https://docs.newrelic.com/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names/). In the UI, while checking other monitors ([e.g.](https://onenr.io/0LZQWBogkjW)) I see they mention „at least once“ (e.g. `Sum of SyntheticCheck query results is >1 unit at least once in 11 mins`). I'll assume that `any` makes sense
- I don't know why this behaviour changed. Our monitors have worked fine with `all` for a long time. Did something in NR change?

# This PR
- This PR does the suggested change. It's still untested
- TODO: verify what changed in New Relic, and whether the new value is fine, and whether we need to update all old policies to have them work in the same way

# Testing instructions

- TBD after deciding the right values
- Probably just deploy a new server and verify that the policy makes sense and that it works in the same way as the old policies 

# Reviewers
- @pomegranited ?

# Merge deadline
- The fix is urgent since it's breaking monitoring.