### PR TITLE
[BB-5077] fix: End of trial email sent to paying customer

### DIFF
--- a/marketing/signals.py
+++ b/marketing/signals.py
@@ -35,5 +35,4 @@ def register_subscriber(sender, **kwargs):
 
     application = kwargs['application']
 
-
     Subscriber.objects.get_or_create(user_id=application.user.id)

--- a/marketing/signals.py
+++ b/marketing/signals.py
@@ -38,5 +38,5 @@ def register_subscriber(sender, **kwargs):
     # Ignore if the appserver was not spawned for a beta tester.
     if not application:
         return
-    
+
     Subscriber.objects.get_or_create(user_id=application.user.id)

--- a/marketing/signals.py
+++ b/marketing/signals.py
@@ -21,27 +21,22 @@ Signals related to marketing.
 """
 from django.dispatch import receiver
 
-from instance.signals import appserver_spawned
+from registration.signals import betapplication_accepted
 from marketing.models import Subscriber
 
 
-@receiver(appserver_spawned)
+@receiver(betapplication_accepted)
 def register_subscriber(sender, **kwargs):
     """
     Registers a marketing email subscriber for Beta testers
     on first successful appserver spawn. Only registers if user is not
     already registered as subscriber.
     """
-    instance = kwargs['instance']
-    appserver = kwargs['appserver']
-    application = instance.betatestapplication_set.first()  # There should only be one
+
+    application = kwargs['application']
 
     # Ignore if the appserver was not spawned for a beta tester.
     if not application:
         return
-    # Ignore if appserver didn't provision
-    elif appserver is None:
-        return
-    else:
-        # Register the user as followup email subscriber
-        Subscriber.objects.get_or_create(user_id=application.user.id)
+    
+    Subscriber.objects.get_or_create(user_id=application.user.id)

--- a/marketing/signals.py
+++ b/marketing/signals.py
@@ -35,8 +35,5 @@ def register_subscriber(sender, **kwargs):
 
     application = kwargs['application']
 
-    # Ignore if the appserver was not spawned for a beta tester.
-    if not application:
-        return
 
     Subscriber.objects.get_or_create(user_id=application.user.id)

--- a/marketing/signals.py
+++ b/marketing/signals.py
@@ -21,11 +21,11 @@ Signals related to marketing.
 """
 from django.dispatch import receiver
 
-from registration.signals import betapplication_accepted
+from registration.signals import betatestapplication_accepted
 from marketing.models import Subscriber
 
 
-@receiver(betapplication_accepted)
+@receiver(betatestapplication_accepted)
 def register_subscriber(sender, **kwargs):
     """
     Registers a marketing email subscriber for Beta testers

--- a/marketing/tests/test_register_subscriber.py
+++ b/marketing/tests/test_register_subscriber.py
@@ -28,9 +28,9 @@ from django.test import TestCase
 
 from instance.models.appserver import AppServer
 from marketing.models import Subscriber
-from registration.tests.utils import UserFactory
 from registration.approval import on_appserver_spawned
 from registration.models import BetaTestApplication
+from registration.tests.utils import BetaTestUserFactory
 
 
 # Test cases ##################################################################
@@ -46,7 +46,7 @@ class RegisterSubscriberTestCase(TestCase):
         Test new subscription entry for trial client on first successful launch of appserver
         """
 
-        user = UserFactory()
+        user = BetaTestUserFactory()
 
         instance = mock.Mock(first_activated=None)
         application = mock.Mock(user=user, subdomain='test', status=BetaTestApplication.PENDING)
@@ -63,7 +63,7 @@ class RegisterSubscriberTestCase(TestCase):
         Test no entry made in subscription table for paying clients on successful launch of appserver
         """
 
-        user = UserFactory()
+        user = BetaTestUserFactory()
 
         instance = mock.Mock(first_activated=None)
         application = mock.Mock(user=user, subdomain='test', status=BetaTestApplication.ACCEPTED)

--- a/marketing/tests/test_register_subscriber.py
+++ b/marketing/tests/test_register_subscriber.py
@@ -1,0 +1,99 @@
+# -*- coding: utf-8 -*-
+#
+# OpenCraft -- tools to aid developing and hosting free software projects
+# Copyright (C) 2015-2019 OpenCraft <xavier@opencraft.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+"""
+Tests for the register subscriber function
+"""
+
+# Imports #####################################################################
+
+from unittest import mock
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from datetime import datetime
+
+from instance.models.appserver import AppServer
+from marketing.models import Subscriber
+from userprofile.models import UserProfile
+from registration.approval import on_appserver_spawned
+from registration.models import BetaTestApplication
+
+
+# Test cases ##################################################################
+
+
+class RegisterSubscriberTestCase(TestCase):
+    """
+    Tests for the register_subscriber function
+    """
+
+    def test_trial_client_subscription(self):
+        """
+        Test new subscription entry for trial client on first successful launch of appserver
+        """
+
+        user = get_user_model().objects.create_user(username='test', email='test@example.com')
+
+        UserProfile.objects.create(
+            user=user,
+            full_name="Test user 1",
+            accepted_privacy_policy=datetime.now(),
+            accept_domain_condition=True,
+            subscribe_to_updates=True,
+        )
+
+        user.refresh_from_db()
+
+        instance = mock.Mock(first_activated=None)
+        application = mock.Mock(user=user, subdomain='test', status=BetaTestApplication.PENDING)
+        appserver = mock.Mock(status=AppServer.Status.Running)
+
+        instance.betatestapplication_set.first = lambda: application
+        application.instance = instance
+
+        on_appserver_spawned(sender=None, instance=instance, appserver=appserver)
+        self.assertTrue(Subscriber.objects.filter(user_id=application.user.id).exists())
+
+    def test_existing_client_subscription(self):
+        """
+        Test no entry made in subscription table for paying clients on successful launch of appserver
+        """
+
+        user = get_user_model().objects.create_user(username='test', email='test@example.com')
+
+        UserProfile.objects.create(
+            user=user,
+            full_name="Test user 1",
+            accepted_privacy_policy=datetime.now(),
+            accept_domain_condition=True,
+            subscribe_to_updates=True,
+        )
+
+        user.refresh_from_db()
+
+        instance = mock.Mock(first_activated=None)
+        application = mock.Mock(user=user, subdomain='test', status=BetaTestApplication.ACCEPTED)
+        appserver = mock.Mock(status=AppServer.Status.Running)
+
+        instance.betatestapplication_set.first = lambda: application
+        application.instance = instance
+
+        on_appserver_spawned(sender=None, instance=instance, appserver=appserver)
+        self.assertFalse(Subscriber.objects.filter(user_id=application.user.id).exists())
+

--- a/marketing/tests/test_register_subscriber.py
+++ b/marketing/tests/test_register_subscriber.py
@@ -23,15 +23,12 @@ Tests for the register subscriber function
 # Imports #####################################################################
 
 from unittest import mock
-from datetime import datetime
 
-from django.contrib.auth import get_user_model
 from django.test import TestCase
-
 
 from instance.models.appserver import AppServer
 from marketing.models import Subscriber
-from userprofile.models import UserProfile
+from registration.tests.utils import UserFactory
 from registration.approval import on_appserver_spawned
 from registration.models import BetaTestApplication
 
@@ -49,17 +46,7 @@ class RegisterSubscriberTestCase(TestCase):
         Test new subscription entry for trial client on first successful launch of appserver
         """
 
-        user = get_user_model().objects.create_user(username='test', email='test@example.com')
-
-        UserProfile.objects.create(
-            user=user,
-            full_name="Test user 1",
-            accepted_privacy_policy=datetime.now(),
-            accept_domain_condition=True,
-            subscribe_to_updates=True,
-        )
-
-        user.refresh_from_db()
+        user = UserFactory()
 
         instance = mock.Mock(first_activated=None)
         application = mock.Mock(user=user, subdomain='test', status=BetaTestApplication.PENDING)
@@ -76,17 +63,7 @@ class RegisterSubscriberTestCase(TestCase):
         Test no entry made in subscription table for paying clients on successful launch of appserver
         """
 
-        user = get_user_model().objects.create_user(username='test', email='test@example.com')
-
-        UserProfile.objects.create(
-            user=user,
-            full_name="Test user 1",
-            accepted_privacy_policy=datetime.now(),
-            accept_domain_condition=True,
-            subscribe_to_updates=True,
-        )
-
-        user.refresh_from_db()
+        user = UserFactory()
 
         instance = mock.Mock(first_activated=None)
         application = mock.Mock(user=user, subdomain='test', status=BetaTestApplication.ACCEPTED)

--- a/marketing/tests/test_register_subscriber.py
+++ b/marketing/tests/test_register_subscriber.py
@@ -23,10 +23,11 @@ Tests for the register subscriber function
 # Imports #####################################################################
 
 from unittest import mock
+from datetime import datetime
 
 from django.contrib.auth import get_user_model
 from django.test import TestCase
-from datetime import datetime
+
 
 from instance.models.appserver import AppServer
 from marketing.models import Subscriber
@@ -96,4 +97,3 @@ class RegisterSubscriberTestCase(TestCase):
 
         on_appserver_spawned(sender=None, instance=instance, appserver=appserver)
         self.assertFalse(Subscriber.objects.filter(user_id=application.user.id).exists())
-

--- a/registration/approval.py
+++ b/registration/approval.py
@@ -27,6 +27,7 @@ from django.dispatch import receiver
 
 from instance.models.appserver import AppServer
 from instance.signals import appserver_spawned
+from registration.signals import betapplication_accepted
 from registration.models import BetaTestApplication
 from registration.utils import send_welcome_email
 
@@ -55,6 +56,8 @@ def accept_application(application, appserver):
         appserver.make_active()
 
     send_welcome_email(application)
+
+    betapplication_accepted.send(sender=None, application=application)
 
     application.status = BetaTestApplication.ACCEPTED
     application.save()

--- a/registration/approval.py
+++ b/registration/approval.py
@@ -27,7 +27,7 @@ from django.dispatch import receiver
 
 from instance.models.appserver import AppServer
 from instance.signals import appserver_spawned
-from registration.signals import betapplication_accepted
+from registration.signals import betatestapplication_accepted
 from registration.models import BetaTestApplication
 from registration.utils import send_welcome_email
 
@@ -57,7 +57,7 @@ def accept_application(application, appserver):
 
     send_welcome_email(application)
 
-    betapplication_accepted.send(sender=None, application=application)
+    betatestapplication_accepted.send(sender=None, application=application)
 
     application.status = BetaTestApplication.ACCEPTED
     application.save()

--- a/registration/approval.py
+++ b/registration/approval.py
@@ -57,10 +57,11 @@ def accept_application(application, appserver):
 
     send_welcome_email(application)
 
-    betatestapplication_accepted.send(sender=None, application=application)
-
     application.status = BetaTestApplication.ACCEPTED
     application.save()
+
+    # Send signal to notify beta test application is accepted
+    betatestapplication_accepted.send(sender=None, application=application)
 
 
 @receiver(appserver_spawned)

--- a/registration/signals.py
+++ b/registration/signals.py
@@ -20,7 +20,7 @@
 Signals related to registration.
 """
 from django.conf import settings
-from django.dispatch import receiver
+from django.dispatch import receiver, Signal
 from django_rest_passwordreset.models import ResetPasswordToken
 from django_rest_passwordreset.signals import reset_password_token_created
 from django_rest_passwordreset.views import ResetPasswordRequestToken
@@ -31,6 +31,16 @@ from opencraft.utils import html_email_helper
 from registration.models import BetaTestApplication
 from registration.utils import send_changes_deployed_success_email
 
+
+
+# Signals #####################################################################
+
+# Emitted after beta test application has been accepted
+betapplication_accepted = Signal(providing_args=['application'])
+
+
+
+# Receiver Functions ###################################################################
 
 # noinspection PyUnusedLocal
 @receiver(reset_password_token_created)

--- a/registration/signals.py
+++ b/registration/signals.py
@@ -32,17 +32,17 @@ from registration.models import BetaTestApplication
 from registration.utils import send_changes_deployed_success_email
 
 
-
 # Signals #####################################################################
 
 # Emitted after beta test application has been accepted
 betapplication_accepted = Signal(providing_args=['application'])
 
 
-
 # Receiver Functions ###################################################################
 
 # noinspection PyUnusedLocal
+
+
 @receiver(reset_password_token_created)
 def password_reset_token_created(
         sender: ResetPasswordRequestToken,

--- a/registration/signals.py
+++ b/registration/signals.py
@@ -35,7 +35,7 @@ from registration.utils import send_changes_deployed_success_email
 # Signals #####################################################################
 
 # Emitted after beta test application has been accepted
-betapplication_accepted = Signal(providing_args=['application'])
+betatestapplication_accepted = Signal(providing_args=['application'])
 
 
 # Receiver Functions ###################################################################

--- a/registration/tests/test_approval.py
+++ b/registration/tests/test_approval.py
@@ -23,7 +23,6 @@ Tests for the betatest approval helper functions
 # Imports #####################################################################
 
 from unittest import mock
-from datetime import datetime
 
 from django.contrib.auth import get_user_model
 from django.test import TestCase
@@ -31,7 +30,7 @@ from django.test import TestCase
 from instance.models.appserver import AppServer
 from registration.approval import ApplicationNotReady, accept_application, on_appserver_spawned
 from registration.models import BetaTestApplication
-from userprofile.models import UserProfile
+from registration.tests.utils import UserFactory
 
 
 # Test cases ##################################################################
@@ -128,17 +127,8 @@ class ApprovalTestCase(TestCase):
         Check if the the first Appserver is correctly activated even when
         spawned manually
         """
-        user = get_user_model().objects.create_user(username='test', email='test@example.com')
 
-        UserProfile.objects.create(
-            user=user,
-            full_name="Test user 1",
-            accepted_privacy_policy=datetime.now(),
-            accept_domain_condition=True,
-            subscribe_to_updates=True,
-        )
-
-        user.refresh_from_db()
+        user = UserFactory()
 
         appserver = mock.Mock(status=AppServer.Status.Running)
         instance = mock.Mock(first_activated=None)

--- a/registration/tests/test_approval.py
+++ b/registration/tests/test_approval.py
@@ -30,7 +30,7 @@ from django.test import TestCase
 from instance.models.appserver import AppServer
 from registration.approval import ApplicationNotReady, accept_application, on_appserver_spawned
 from registration.models import BetaTestApplication
-from registration.tests.utils import UserFactory
+from registration.tests.utils import BetaTestUserFactory
 
 
 # Test cases ##################################################################
@@ -128,7 +128,7 @@ class ApprovalTestCase(TestCase):
         spawned manually
         """
 
-        user = UserFactory()
+        user = BetaTestUserFactory()
 
         appserver = mock.Mock(status=AppServer.Status.Running)
         instance = mock.Mock(first_activated=None)

--- a/registration/tests/test_approval.py
+++ b/registration/tests/test_approval.py
@@ -23,6 +23,7 @@ Tests for the betatest approval helper functions
 # Imports #####################################################################
 
 from unittest import mock
+from datetime import datetime
 
 from django.contrib.auth import get_user_model
 from django.test import TestCase
@@ -30,6 +31,7 @@ from django.test import TestCase
 from instance.models.appserver import AppServer
 from registration.approval import ApplicationNotReady, accept_application, on_appserver_spawned
 from registration.models import BetaTestApplication
+from userprofile.models import UserProfile
 
 
 # Test cases ##################################################################
@@ -126,9 +128,21 @@ class ApprovalTestCase(TestCase):
         Check if the the first Appserver is correctly activated even when
         spawned manually
         """
+        user = get_user_model().objects.create_user(username='test', email='test@example.com')
+
+        UserProfile.objects.create(
+            user=user,
+            full_name="Test user 1",
+            accepted_privacy_policy=datetime.now(),
+            accept_domain_condition=True,
+            subscribe_to_updates=True,
+        )
+
+        user.refresh_from_db()
+
         appserver = mock.Mock(status=AppServer.Status.Running)
         instance = mock.Mock(first_activated=None)
-        application = mock.Mock(status=BetaTestApplication.PENDING)
+        application = mock.Mock(user=user, status=BetaTestApplication.PENDING)
 
         application.instance = instance
         instance.betatestapplication_set.first = lambda: application

--- a/registration/tests/utils.py
+++ b/registration/tests/utils.py
@@ -201,18 +201,24 @@ class UserMixin:
             password=self.password,
         )
 
-class UserProfileFactory(DjangoModelFactory):
+class BetaTestUserProfileFactory(DjangoModelFactory):
+    """
+    Factory for creating UserProfile along with User
+    """
     class Meta:
         model = UserProfile
 
     full_name = "Test User"
-    accepted_privacy_policy=factory.LazyFunction(datetime.now)
-    accept_domain_condition=True
-    subscribe_to_updates=True
+    accepted_privacy_policy = factory.LazyFunction(datetime.now)
+    accept_domain_condition = True
+    subscribe_to_updates = True
 
     user = factory.SubFactory('registration.tests.utils.UserFactory', profile=None)
 
-class UserFactory(DjangoModelFactory):
+class BetaTestUserFactory(DjangoModelFactory):
+    """
+    Factory for creating User along with UserProfile
+    """
     class Meta:
         model = User
         django_get_or_create = ('username',)
@@ -221,4 +227,4 @@ class UserFactory(DjangoModelFactory):
     username = "test"
     email = factory.LazyAttribute(lambda a: '{}@example.com'.format(a.username).lower())
 
-    profile = factory.RelatedFactory(UserProfileFactory, factory_related_name='user')
+    profile = factory.RelatedFactory(BetaTestUserProfileFactory, factory_related_name='user')

--- a/registration/tests/utils.py
+++ b/registration/tests/utils.py
@@ -22,6 +22,7 @@ Utils for registration tests
 
 # Imports #####################################################################
 import time
+from datetime import datetime
 
 from django.contrib.auth.models import User
 from django.contrib.sites.models import Site
@@ -35,7 +36,10 @@ from selenium.webdriver.common.desired_capabilities import DesiredCapabilities
 from selenium.webdriver.firefox.options import Options
 from selenium.webdriver.support import expected_conditions
 from selenium.webdriver.support.ui import WebDriverWait
+import factory
+from factory.django import DjangoModelFactory
 
+from userprofile.models import UserProfile
 
 # Utility Functions ###########################################################
 
@@ -196,3 +200,25 @@ class UserMixin:
             email=self.email,
             password=self.password,
         )
+
+class UserProfileFactory(DjangoModelFactory):
+    class Meta:
+        model = UserProfile
+
+    full_name = "Test User"
+    accepted_privacy_policy=factory.LazyFunction(datetime.now)
+    accept_domain_condition=True
+    subscribe_to_updates=True
+
+    user = factory.SubFactory('registration.tests.utils.UserFactory', profile=None)
+
+class UserFactory(DjangoModelFactory):
+    class Meta:
+        model = User
+        django_get_or_create = ('username',)
+
+
+    username = "test"
+    email = factory.LazyAttribute(lambda a: '{}@example.com'.format(a.username).lower())
+
+    profile = factory.RelatedFactory(UserProfileFactory, factory_related_name='user')


### PR DESCRIPTION
## Description

This PR is fix for a bug identified in OCIM application, where a paying client would get an end of trial reminder email after they launched a new appserver


## Supporting information

[BB-5077](https://tasks.opencraft.com/browse/BB-5077)

## Testing instructions

1. Register a new trial instance in OCIM
2. Once the first app server is ready, delete the corresponding entry created in Subscribers table from the Django admin page
3. Launch a new appserver from console
4. After the new appserver is up and ready, check that there should be no new entry in the Subscribers table

## Deadline

"None"
