### PR TITLE
[SE-5006] fix: deprovision s3 buckets with better filtering

### DIFF
--- a/instance/management/commands/deprovision_buckets.py
+++ b/instance/management/commands/deprovision_buckets.py
@@ -126,5 +126,5 @@ class Command(BaseCommand):
             if not dry_run:
                 try:
                     instance.deprovision_s3()
-                except Exception as exc:
+                except Exception as exc:  # pylint: disable=broad-except
                     LOG.error('Cannot delete bucket for %d: %s', instance.id, str(exc))

--- a/instance/management/commands/deprovision_buckets.py
+++ b/instance/management/commands/deprovision_buckets.py
@@ -114,7 +114,7 @@ class Command(BaseCommand):
             instance
             for instance in instances if (
                 instance.latest_archiving_date is not None and
-                instance.latest_archiving_date > timezone.now() - timedelta(days=num_days_archived)
+                instance.latest_archiving_date + timedelta(days=num_days_archived) < timezone.now()
             ) or instance.latest_archiving_date is None
         ]
 

--- a/instance/tests/management/test_deprovision_buckets.py
+++ b/instance/tests/management/test_deprovision_buckets.py
@@ -19,11 +19,11 @@
 """
 Instance - deprovision_buckets unit tests
 """
-import ddt
 import re
 from datetime import timedelta
 from unittest.mock import patch
 
+import ddt
 from django.core.management import call_command
 from django.test import TestCase
 from django.utils.six import StringIO

--- a/instance/tests/management/test_deprovision_buckets.py
+++ b/instance/tests/management/test_deprovision_buckets.py
@@ -90,10 +90,12 @@ class DeprovisionBucketsTestCase(TestCase):
         ('se-1234', 'testdomain'),
     )
     @ddt.unpack
-    def test_deprovision_s3_of_archived_sandbox(self, *mocks, bucket_name, lms_domain):
+    def test_deprovision_s3_of_archived_sandbox(self, *params):
         """
         Verify that the command correctly deprovisions the bucket for an archived sandbox instance.
         """
+        *_, bucket_name, lms_domain = params
+
         instance = OpenEdXInstance.objects.create(
             sub_domain='test',
             name='test instance',

--- a/instance/tests/management/test_deprovision_buckets.py
+++ b/instance/tests/management/test_deprovision_buckets.py
@@ -19,6 +19,7 @@
 """
 Instance - deprovision_buckets unit tests
 """
+import ddt
 import re
 from datetime import timedelta
 from unittest.mock import patch
@@ -33,6 +34,7 @@ from instance.gandi import GandiV5API
 from instance.models.openedx_instance import OpenEdXInstance
 
 
+@ddt.ddt
 class DeprovisionBucketsTestCase(TestCase):
     """
     Test cases for the `deprovision_buckets` management command.
@@ -75,7 +77,20 @@ class DeprovisionBucketsTestCase(TestCase):
     @patch('instance.models.mixins.openedx_monitoring.OpenEdXMonitoringMixin.disable_monitoring')
     @patch('instance.models.load_balancer.LoadBalancingServer.reconfigure')
     @patch('instance.models.mixins.ansible.AnsibleAppServerMixin._run_playbook', return_value=("", 0))
-    def test_deprovision_s3_of_archived_sandbox(self, *mocks):
+    @ddt.data(
+        ('testbucket', '.sandbox.'),
+        ('testbucket', 'pr12345'),
+        ('testbucket', 'pr-12345'),
+        ('testbucket', 'se1234'),
+        ('testbucket', 'se-1234'),
+        ('-sandbox-', 'testdomain'),
+        ('pr12345', 'testdomain'),
+        ('pr-12345', 'testdomain'),
+        ('se1234', 'testdomain'),
+        ('se-1234', 'testdomain'),
+    )
+    @ddt.unpack
+    def test_deprovision_s3_of_archived_sandbox(self, *mocks, bucket_name, lms_domain):
         """
         Verify that the command correctly deprovisions the bucket for an archived sandbox instance.
         """
@@ -83,8 +98,8 @@ class DeprovisionBucketsTestCase(TestCase):
             sub_domain='test',
             name='test instance',
             storage_type=OpenEdXInstance.S3_STORAGE,
-            s3_bucket_name='testbucket',
-            internal_lms_domain='.sandbox.'
+            s3_bucket_name=bucket_name,
+            internal_lms_domain=lms_domain,
         )
         instance.archive()
         # instances need to be archived for at least 3 months for us to be able to deprovision the s3 buckets

--- a/instance/tests/management/test_deprovision_buckets.py
+++ b/instance/tests/management/test_deprovision_buckets.py
@@ -94,7 +94,7 @@ class DeprovisionBucketsTestCase(TestCase):
         """
         Verify that the command correctly deprovisions the bucket for an archived sandbox instance.
         """
-        *_, bucket_name, lms_domain = params
+        bucket_name, lms_domain, *_ = params
 
         instance = OpenEdXInstance.objects.create(
             sub_domain='test',

--- a/instance/tests/management/test_deprovision_buckets.py
+++ b/instance/tests/management/test_deprovision_buckets.py
@@ -79,15 +79,15 @@ class DeprovisionBucketsTestCase(TestCase):
     @patch('instance.models.mixins.ansible.AnsibleAppServerMixin._run_playbook', return_value=("", 0))
     @ddt.data(
         ('testbucket', '.sandbox.'),
-        ('testbucket', 'pr12345'),
-        ('testbucket', 'pr-12345'),
-        ('testbucket', 'se1234'),
-        ('testbucket', 'se-1234'),
+        ('testbucket', '-pr12345-'),
+        ('testbucket', '-pr-12345-'),
+        ('testbucket', '-se1234-'),
+        ('testbucket', '-se-1234-'),
         ('-sandbox-', 'testdomain'),
-        ('pr12345', 'testdomain'),
-        ('pr-12345', 'testdomain'),
-        ('se1234', 'testdomain'),
-        ('se-1234', 'testdomain'),
+        ('-pr12345-', 'testdomain'),
+        ('-pr-12345-', 'testdomain'),
+        ('-se1234-', 'testdomain'),
+        ('-se-1234-', 'testdomain'),
     )
     @ddt.unpack
     def test_deprovision_s3_of_archived_sandbox(self, *params):


### PR DESCRIPTION
## Description

When deprovisioning S3 bucket for an instance, we need to check for both
the instance and bucket names. In case of any of them meet the
conditions, we must deprovision the related bucket.

## Supporting information

Related PRs:

* https://github.com/open-craft/opencraft/pull/848

### Dependencies

N/A

## Testing instructions

* Run the command on stage and prod using the `--dry-run` flag
* Check for the output for any suspicious instance name
* Run the commands without the `--dry-run` flag
* Check that the AWS buckets are removed

## Deadline

ASAP

## Other information

A new `--dry-run` option is added beside the fix to ensure we can run the command without any harm.