### PR TITLE
[SE-5121] Set an expiry time on the DNS operation lock.

### DIFF
--- a/instance/gandi.py
+++ b/instance/gandi.py
@@ -106,7 +106,7 @@ class GandiV5API:
         Encapsulate logic that is common to high-level DNS operations: grab the global lock, do the operation,
         and retry the whole procedure multiple times if necessary.
         """
-        with cache.lock('gandi_set_dns_record'):  # Only do one DNS update at a time
+        with cache.lock('gandi_set_dns_record', timeout=settings.REDIS_LOCK_TIMEOUT):
             for i in range(1, attempts + 1):
                 try:
                     logger.info('%s (attempt %d out %d)', log_msg, i, attempts)


### PR DESCRIPTION
We use a global lock to ensure that only one process at a time is modifying DNS records.

By default the lock never expires, which means that if Ocim crashes before being able to release the lock, DNS operations contiinue being locked indefinitely even when Ocim comes back up.

We need to put a timeout on the DNS operation to avoid this from happening.

**Notes**:

I did not bother adding a test for this change since I don't think it's worth the trouble.

**Testing instructions**:

Properly testing this would be very hard -- you'd have to kill Ocim while it was performing a DNS operation and then verify that the lock gets released eventually. I don't think it's worth going through that kind of trouble for such a small change.

It should be sufficient to verify that spawning new instances and changing DNS records continues working correctly after this change.