### PR TITLE
[SE-1142] Added filtering on URL parameters.

### DIFF
--- a/instance/api/filters.py
+++ b/instance/api/filters.py
@@ -101,7 +101,8 @@ class InstanceFilterBackend(filters.BaseFilterBackend):
 
     def _filter_openedx_release(self, queryset, value):
         if value:
-            return queryset.filter(openedxappserver_set__openedx_release=value).distinct()
+            instances = OpenEdXInstance.objects.filter(openedx_release__iexact=value)
+            return queryset.filter(instance_id__in=instances)
         return queryset
 
     def _filter_tag(self, queryset, value):
@@ -112,7 +113,7 @@ class InstanceFilterBackend(filters.BaseFilterBackend):
 
     def _filter_deployment_type(self, queryset, value):
         if value:
-            return queryset.filter(deployment_type=value)
+            return queryset.filter(deployment__type=value)
         return queryset
 
     def filter_queryset(self, request, queryset, view):

--- a/instance/api/filters.py
+++ b/instance/api/filters.py
@@ -82,16 +82,23 @@ class InstanceFilterBackend(filters.BaseFilterBackend):
     """
 
     def _filter_name(self, queryset, value):
+        """
+        Filter the InstanceRef queryset on partial name.
+        """
         if value:
             return queryset.filter(name__icontains=value)
         return queryset
 
     def _filter_notes(self, queryset, value):
+        "Filter the InstanceRef queryset on partial notes."
         if value:
             return queryset.filter(notes__icontains=value)
         return queryset
 
     def _filter_status(self, queryset, value):
+        """
+        Filter the InstanceRef queryset on exact app server status.
+        """
         if value:
             # The .distinct is important, because an instance reference can
             # have multiple appservers with the same status. In that case
@@ -101,25 +108,35 @@ class InstanceFilterBackend(filters.BaseFilterBackend):
 
 
     def _filter_openedx_release(self, queryset, value):
+        """
+        Filter the InstanceRef queryset on exact openedx_release.
+        """
         if value:
             instances = OpenEdXInstance.objects.filter(openedx_release__iexact=value)
             return queryset.filter(instance_id__in=instances)
         return queryset
 
     def _filter_tag(self, queryset, value):
+        """
+        Filter the InstanceRef queryset on the OpenEdXInstance containing at
+        least one matching tag.
+        """
         if value:
-            instances = OpenEdXInstance.objects.filter(tags__name__endswith=value)
+            instances = OpenEdXInstance.objects.filter(tags__name__iexact=value)
             return queryset.filter(instance_id__in=instances)
         return queryset
 
     def _filter_deployment_type(self, queryset, value):
+        """
+        Filter the InstanceRef queryset on the matching deployment_type.
+        """
         if value:
             return queryset.filter(deployment__type=value)
         return queryset
 
     def filter_queryset(self, request, queryset, view):
         """
-        Filters the queryset.
+        Filters the queryset based on the request query params.
 
         For each field in request.GET looks for a corresponding self._filter_{field}
         method to filter by.

--- a/instance/api/filters.py
+++ b/instance/api/filters.py
@@ -22,6 +22,7 @@ Filters for the API
 
 from rest_framework import filters
 
+from instance.models.openedx_instance import OpenEdXInstance
 from userprofile.models import UserProfile
 
 
@@ -65,3 +66,69 @@ class IsOrganizationOwnerFilterBackendInstance(IsOrganizationOwnerFilterBackend)
         Return filtered queryset by organization.
         """
         return queryset.filter(owner=organization)
+
+
+class InstanceFilterBackend(filters.BaseFilterBackend):
+    """
+    More complex filter for Instance that allows users to filter on fields.
+
+    Currently allowed fields:
+    - deployment_type
+    - name
+    - notes
+    - openedx_release
+    - status
+    - tag
+    """
+
+    def _filter_name(self, queryset, value):
+        if value:
+            return queryset.filter(name__icontains=value)
+        return queryset
+
+    def _filter_notes(self, queryset, value):
+        if value:
+            return queryset.filter(notes__icontains=value)
+        return queryset
+
+    def _filter_status(self, queryset, value):
+        if value:
+            # The .distinct is important, because an instance reference can
+            # have multiple appservers with the same status. In that case
+            # there'll be duplicate rows.
+            return queryset.filter(openedxappserver_set__value=value).distinct()
+        return queryset
+
+    def _filter_openedx_release(self, queryset, value):
+        if value:
+            return queryset.filter(openedxappserver_set__openedx_release=value).distinct()
+        return queryset
+
+    def _filter_tag(self, queryset, value):
+        if value:
+            instances = OpenEdXInstance.objects.filter(tags__name__endswith=value)
+            return queryset.filter(instance_id__in=instances)
+        return queryset
+
+    def _filter_deployment_type(self, queryset, value):
+        if value:
+            return queryset.filter(deployment_type=value)
+        return queryset
+
+    def filter_queryset(self, request, queryset, view):
+        """
+        Filters the queryset.
+
+        For each field in request.GET looks for a corresponding self._filter_{field}
+        method to filter by.
+        """
+        # Note: This method was done for simplicity. It would be more advantageous to add
+        # django_filters once filtering gets more complex.
+        for field, value in request.query_params.items():
+            try:
+                filter_func = getattr(self, f'_filter_{field}')
+            except AttributeError:
+                continue
+
+            queryset = filter_func(queryset, value)
+        return queryset

--- a/instance/api/filters.py
+++ b/instance/api/filters.py
@@ -19,7 +19,7 @@
 """
 Filters for the API
 """
-
+from django.conf import settings
 from rest_framework import filters
 
 from instance.models.openedx_instance import OpenEdXInstance
@@ -143,14 +143,17 @@ class InstanceFilterBackend(filters.BaseFilterBackend):
         - production
         - sandbox
         """
+
         # There currently isn't a clean way of determining this
         # so the below is just a hack.
-
         if not value:
             return queryset
 
-        # TODO: Find the setting that contains this value.
-        default_prod_monitor_email = ['urgent@opencraft.com']
+        default_prod_monitor_email = settings.PROD_APPSERVER_FAIL_EMAILS
+
+        # For dev environments this setting is empty, no use filtering on it.
+        if not default_prod_monitor_email:
+            return queryset
 
         if value == 'production':
             instances = OpenEdXInstance.objects.filter(

--- a/instance/api/filters.py
+++ b/instance/api/filters.py
@@ -96,8 +96,9 @@ class InstanceFilterBackend(filters.BaseFilterBackend):
             # The .distinct is important, because an instance reference can
             # have multiple appservers with the same status. In that case
             # there'll be duplicate rows.
-            return queryset.filter(openedxappserver_set__value=value).distinct()
+            return queryset.filter(openedxappserver_set___status=value).distinct()
         return queryset
+
 
     def _filter_openedx_release(self, queryset, value):
         if value:

--- a/instance/api/filters.py
+++ b/instance/api/filters.py
@@ -106,7 +106,6 @@ class InstanceFilterBackend(filters.BaseFilterBackend):
             return queryset.filter(openedxappserver_set___status=value).distinct()
         return queryset
 
-
     def _filter_openedx_release(self, queryset, value):
         """
         Filter the InstanceRef queryset on exact openedx_release.

--- a/instance/api/instance.py
+++ b/instance/api/instance.py
@@ -35,7 +35,7 @@ from instance.serializers.instance import (
     InstanceAppServerSerializer
 )
 
-from .filters import IsOrganizationOwnerFilterBackendInstance
+from .filters import IsOrganizationOwnerFilterBackendInstance, InstanceFilterBackend
 
 
 # Views - API #################################################################
@@ -69,7 +69,7 @@ class InstanceViewSet(viewsets.ReadOnlyModelViewSet):
     """
     queryset = InstanceReference.objects.all()
     serializer_class = InstanceReferenceDetailedSerializer
-    filter_backends = (IsOrganizationOwnerFilterBackendInstance,)
+    filter_backends = (IsOrganizationOwnerFilterBackendInstance, InstanceFilterBackend)
 
     def get_queryset(self):
         # Don't load all columns, because some of them have very big data

--- a/instance/static/js/src/instance.js
+++ b/instance/static/js/src/instance.js
@@ -77,8 +77,8 @@ app.factory('WebSocketClient', function() {
 
 // Controllers ////////////////////////////////////////////////////////////////
 
-app.controller("Index", ['$scope', '$state', 'OpenCraftAPI', 'WebSocketClient', '$timeout',
-    function ($scope, $state, OpenCraftAPI, WebSocketClient, $timeout) {
+app.controller("Index", ['$scope', '$state', 'OpenCraftAPI', 'WebSocketClient', '$timeout', '$location',
+    function ($scope, $state, OpenCraftAPI, WebSocketClient, $timeout, $location) {
 
         $scope.init = function() {
             $scope.loading = true;
@@ -103,7 +103,7 @@ app.controller("Index", ['$scope', '$state', 'OpenCraftAPI', 'WebSocketClient', 
             $scope.loading = true; // Display loading message
 
             console.log('Updating instance list');
-            return OpenCraftAPI.all("instance").getList().then(function(instanceList) {
+            return OpenCraftAPI.all("instance").getList($location.search()).then(function(instanceList) {
                 $scope.instanceList = instanceList;
                 console.log('Updated instance list:', instanceList);
             }, function(response) {

--- a/instance/tests/api/test_openedx_instance.py
+++ b/instance/tests/api/test_openedx_instance.py
@@ -434,7 +434,6 @@ class OpenEdXInstanceAPITestCase(APITestCase):
         self.assertEqual(len(response.data), 1)
         self.assertEqual(response.data[0]['id'], instance.ref.id)
 
-
     @patch_services
     def test_instance_list_filter_on_lifecycle_sandbox(self, mock_consul, mock_patch_services):
         """

--- a/instance/tests/api/test_openedx_instance.py
+++ b/instance/tests/api/test_openedx_instance.py
@@ -411,3 +411,48 @@ class OpenEdXInstanceAPITestCase(APITestCase):
         response = self.api_client.get('/api/v1/instance/?status=running')
         self.assertEqual(len(response.data), 1)
         self.assertEqual(response.data[0]['id'], instance.ref.id)
+
+    @patch_services
+    def test_instance_list_filter_on_lifecycle_production(self, mock_consul, mock_patch_services):
+        """
+        GET - instance list - filter on all production instances.
+        """
+        instance = OpenEdXInstanceFactory(
+            sub_domain='test.com',
+            name='test.com',
+            additional_monitoring_emails=['urgent@opencraft.com']
+        )
+        instance.ref.owner = self.organization2
+        instance.ref.save()
+
+        instance2 = OpenEdXInstanceFactory(sub_domain='test2.com', name='test2.com')
+        instance2.ref.owner = self.organization2
+        instance2.ref.save()
+
+        self.api_client.login(username='user3', password='pass')
+        response = self.api_client.get('/api/v1/instance/?lifecycle=production')
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]['id'], instance.ref.id)
+
+
+    @patch_services
+    def test_instance_list_filter_on_lifecycle_sandbox(self, mock_consul, mock_patch_services):
+        """
+        GET - instance list - filter on all sandbox instances.
+        """
+        instance = OpenEdXInstanceFactory(
+            sub_domain='test.com',
+            name='test.com',
+            additional_monitoring_emails=['urgent@opencraft.com']
+        )
+        instance.ref.owner = self.organization2
+        instance.ref.save()
+
+        instance2 = OpenEdXInstanceFactory(sub_domain='test2.com', name='test2.com')
+        instance2.ref.owner = self.organization2
+        instance2.ref.save()
+
+        self.api_client.login(username='user3', password='pass')
+        response = self.api_client.get('/api/v1/instance/?lifecycle=sandbox')
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]['id'], instance2.ref.id)

--- a/instance/tests/api/test_openedx_instance.py
+++ b/instance/tests/api/test_openedx_instance.py
@@ -285,6 +285,9 @@ class OpenEdXInstanceAPITestCase(APITestCase):
         self.assertEqual(response.data['active_appservers'][0]['status'], 'error')
 
     def test_instance_list_filter_on_name(self, mock_consul):
+        """
+        GET - instance list - it should be possible to filter on name
+        """
         instance = OpenEdXInstanceFactory(sub_domain='test.com', name='test.com')
         instance.ref.owner = self.organization2
         instance.save()
@@ -300,6 +303,9 @@ class OpenEdXInstanceAPITestCase(APITestCase):
         self.assertEqual(response.data[0]['id'], instance.ref.id)
 
     def test_instance_list_filter_on_notes(self, mock_consul):
+        """
+        GET - instance list - it should be possible to filter on notes
+        """
         instance = OpenEdXInstanceFactory(sub_domain='test.com', name='test.com')
         instance.ref.owner = self.organization2
         instance.ref.notes = 'test.com notes'
@@ -319,6 +325,9 @@ class OpenEdXInstanceAPITestCase(APITestCase):
         self.assertEqual(response.data[0]['id'], instance2.ref.id)
 
     def test_instance_list_filter_on_deployment_type(self, mock_consul):
+        """
+        GET - instance list - it should be possible to filter on deployment type
+        """
         instance = OpenEdXInstanceFactory(sub_domain='test.com', name='test.com')
         instance.ref.owner = self.organization2
         instance.ref.save()
@@ -337,6 +346,9 @@ class OpenEdXInstanceAPITestCase(APITestCase):
         self.assertEqual(response.data[0]['id'], instance.ref.id)
 
     def test_instance_list_filter_on_openedx_release(self, mock_consul):
+        """
+        GET - instance list - it should be possible to filter on the OpenEdx release
+        """
         instance = OpenEdXInstanceFactory(sub_domain='test.com', name='test.com', openedx_release='maple')
         instance.ref.owner = self.organization2
         instance.ref.save()
@@ -353,7 +365,10 @@ class OpenEdXInstanceAPITestCase(APITestCase):
         self.assertEqual(response.data[0]['id'], instance2.ref.id)
 
     def test_instance_list_filter_on_tag(self, mock_consul):
-
+        """
+        GET - instance list - it should be possible to filter on any of the instance
+        tags
+        """
         tag1, _ = InstanceTag.objects.get_or_create(name='fast')
         tag2, _ = InstanceTag.objects.get_or_create(name='slow')
 
@@ -376,7 +391,10 @@ class OpenEdXInstanceAPITestCase(APITestCase):
 
     @patch_services
     def test_instance_list_filter_on_status(self, mock_consul, patch_services):
-
+        """
+        GET - instance list - it should be possible to filter on any of the
+        app server statuses
+        """
         instance = OpenEdXInstanceFactory(sub_domain='test.com', name='test.com')
         instance.ref.owner = self.organization2
         instance.ref.save()
@@ -389,11 +407,8 @@ class OpenEdXInstanceAPITestCase(APITestCase):
 
         appserver2_id = instance2.spawn_appserver()
         instance2.appserver_set.update(_status=AppServerStatus.New.state_id)
-        
+
         self.api_client.login(username='user3', password='pass')
         response = self.api_client.get('/api/v1/instance/?status=running')
         self.assertEqual(len(response.data), 1)
         self.assertEqual(response.data[0]['id'], instance.ref.id)
-
-
-    

--- a/instance/tests/api/test_openedx_instance.py
+++ b/instance/tests/api/test_openedx_instance.py
@@ -26,6 +26,7 @@ from unittest.mock import patch
 
 import ddt
 from django.conf import settings
+from django.test.utils import override_settings
 from rest_framework import status
 
 from instance.models.deployment import DeploymentType
@@ -412,6 +413,7 @@ class OpenEdXInstanceAPITestCase(APITestCase):
         self.assertEqual(len(response.data), 1)
         self.assertEqual(response.data[0]['id'], instance.ref.id)
 
+    @override_settings(PROD_APPSERVER_FAIL_EMAILS=['urgent@example.com'])
     @patch_services
     def test_instance_list_filter_on_lifecycle_production(self, mock_consul, mock_patch_services):
         """
@@ -420,7 +422,7 @@ class OpenEdXInstanceAPITestCase(APITestCase):
         instance = OpenEdXInstanceFactory(
             sub_domain='test.com',
             name='test.com',
-            additional_monitoring_emails=['urgent@opencraft.com']
+            additional_monitoring_emails=settings.PROD_APPSERVER_FAIL_EMAILS
         )
         instance.ref.owner = self.organization2
         instance.ref.save()
@@ -434,6 +436,7 @@ class OpenEdXInstanceAPITestCase(APITestCase):
         self.assertEqual(len(response.data), 1)
         self.assertEqual(response.data[0]['id'], instance.ref.id)
 
+    @override_settings(PROD_APPSERVER_FAIL_EMAILS=['urgent@example.com'])
     @patch_services
     def test_instance_list_filter_on_lifecycle_sandbox(self, mock_consul, mock_patch_services):
         """
@@ -442,7 +445,7 @@ class OpenEdXInstanceAPITestCase(APITestCase):
         instance = OpenEdXInstanceFactory(
             sub_domain='test.com',
             name='test.com',
-            additional_monitoring_emails=['urgent@opencraft.com']
+            additional_monitoring_emails=settings.PROD_APPSERVER_FAIL_EMAILS
         )
         instance.ref.owner = self.organization2
         instance.ref.save()

--- a/instance/tests/api/test_openedx_instance.py
+++ b/instance/tests/api/test_openedx_instance.py
@@ -28,10 +28,11 @@ import ddt
 from django.conf import settings
 from rest_framework import status
 
+from instance.models.deployment import DeploymentType
+from instance.models.instance import InstanceTag
 from instance.tests.api.base import APITestCase
 from instance.tests.models.factories.openedx_instance import OpenEdXInstanceFactory
-from instance.tests.models.factories.openedx_appserver import make_test_appserver
-
+from instance.tests.models.factories.openedx_appserver import make_test_appserver, make_test_deployment
 
 # Tests #######################################################################
 
@@ -280,3 +281,93 @@ class OpenEdXInstanceAPITestCase(APITestCase):
         self.assertIn(('status_description', 'App server never got up and running '
                        '(something went wrong when trying to build new VM)'), instance_data)
         self.assertEqual(response.data['active_appservers'][0]['status'], 'error')
+
+    def test_instance_list_filter_on_name(self, mock_consul):
+        instance = OpenEdXInstanceFactory(sub_domain='test.com', name='test.com')
+        instance.ref.owner = self.organization2
+        instance.save()
+
+        instance2 = OpenEdXInstanceFactory(sub_domain='test2.com', name='test2.com')
+        instance2.ref.owner = self.organization2
+        instance2.save()
+
+
+        self.api_client.login(username='user3', password='pass')
+        response = self.api_client.get('/api/v1/instance/?name=test.com')
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]['id'], instance.ref.id)
+
+    def test_instance_list_filter_on_notes(self, mock_consul):
+        instance = OpenEdXInstanceFactory(sub_domain='test.com', name='test.com')
+        instance.ref.owner = self.organization2
+        instance.ref.notes = 'test.com notes'
+        instance.ref.save()
+        instance.save()
+
+        instance2 = OpenEdXInstanceFactory(sub_domain='test2.com', name='test2.com')
+        instance2.ref.owner = self.organization2
+        instance2.ref.notes = 'test2.com notes'
+        instance2.ref.save()
+        instance2.save()
+
+
+        self.api_client.login(username='user3', password='pass')
+        response = self.api_client.get('/api/v1/instance/?notes=test2')
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]['id'], instance2.ref.id)
+
+    def test_instance_list_filter_on_deployment_type(self, mock_consul):
+        instance = OpenEdXInstanceFactory(sub_domain='test.com', name='test.com')
+        instance.ref.owner = self.organization2
+        instance.ref.save()
+        instance.save()
+        make_test_deployment(instance=instance, deployment_type=DeploymentType.pr)
+
+        instance2 = OpenEdXInstanceFactory(sub_domain='test2.com', name='test2.com')
+        instance2.ref.owner = self.organization2
+        instance2.ref.save()
+        instance2.save()
+        make_test_deployment(instance=instance2, deployment_type=DeploymentType.batch)
+
+        self.api_client.login(username='user3', password='pass')
+        response = self.api_client.get(f'/api/v1/instance/?deployment_type={DeploymentType.pr}')
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]['id'], instance.ref.id)
+
+    def test_instance_list_filter_on_openedx_release(self, mock_consul):
+        instance = OpenEdXInstanceFactory(sub_domain='test.com', name='test.com', openedx_release='maple')
+        instance.ref.owner = self.organization2
+        instance.ref.save()
+        instance.save()
+
+        instance2 = OpenEdXInstanceFactory(sub_domain='test2.com', name='test2.com', openedx_release='lilac')
+        instance2.ref.owner = self.organization2
+        instance2.ref.save()
+        instance2.save()
+
+        self.api_client.login(username='user3', password='pass')
+        response = self.api_client.get('/api/v1/instance/?openedx_release=lilac')
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]['id'], instance2.ref.id)
+
+    def test_instance_list_filter_on_tag(self, mock_consul):
+
+        tag1, _ = InstanceTag.objects.get_or_create(name='fast')
+        tag2, _ = InstanceTag.objects.get_or_create(name='slow')
+
+        instance = OpenEdXInstanceFactory(sub_domain='test.com', name='test.com')
+        instance.tags.add(tag1)
+        instance.ref.owner = self.organization2
+        instance.ref.save()
+        instance.save()
+
+        instance2 = OpenEdXInstanceFactory(sub_domain='test2.com', name='test2.com')
+        instance2.tags.add(tag2)
+        instance2.ref.owner = self.organization2
+        instance2.ref.save()
+        instance2.save()
+
+        self.api_client.login(username='user3', password='pass')
+        response = self.api_client.get('/api/v1/instance/?tag=slow')
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]['id'], instance2.ref.id)

--- a/instance/tests/api/test_openedx_instance.py
+++ b/instance/tests/api/test_openedx_instance.py
@@ -36,6 +36,7 @@ from instance.tests.models.factories.openedx_instance import OpenEdXInstanceFact
 from instance.tests.models.factories.openedx_appserver import make_test_appserver, make_test_deployment
 from instance.tests.utils import patch_services
 
+
 # Tests #######################################################################
 
 @ddt.ddt
@@ -296,7 +297,6 @@ class OpenEdXInstanceAPITestCase(APITestCase):
         instance2.ref.owner = self.organization2
         instance2.save()
 
-
         self.api_client.login(username='user3', password='pass')
         response = self.api_client.get('/api/v1/instance/?name=test.com')
         self.assertEqual(len(response.data), 1)
@@ -317,7 +317,6 @@ class OpenEdXInstanceAPITestCase(APITestCase):
         instance2.ref.notes = 'test2.com notes'
         instance2.ref.save()
         instance2.save()
-
 
         self.api_client.login(username='user3', password='pass')
         response = self.api_client.get('/api/v1/instance/?notes=test2')
@@ -390,7 +389,7 @@ class OpenEdXInstanceAPITestCase(APITestCase):
         self.assertEqual(response.data[0]['id'], instance2.ref.id)
 
     @patch_services
-    def test_instance_list_filter_on_status(self, mock_consul, patch_services):
+    def test_instance_list_filter_on_status(self, mock_consul, mock_patch_services):
         """
         GET - instance list - it should be possible to filter on any of the
         app server statuses
@@ -405,7 +404,7 @@ class OpenEdXInstanceAPITestCase(APITestCase):
         instance2.ref.owner = self.organization2
         instance2.ref.save()
 
-        appserver2_id = instance2.spawn_appserver()
+        instance2.spawn_appserver()
         instance2.appserver_set.update(_status=AppServerStatus.New.state_id)
 
         self.api_client.login(username='user3', password='pass')


### PR DESCRIPTION
## Description

Administrators can now filter the instance list by modifying the modifying the URL and adding query
parameters. Eg. ?status=running.

Supported filters are:
    - deployment_type
    - name
    - notes
    - status
    - openedx_release
    - tag
    
## Supporting information


https://tasks.opencraft.com/browse/SE-1142

## Testing instructions

Modify the ocim instance url and add `?status=running` or `?tag=success`

## Deadline

None

## Other information

- This PR is not yet complete. Tests need to be added.