### PR TITLE
[SE-5289] support more special chars in password

### DIFF
--- a/registration/tests/test_api.py
+++ b/registration/tests/test_api.py
@@ -86,6 +86,9 @@ class AccountAPITestCase(APITestCase):
         # Allow registration with or without subscribing to updates
         ({"subscribe_to_updates": True}),
         ({"subscribe_to_updates": False}),
+        ({'password': 'Thisisapassword123()'}),
+        ({'password': 'TrickyPassword*'}),
+        ({'password': 'TrickyPassword[]'}),
     )
     def test_account_creation_success(self, override_data):
         """

--- a/registration/validators.py
+++ b/registration/validators.py
@@ -57,7 +57,7 @@ class SymbolValidator:
     Symbol password validator
     """
     def validate(self, password, user=None):  # pylint: disable=missing-docstring
-        if not re.findall(r'[,.\\!~`<>\/!?:;"+=\-%\'$&@#{}()_]', password):
+        if not re.findall(r'[,.\\!~`<>\/!?:;"+=\-%\'$&@#{}()\[\]_*]', password):
             raise ValidationError(
                 "The password must contain at least 1 special character.",
                 code='password_no_special_chars',


### PR DESCRIPTION
I added these chars '*','['.']' in the `registration/validators.py`
and modified the unit test to make sure nothing is broken