### PR TITLE
[SE-5391] refactor: activate app servers before setting dns

### DIFF
--- a/instance/models/openedx_appserver.py
+++ b/instance/models/openedx_appserver.py
@@ -340,8 +340,6 @@ class OpenEdXAppServer(AppServer, OpenEdXAppConfiguration, AnsibleAppServerMixin
                 self.instance.name
             )
 
-        self.instance.reconfigure_load_balancer()
-
         if active:
             self.instance.enable_monitoring()
 
@@ -349,6 +347,8 @@ class OpenEdXAppServer(AppServer, OpenEdXAppConfiguration, AnsibleAppServerMixin
         # For more information, see https://tasks.opencraft.com/browse/SE-5391
         self.is_active = active
         self.save()
+
+        self.instance.reconfigure_load_balancer()
 
         self.instance.set_active_vm_dns_records(deactivate_appserver=not active)
         self.instance.update_consul_metadata()

--- a/instance/models/openedx_appserver.py
+++ b/instance/models/openedx_appserver.py
@@ -340,11 +340,16 @@ class OpenEdXAppServer(AppServer, OpenEdXAppConfiguration, AnsibleAppServerMixin
                 self.instance.name
             )
 
-        self.is_active = active
-        self.save()
         self.instance.reconfigure_load_balancer()
+
         if active:
             self.instance.enable_monitoring()
+
+        # Mark the app server active only if all necessary methods ran successfully.
+        # For more information, see https://tasks.opencraft.com/browse/SE-5391
+        self.is_active = active
+        self.save()
+
         self.instance.set_active_vm_dns_records(deactivate_appserver=not active)
         self.instance.update_consul_metadata()
 

--- a/instance/newrelic.py
+++ b/instance/newrelic.py
@@ -184,7 +184,6 @@ def add_alert_nrql_condition(policy_id, monitor_url, name):
                 'type': 'static',
                 'name': name,
                 'enabled': True,
-                'value_function': 'sum',
                 'terms': [{
                     'duration': settings.NEWRELIC_NRQL_ALERT_CONDITION_DURATION,
                     'threshold': settings.NEWRELIC_NRQL_ALERT_CONDITION_THRESHOLD,
@@ -194,11 +193,14 @@ def add_alert_nrql_condition(policy_id, monitor_url, name):
                 }],
                 'nrql': {
                     'query': query,
-                    'since_value': '3',
                 },
                 'signal': {
+                    'aggregation_window': f"{settings.NEWRELIC_NRQL_ALERT_SIGNAL_EXPIRATION}",
+                    'aggregation_method': 'CADENCE',
+                    'aggregation_delay': 120,
                     'fill_option': 'static',
-                    'fill_value': '0'
+                    'fill_value': '0.0',
+                    'slide_by': 60
                 },
                 'expiration': {
                     'expiration_duration': settings.NEWRELIC_NRQL_ALERT_SIGNAL_EXPIRATION,

--- a/instance/tests/test_newrelic.py
+++ b/instance/tests/test_newrelic.py
@@ -258,7 +258,6 @@ class NewRelicTestCase(TestCase):
                 'type': 'static',
                 'name': condition_name,
                 'enabled': True,
-                'value_function': 'sum',
                 'terms': [{
                     'duration': '16',
                     'threshold': '2',
@@ -268,11 +267,14 @@ class NewRelicTestCase(TestCase):
                 }],
                 'nrql': {
                     'query': query,
-                    'since_value': '3',
                 },
                 'signal': {
+                    'aggregation_delay': 120,
+                    'aggregation_method': 'CADENCE',
+                    'aggregation_window': '960',
                     'fill_option': 'static',
-                    'fill_value': '0'
+                    'fill_value': '0.0',
+                    'slide_by': 60
                 },
                 'expiration': {
                     'expiration_duration': '960',


### PR DESCRIPTION
## Description

This PR implements the monitoring changes introduced by NewRelic and causes provisioning issues.

## Testing instructions

* check out the branch on Ocim stage
* run `OpenEdXInstance.objects.get(id=965).enable_monitoring()` in shell
* validate the monitoring items are set correctly in NewRelic
* validate that no critical or warning messages shown