### PR TITLE
Removes  django-angular lib. and its usage from login form

### DIFF
--- a/marketing/templates/marketing/conversion.html
+++ b/marketing/templates/marketing/conversion.html
@@ -20,7 +20,7 @@
       {% csrf_token %}
       {% if form.non_field_errors %}
       <div class="page-content__inner__wrapper">
-        <ul class="djng-form-errors">
+        <ul class="login-form-errors">
           {% for error in form.non_field_errors %}
           <li class="invalid">{{ error|last }}</li>
           {% endfor %}

--- a/opencraft/settings.py
+++ b/opencraft/settings.py
@@ -138,7 +138,6 @@ INSTALLED_APPS = (
     'django_extensions',
     'foundation',
     'compressor',
-    'djng',
     'rest_framework',
     'django_rest_passwordreset',
     'huey.contrib.djhuey',

--- a/registration/forms.py
+++ b/registration/forms.py
@@ -26,7 +26,6 @@ import logging
 
 from django import forms
 from django.contrib.auth.forms import AuthenticationForm
-from djng.forms import NgDeclarativeFieldsMetaclass, NgFormValidationMixin
 
 
 # Logging #####################################################################
@@ -77,6 +76,7 @@ class PasswordInput(InputStyleMixin, forms.widgets.PasswordInput):
     """
 
 
+
 class Textarea(InputStyleMixin, forms.widgets.Textarea):
     """
     Adds styles to textareas.
@@ -86,7 +86,7 @@ class Textarea(InputStyleMixin, forms.widgets.Textarea):
 
 # Forms #######################################################################
 
-class LoginForm(NgFormValidationMixin, AuthenticationForm, metaclass=NgDeclarativeFieldsMetaclass):
+class LoginForm(AuthenticationForm):
     """
     Allows users to login with username/email and password.
     """
@@ -94,6 +94,7 @@ class LoginForm(NgFormValidationMixin, AuthenticationForm, metaclass=NgDeclarati
         label='Your email or username',
         help_text='You can enter either your username or your email to login.',
         widget=TextInput,
+        max_length=150
     )
     password = forms.CharField(
         help_text=('If you have forgotten your login details or need to reset '

--- a/registration/static/js/src/login.js
+++ b/registration/static/js/src/login.js
@@ -19,6 +19,6 @@
 
 // App configuration //////////////////////////////////////////////////////////
 
-var app = angular.module('LoginApp', ['djng.forms']);
+var app = angular.module('LoginApp', []);
 
 })();

--- a/registration/templates/registration/form_field.html
+++ b/registration/templates/registration/form_field.html
@@ -1,14 +1,22 @@
 {% load staticfiles %}
 <div class="page-content__inner__wrapper">
     <div class="page-content__inner__left">
-        <div class="field field--host">
+        <div class="field field--host login-form-field">
             <label class="field-label {% if field.field.required %}field-label--required{% endif %}" for="{{ field.id_for_label }}">
                 {{ field.label }}
             </label>
             <div class="input--host__wrapper input--host__wrapper--{{ field.name }}">
                 {{ field }}
             </div>
-            {{ field.errors }}
+            <div class="login-field-errors__inner__wrapper">
+                <ul class="login-field-errors">
+                        {% if field.errors %}
+                            {% for error in field.errors %}
+                                <li class="invalid">{{ error }}</li>
+                            {% endfor %}
+                        {% endif %}
+                </ul>
+            </div>
         </div>
     </div>
     <div class="page-content__inner__right">

--- a/registration/templates/registration/login.html
+++ b/registration/templates/registration/login.html
@@ -16,6 +16,5 @@
 {% endblock content %}
 
 {% block body_js %}
-<script src="{% static "djng/js/django-angular.min.js" %}"></script>
 <script src="{% static "js/src/login.js" %}"></script>
 {% endblock body_js %}

--- a/registration/templates/registration/login_form.html
+++ b/registration/templates/registration/login_form.html
@@ -4,9 +4,9 @@
 
     {% if form.non_field_errors %}
         <div class="page-content__inner__wrapper">
-            <ul class="djng-form-errors">
+            <ul class="login-form-errors">
                 {% for error in form.non_field_errors %}
-                    <li class="invalid">{{ error|last }}</li>
+                    <li class="invalid">{{ error }}</li>
                 {% endfor %}
             </ul>
         </div>

--- a/static/scss/global.scss
+++ b/static/scss/global.scss
@@ -3,7 +3,7 @@
  */
 
 // http://sass-guidelin.es/#the-7-1-pattern
-// 
+//
 
 
 // EXTERNAL DEPENDENCIES
@@ -46,6 +46,4 @@
 
 // PAGES
 @import 'pages/page';
-
-// DJANGO-ANGULAR
-@import 'djng';
+@import 'pages/login';

--- a/static/scss/pages/_login.scss
+++ b/static/scss/pages/_login.scss
@@ -1,3 +1,4 @@
+
 [ng\:cloak], [ng-cloak], [data-ng-cloak], [x-ng-cloak], .ng-cloak, .x-ng-cloak {
     display: none !important;
 }
@@ -8,18 +9,18 @@ form .ng-invalid.ng-dirty {
     border-color: #e9322d;
 }
 
-ul.djng-form-errors, ul.djng-field-errors {
+ul.login-form-errors, ul.login-field-errors {
     display: inline-block;
     list-style-type: none;
     margin: 5px 0 0 0;
     padding: 0;
 }
 
-ul.djng-form-errors li, ul.djng-field-errors li {
+ul.login-form-errors li, ul.login-field-errors li {
     color: #e9322d;
 }
 
-ul.djng-field-errors {
+ul.login-field-errors {
     li::before {
         position: absolute;
         top: 2.8rem;
@@ -27,15 +28,11 @@ ul.djng-field-errors {
         line-height: 2rem;
     }
 
-    li.valid::before {
-        content: url('/static/img/svg/forms/opencraft_valid.svg');
-    }
-
     li.invalid::before {
         content: url('/static/img/svg/forms/opencraft_error.svg');
     }
 }
 
-.checkbox__wrapper__text ul.djng-field-errors li::before {
+.checkbox__wrapper__text ul.login-field-errors li::before {
     top: 0.35rem;
 }


### PR DESCRIPTION
### Description
The changes in the PR remove the usage of django-angular (djng) third-party lib. as we use patched lib. and the updated lib. requires lengthy migration and currently, we are using djng only for login form. 

Ticket: https://tasks.opencraft.com/browse/SE-3732


### Testing instruction
- Run the ocim backend server (`vagrant ssh` followed by `make run.dev`)
- Open http://localhost:5000/login 
- FIllup the login form with valid/invalid data for testing
- Open https://stage.manage.opencraft.com/login to compare the UI.

### UI Screenshots
#### Earlier
![image](https://user-images.githubusercontent.com/16653571/157828245-3d4ef4b5-9844-4df6-a0a1-970c230a5c6e.png)
![image](https://user-images.githubusercontent.com/16653571/157827768-f8f22d56-0e06-4051-ac9a-b4dd5a17b04a.png)
![image](https://user-images.githubusercontent.com/16653571/157827887-9dfa3804-426c-48be-afcb-fc422d1a5030.png)
#### After PR changes
![image](https://user-images.githubusercontent.com/16653571/157828148-b7f51ba6-5b29-476a-972f-4bce70273d0a.png)
![image](https://user-images.githubusercontent.com/16653571/157828569-b04a94b8-1c11-408c-a9d8-15180ff88236.png)
![image](https://user-images.githubusercontent.com/16653571/157828430-d11c2a70-8189-4920-9cc4-691913ec9658.png)


#### Note for reviewers:
The 2nd screenshot in "Earlier" and "After PR changes" are different i.e, "After PR changes" doesn't show a "green tick" around the username because of two reasons:
1. It (someway) indicates the username field value is correct which is not true.
2. This indicates a client-side validation earlier rendered using djng-angular now we will have to write separate indicators for password and username.

I'm fine with adding such a (green tick) indicator for the username field if needed, open to suggestions! 
