### PR TITLE
fix: [BB-6000]adds correct regex to configure CORS

### DIFF
--- a/instance/models/mixins/openedx_config.py
+++ b/instance/models/mixins/openedx_config.py
@@ -153,7 +153,9 @@ class OpenEdXConfigMixin(ConfigMixinBase):
 
             # Nginx
             "NGINX_SET_X_FORWARDED_HEADERS": False,
-            "NGINX_PROXY_ORIGIN_REGEX": r'^(http|https)://.*\.{}'.format(self.instance.domain),
+            "NGINX_PROXY_ORIGIN_REGEX": r'^(http|https)://.*{}'.format(
+                str(self.instance.domain).replace(".", r"\.")
+            ),
 
             # SSL is handled on the load balancer, and the appservers are HTTP only.
             "NGINX_ENABLE_SSL": False,

--- a/instance/models/mixins/openedx_config.py
+++ b/instance/models/mixins/openedx_config.py
@@ -153,6 +153,7 @@ class OpenEdXConfigMixin(ConfigMixinBase):
 
             # Nginx
             "NGINX_SET_X_FORWARDED_HEADERS": False,
+            "NGINX_PROXY_ORIGIN_REGEX": r'^(http|https)://.*\.{}'.format(self.instance.domain),
 
             # SSL is handled on the load balancer, and the appservers are HTTP only.
             "NGINX_ENABLE_SSL": False,


### PR DESCRIPTION
**Description**
Setup correct value of NGINX_PROXY_ORIGIN_REGEX during instance spinup which is used by ansible-playbooks to configure CORS for nginx generated errors 

**Ticket link**: https://tasks.opencraft.com/browse/BB-6000

**Testing instructions**
Looking into the steps required to test the change on staging.