### PR TITLE
[SE-5426] reconfigure NewRelic monitoring

### DIFF
--- a/instance/tests/test_newrelic.py
+++ b/instance/tests/test_newrelic.py
@@ -222,9 +222,9 @@ class NewRelicTestCase(TestCase):
 
     @responses.activate
     @override_settings(
-        NEWRELIC_NRQL_ALERT_CONDITION_THRESHOLD='2',
-        NEWRELIC_NRQL_ALERT_CONDITION_DURATION='16',
-        NEWRELIC_NRQL_ALERT_SIGNAL_EXPIRATION='960',
+        NEWRELIC_NRQL_ALERT_CONDITION_THRESHOLD=2,
+        NEWRELIC_NRQL_ALERT_CONDITION_DURATION=16,
+        NEWRELIC_NRQL_SIGNAL_AGGREGATION_WINDOW=960,
     )
     def test_add_alert_nrql_condition(self):
         """
@@ -259,8 +259,8 @@ class NewRelicTestCase(TestCase):
                 'name': condition_name,
                 'enabled': True,
                 'terms': [{
-                    'duration': '16',
-                    'threshold': '2',
+                    'duration': 16,
+                    'threshold': 2,
                     'operator': 'above',
                     'priority': 'critical',
                     'time_function': 'any',
@@ -269,15 +269,15 @@ class NewRelicTestCase(TestCase):
                     'query': query,
                 },
                 'signal': {
-                    'aggregation_delay': 120,
-                    'aggregation_method': 'CADENCE',
-                    'aggregation_window': '960',
+                    'aggregation_delay': 192,
+                    'aggregation_method': 'EVENT_FLOW',
+                    'aggregation_window': 960,
                     'fill_option': 'static',
                     'fill_value': '0.0',
-                    'slide_by': 60
+                    'slide_by': 96
                 },
                 'expiration': {
-                    'expiration_duration': '960',
+                    'expiration_duration': 960,
                     'open_violation_on_expiration': False,
                     'close_violations_on_expiration': True,
                 }

--- a/opencraft/settings.py
+++ b/opencraft/settings.py
@@ -814,14 +814,16 @@ NEWRELIC_ADMIN_USER_API_KEY = env('NEWRELIC_ADMIN_USER_API_KEY', default=None)
 NODE_EXPORTER_PASSWORD = env('NODE_EXPORTER_PASSWORD', default=None)
 
 # Threhold for NRQL alert condition
-NEWRELIC_NRQL_ALERT_CONDITION_THRESHOLD = env('NEWRELIC_NRQL_ALERT_CONDITION_THRESHOLD', default='1')
+NEWRELIC_NRQL_ALERT_CONDITION_THRESHOLD = env.int('NEWRELIC_NRQL_ALERT_CONDITION_THRESHOLD', default=1)
 
 # Duration for NRQL alert conditions (minutes)
-NEWRELIC_NRQL_ALERT_CONDITION_DURATION = env('NEWRELIC_NRQL_ALERT_CONDITION_DURATION', default='11')
+NEWRELIC_NRQL_ALERT_CONDITION_DURATION = env.int('NEWRELIC_NRQL_ALERT_CONDITION_DURATION', default=10)
 
-# Signal Expiration for NRQL loss of signal alert conditions (seconds)
-# Default is set to `NEWRELIC_NRQL_ALERT_CONDITION_DURATION` default
-NEWRELIC_NRQL_ALERT_SIGNAL_EXPIRATION = env('NEWRELIC_NRQL_ALERT_SIGNAL_EXPIRATION', default='660')
+# The duration of the time window used to evaluate the NRQL query, in seconds.
+# The value must be at least 30 seconds, and no more than 15 minutes (900 seconds).
+# Aggregation delay and data smoothing (slide_by) is calculated based on the aggregation window.
+# The default window is 10 minutes = 600 seconds.
+NEWRELIC_NRQL_SIGNAL_AGGREGATION_WINDOW = env.int('NEWRELIC_NRQL_SIGNAL_AGGREGATION_WINDOW', default=600)
 
 # Load balancing ##############################################################
 


### PR DESCRIPTION
## Description

The current monitoring is set for the legacy NewRelic infrastructure, though NewRelic improved its event aggregation and monitoring. As part of this patch, the aggregation method, window and delay has been changed in order to provide more reliable alerting and reduce the number of false positive alerts.

The default values of settings are updated, since we didn't set the desired behaviour previously. We wanted to be alerted if an issue exists for 10 minutes but calculate with some event delays, so the alert time was set to 11 minutes. At that time, we had no better option as the `aggregation_delay` and `event_flow` aggregation type did not exist. Now that we have these extra settings, we can be alerted if the issue persists for 10 minutes plus we wait for some time (20% of the `aggregation_window`) to receive missing data points. If the data point arrives, no alert will be triggered. Otherwise, we got alerted.

The 20% for delay may seems too much, but since the **maximum** aggregation window allowed by NewRelic is 15 minutes, the maximum delay is 3 minutes. That's not that bad, especially that load balancers may need some time to update their configuration within the current infrastructure. We are using 10 minutes with 20% delay, so if we have no data points for 12 minutes, NewRelic will alert us.

## Supporting information

* [Available event aggregation methods](https://docs.newrelic.com/whats-new/2021/10/wn-new-aggregation-methods)
* [Example configurations for NRQL alerting](https://registry.terraform.io/providers/newrelic/newrelic/latest/docs/resources/nrql_alert_condition#additional-examples)
* [Related PR that influenced this change](https://github.com/open-craft/opencraft/pull/880)
* [Mattermost discussion about the issue](https://chat.opencraft.com/opencraft/pl/ajm4qbn9xpf6by39k9i6en6qcc)

### Dependencies

N/A

## Sandbox

No alerts were updated yet to use the new alert conditions, as I wanted to have a review first.

## Testing instructions

1. First of all, read through ALL the linked resources
2. Validate that this PR description meets the code changes
3. Deploy to Ocim stage, disable monitoring for one (test) server using `disable_monitoring` function, then re-enable it using `enable_monitoring` -- this will delete and re-register NRQL alert policies
4. Check the NewRelic UI that the configuration is created as expected

## Deadline

As soon as possible, since we are getting false alerts.

## Other information

We won't need to update any playbooks as Ocim is using the default values, set in `settings.py` for NewRelic alert configuration. That's true for CI/CD as well.