### PR TITLE
add deployment method to ui

### DIFF
--- a/instance/static/html/instance/details.html
+++ b/instance/static/html/instance/details.html
@@ -9,8 +9,12 @@
   <div class="row">
     <div class="large-10 columns">
       <ul class="instance-description">
-        <li>LMS: <a href="{{ instance.url }}" target="_new">{{ instance.url }}</a></li>
-        <li>Studio: <a href="{{ instance.studio_url }}" target="_new">{{ instance.studio_url }}</a></li>
+      <li>LMS: <a href="{{ instance.url }}" target="_new">{{ instance.url }}</a></li>
+      <li>Studio: <a href="{{ instance.studio_url }}" target="_new">{{ instance.studio_url }}</a></li>
+      <li>Instance Type: {{instance.instance_type}}</li>
+      <li ng-if="instance.instance_type == 'groveinstance'">
+          Config Repo: <a href="{{instance.configuration_source_repo_url}}">{{instance. configuration_source_repo_url}}</a>
+      </li>
       </ul>
     </div>
     <div class="large-2 columns">


### PR DESCRIPTION
Description
This PR make small UI changes to make the OCIM UI support grove, It adds a field to indicate what is the instance type and adds a link to the config repo if it's a grove instance

Dependencies
gabor/add-grove branch

Screenshots
![Screenshot from 2022-03-30 11-42-18](https://user-images.githubusercontent.com/24472871/160802778-a8c40af9-61f1-495e-8461-35a234c094e7.png)



Testing instructions
you can test this by running ocim and the frontend then manually create a grove instance in the shell

Deadline
N/A