### PR TITLE
fix: ensure singlebeat identifier set correctly

### DIFF
--- a/instance/models/mixins/openedx_database.py
+++ b/instance/models/mixins/openedx_database.py
@@ -501,7 +501,7 @@ class OpenEdXDatabaseMixin(MySQLInstanceMixin, MongoDBInstanceMixin, RabbitMQIns
 
         redis_transport_options = {
             "CELERY_BROKER_TRANSPORT_OPTIONS": {
-                "global_keyprefix": self.redis_key_prefix
+                "global_keyprefix": f"{self.redis_key_prefix}_"
             }
         }
 

--- a/instance/models/mixins/redis.py
+++ b/instance/models/mixins/redis.py
@@ -110,7 +110,7 @@ class RedisInstanceMixin(models.Model):
 
         Username used to prefix redis keys and set ACLs on the Redis server.
         """
-        return f"{self.redis_username}_"
+        return self.redis_username
 
     def delete_redis_acl(self, client: redis.Redis):
         """
@@ -126,7 +126,7 @@ class RedisInstanceMixin(models.Model):
             username=self.redis_username,
             passwords=[f"+{self.redis_password}"],
             keys=[
-                f"{self.redis_key_prefix}*",
+                f"{self.redis_key_prefix}_*",
                 f"SINGLE_BEAT_{self.redis_key_prefix}",
             ],
             commands=["+@all"],


### PR DESCRIPTION
## Description

This PR fixes redis key prefix composition issues which put a `_` at the end of the single beat identifier, which shouldn't happen.

## Supporting information

* [How identifier is composed](https://github.com/akachanov/single-beat/blob/master/singlebeat/beat.py#L21)

### Dependencies

N/A

## Testing instructions

* Check that https://temp-lilac.opencraft.hosting/admin/instructor_task/instructortask/  is produced 1 minute tasks until March 31, 2022, 9:14 a.m.

## Deadline

ASAP
