### PR TITLE
[SE-5526] Add proxy settings to extra env tokens.

### DIFF
--- a/instance/models/mixins/openedx_config.py
+++ b/instance/models/mixins/openedx_config.py
@@ -48,7 +48,9 @@ class OpenEdXConfigMixin(ConfigMixinBase):
             "CLOSEST_CLIENT_IP_FROM_HEADERS": [
                 {"name": "X-Forwarded-For", "index": -1},
             ],
-            "NUM_PROXIES": 1,
+            "REST_FRAMEWORK": {
+                "NUM_PROXIES": 1,
+            },
         }
 
         template = {

--- a/instance/models/mixins/openedx_config.py
+++ b/instance/models/mixins/openedx_config.py
@@ -43,6 +43,12 @@ class OpenEdXConfigMixin(ConfigMixinBase):
             # Use database-backed sessions to stay logged in across appserver deploys.
             # (We have EDXAPP_CLEARSESSIONS_CRON_ENABLED to clean up old data.)
             "SESSION_ENGINE": "django.contrib.sessions.backends.cached_db",
+            # The following two settings help determine the public IP of the request.
+            # See: https://discuss.openedx.org/t/security-patch-for-rate-limiting-in-edx-platform/7078
+            "CLOSEST_CLIENT_IP_FROM_HEADERS": [
+                {"name": "X-Forwarded-For", "index": -1},
+            ],
+            "NUM_PROXIES": 1,
         }
 
         template = {


### PR DESCRIPTION
Maple [requires additional configuration](https://discuss.openedx.org/t/security-patch-for-rate-limiting-in-edx-platform/7078) to be able to reliably determine the remote IP of a request.

In our setup the appservers are deployed behind one loadbalancer which we can trust to set the correct `X-Forwarded-For` header (haproxy) and `REST_FRAMEWORK['NUM_PROXIES']` to `1`.

The `CLOSEST_CLIENT_IP_FROM_HEADERS` setting therefore needs to be set to `[{'name': 'X-Forwarded-For', 'index': -1}]`.

For more info see:
https://tasks.opencraft.com/browse/SE-5547

**Test instructions**:

1. Deploy a new appserver (or use [this one that I spawned on stage](https://stage.manage.opencraft.com/instance/9340/edx-appserver/3763/)).
2. SSH into the appserver VM and start the django shell: `/edx/bin/edxapp-shell-lms`
3. Import django settings: `from django.conf import settings`
4. Verify that `settings.CLOSEST_CLIENT_IP_FROM_HEADERS` and `settings.REST_FRAMEWORK['NUM_PROXIES']` are defined.